### PR TITLE
fix sass_issue

### DIFF
--- a/example/cuda/sass_divergence_demo.cu
+++ b/example/cuda/sass_divergence_demo.cu
@@ -148,7 +148,7 @@ int main() {
     opts.enable_debug_output = true;
     opts.sampling_auto_start = true;
     opts.enable_stack_trace = false;
-    opts.profiling_engine = gpufl::ProfilingEngine::SassMetrics;
+    opts.profiling_engine = gpufl::ProfilingEngine::PcSamplingWithSass;
 
     if (!gpufl::init(opts)) {
         std::cerr << "Failed to initialize gpufl" << std::endl;

--- a/include/gpufl/backends/nvidia/engine/pc_sampling_engine.cpp
+++ b/include/gpufl/backends/nvidia/engine/pc_sampling_engine.cpp
@@ -183,8 +183,14 @@ void PcSamplingEngine::EnableSamplingFeatures_() {
     CUpti_PCSamplingConfigurationInfo configInfo[7] = {};
     configInfo[0].attributeType =
         CUPTI_PC_SAMPLING_CONFIGURATION_ATTR_TYPE_COLLECTION_MODE;
+    // KERNEL_SERIALIZED and SASS lazy patching both intercept cuLaunchKernel
+    // at the driver level and deadlock on the first kernel launch. Use
+    // CONTINUOUS mode when SASS metrics are also active so that the lazy
+    // patching pass can complete before PC samples are drained.
     configInfo[0].attributeData.collectionModeData.collectionMode =
-        CUPTI_PC_SAMPLING_COLLECTION_MODE_KERNEL_SERIALIZED;
+        (opts_.profiling_engine == ProfilingEngine::PcSamplingWithSass)
+            ? CUPTI_PC_SAMPLING_COLLECTION_MODE_CONTINUOUS
+            : CUPTI_PC_SAMPLING_COLLECTION_MODE_KERNEL_SERIALIZED;
 
     configInfo[1].attributeType =
         CUPTI_PC_SAMPLING_CONFIGURATION_ATTR_TYPE_SAMPLING_PERIOD;

--- a/include/gpufl/backends/nvidia/resource_handler.cpp
+++ b/include/gpufl/backends/nvidia/resource_handler.cpp
@@ -39,12 +39,20 @@ void ResourceHandler::handle(CUpti_CallbackDomain domain, CUpti_CallbackId cbid,
             const void *cubinPtr = modData->pCubin;
             const size_t cubinSize = modData->cubinSize;
 
-            // CUPTI_CBID_RESOURCE_MODULE_PROFILED fires on every kernel
-            // launch when PC sampling is active. Use the raw pointer as an
-            // O(1) sentinel — cubin memory is stable for the process lifetime.
             {
                 std::lock_guard<std::mutex> lk(backend_->cubin_mu_);
                 if (backend_->seen_cubin_ptrs_.count(cubinPtr)) return;
+                // CUPTI_CBID_RESOURCE_MODULE_PROFILED fires on every kernel
+                // launch when PC sampling is active, including for
+                // SASS-patched cubin variants that have a different pointer
+                // than the original. Calling cuptiGetCubinCrc() from within
+                // this callback deadlocks when SASS lazy patching holds
+                // CUPTI-internal locks. Mark the pointer seen and bail out —
+                // the original cubin was already processed by MODULE_LOADED.
+                if (cbid == CUPTI_CBID_RESOURCE_MODULE_PROFILED) {
+                    backend_->seen_cubin_ptrs_.insert(cubinPtr);
+                    return;
+                }
             }
 
             CUpti_GetCubinCrcParams params = {CUpti_GetCubinCrcParamsSize};


### PR DESCRIPTION
## Description
Root cause: CUPTI_PC_SAMPLING_COLLECTION_MODE_KERNEL_SERIALIZED and SASS lazy
 patching (enableLazyPatching=1) both intercept cuLaunchKernel at the driver
level. The DRIVER callback (domain=1 cbid=307) fires, then both CUPTI
subsystems try to process the same launch — each waits for the other. That's
the hang. flushDisassembly succeeds meanwhile because it's on a background
thread.

Fix: Switch to CONTINUOUS mode when SASS is also active. CONTINUOUS doesn't
serialize kernel launches, so SASS patching can proceed. The explicit
enableStartStopControl stays — it's orthogonal to collection mode.

1. resource_handler.cpp — PROFILED callback no longer calls
  cuptiGetCubinCrc() (deadlocked with SASS patching, holding CUPTI's internal
  lock).
2. pc_sampling_engine.cpp — PcSamplingWithSass mode now uses
CUPTI_PC_SAMPLING_COLLECTION_MODE_CONTINUOUS instead of KERNEL_SERIALIZED.
Both modes serialized kernel launch at the driver level and deadlocked.
CONTINUOUS lets SASS lazy patching complete the cubin instrumentation before
PC samples are drained, while explicit start/stop control
(enableStartStopControl=1) remains in effect.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

## Testing
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas