### PR TITLE
Adding report function to printout the summary at the end of the program

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,6 +66,8 @@ target_sources(gpufl PRIVATE
     include/gpufl/core/debug_logger.cpp
     include/gpufl/core/stack_trace.cpp
     include/gpufl/core/scope_registry.cpp
+    include/gpufl/report/json_reader.cpp
+    include/gpufl/report/text_report.cpp
 )
 
 set(GPUFL_HAS_CUDA 0)

--- a/example/amd/gpufl_scope_demo.cpp
+++ b/example/amd/gpufl_scope_demo.cpp
@@ -1,8 +1,9 @@
+#include <hip/hip_runtime.h>
+
 #include <cstdlib>
 #include <iostream>
 
-#include <hip/hip_runtime.h>
-
+#include "../../include/gpufl/gpufl.hpp"
 #include "gpufl/gpufl.hpp"
 
 static bool checkHip(const hipError_t status, const char* what) {
@@ -131,6 +132,7 @@ int main() {
     std::free(h_c);
 
     gpufl::shutdown();
+    gpufl::generateReport();
 
     std::cout << "\nDemo complete. Inspect logs with prefix " << opts.log_path
               << "\n";

--- a/example/amd/gpufl_scope_demo.cpp
+++ b/example/amd/gpufl_scope_demo.cpp
@@ -3,7 +3,6 @@
 #include <cstdlib>
 #include <iostream>
 
-#include "../../include/gpufl/gpufl.hpp"
 #include "gpufl/gpufl.hpp"
 
 static bool checkHip(const hipError_t status, const char* what) {

--- a/include/gpufl/backends/amd/rocm_collector.cpp
+++ b/include/gpufl/backends/amd/rocm_collector.cpp
@@ -185,6 +185,24 @@ bool ReadPowerThrottle(const uint32_t deviceIndex) {
     return powerUw >= capUw;
 }
 
+bool IsCpuLikeSmiDevice(const uint32_t deviceIndex) {
+    char name[256] = {};
+    if (!IsSuccess(rsmi_dev_name_get(deviceIndex, name, sizeof(name))) ||
+        name[0] == '\0') {
+        return false;
+    }
+    const std::string lower = [&] {
+        std::string s(name);
+        std::transform(s.begin(), s.end(), s.begin(),
+                       [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+        return s;
+    }();
+    return lower.find("raphael") != std::string::npos ||
+           lower.find("ryzen") != std::string::npos ||
+           lower.find("epyc") != std::string::npos ||
+           lower.find("threadripper") != std::string::npos;
+}
+
 DeviceSample BuildTelemetrySample(const uint32_t deviceIndex) {
     DeviceSample sample{};
     sample.device_id = static_cast<int>(deviceIndex);
@@ -384,6 +402,10 @@ std::vector<DeviceSample> RocmCollector::sampleAll() {
 #if GPUFL_HAS_ROCM_SMI
     out.reserve(telemetry_device_count_);
     for (uint32_t i = 0; i < telemetry_device_count_; ++i) {
+        if (IsCpuLikeSmiDevice(i)) {
+            GFL_LOG_DEBUG("[RocmCollector] skipping CPU iGPU SMI device index=", i);
+            continue;
+        }
         out.push_back(BuildTelemetrySample(i));
     }
 #endif

--- a/include/gpufl/core/gpufl.cpp
+++ b/include/gpufl/core/gpufl.cpp
@@ -1,5 +1,7 @@
 #include "gpufl.hpp"
 
+#include <filesystem>
+#include <fstream>
 #include <iostream>
 #include <memory>
 #include <string>
@@ -18,6 +20,7 @@
 #include "gpufl/core/monitor_backend.hpp"
 #include "gpufl/core/runtime.hpp"
 #include "gpufl/core/scope_registry.hpp"
+#include "gpufl/report/text_report.hpp"
 #if GPUFL_HAS_CUDA || defined(__CUDACC__)
 #include <cuda_runtime.h>
 #endif
@@ -48,6 +51,10 @@ static std::string defaultLogPath_(const std::string& app) {
     return app + ".log";
 }
 
+// Remembered after init() for use by generateReport() after shutdown()
+static std::string g_lastLogPath;
+static std::string g_lastAppName;
+
 static std::atomic<uint64_t> g_nextScopeId{1};
 
 static uint64_t nextScopeId_() {
@@ -75,6 +82,9 @@ bool init(const InitOptions& opts) {
     Logger::Options logOpts;
     logOpts.base_path = logPath;
     logOpts.system_sample_rate_ms = opts.system_sample_rate_ms;
+
+    g_lastLogPath = logPath;
+    g_lastAppName = rt->app_name;
 
     GFL_LOG_DEBUG("Opening log file: ", logPath);
     if (!rt->logger->open(logOpts)) {
@@ -309,4 +319,28 @@ ScopedMonitor::~ScopedMonitor() {
         }
     }
 }
+void generateReport(const std::string& output_path) {
+    namespace fs = std::filesystem;
+
+    fs::path p(g_lastLogPath);
+    std::string dir = p.parent_path().string();
+    if (dir.empty()) dir = ".";
+
+    std::string prefix = p.filename().string();
+    if (prefix.size() > 4 && prefix.substr(prefix.size() - 4) == ".log")
+        prefix = prefix.substr(0, prefix.size() - 4);
+
+    report::TextReport::Options opts;
+    opts.log_dir = dir;
+    opts.log_prefix = prefix;
+    std::string text = report::TextReport(opts).generate();
+
+    if (output_path.empty()) {
+        std::cout << text;
+    } else {
+        std::ofstream file(output_path);
+        if (file.is_open()) file << text;
+    }
+}
+
 }  // namespace gpufl

--- a/include/gpufl/gpufl.hpp
+++ b/include/gpufl/gpufl.hpp
@@ -44,6 +44,12 @@ bool init(const InitOptions& opts);
 // Stop runtime, flush and close logs.
 void shutdown();
 
+// Generate a text report from the log files written during this session.
+// Call after shutdown().
+// - No argument: prints the report to console (stdout).
+// - With output_path: saves the report to a file.
+void generateReport(const std::string& output_path = "");
+
 class ScopedMonitor {
    public:
     explicit ScopedMonitor(std::string name, std::string tag, bool deep_profiling);

--- a/include/gpufl/report/json_reader.cpp
+++ b/include/gpufl/report/json_reader.cpp
@@ -1,0 +1,335 @@
+#include "gpufl/report/json_reader.hpp"
+
+#include <cctype>
+#include <cstdlib>
+#include <fstream>
+#include <stdexcept>
+
+namespace gpufl {
+namespace report {
+
+// ── Static defaults ─────────────────────────────────────────────────────────
+
+const JsonValue JsonValue::kNull;
+const std::string JsonValue::kEmptyString;
+const JsonValue::Array JsonValue::kEmptyArray;
+const JsonValue::Object JsonValue::kEmptyObject;
+
+// ── Type ────────────────────────────────────────────────────────────────────
+
+JsonValue::Type JsonValue::type() const {
+    return std::visit([](auto&& v) -> Type {
+        using T = std::decay_t<decltype(v)>;
+        if constexpr (std::is_same_v<T, Null>)        return Type::Null;
+        if constexpr (std::is_same_v<T, bool>)        return Type::Bool;
+        if constexpr (std::is_same_v<T, int64_t>)     return Type::Int;
+        if constexpr (std::is_same_v<T, double>)      return Type::Double;
+        if constexpr (std::is_same_v<T, std::string>) return Type::String;
+        if constexpr (std::is_same_v<T, Array>)       return Type::Array;
+        if constexpr (std::is_same_v<T, Object>)      return Type::Object;
+    }, data_);
+}
+
+// ── Value accessors ─────────────────────────────────────────────────────────
+
+bool JsonValue::get_bool(bool def) const {
+    if (auto* v = std::get_if<bool>(&data_)) return *v;
+    return def;
+}
+
+int64_t JsonValue::get_int(int64_t def) const {
+    if (auto* v = std::get_if<int64_t>(&data_)) return *v;
+    return def;
+}
+
+double JsonValue::get_double(double def) const {
+    if (auto* v = std::get_if<double>(&data_)) return *v;
+    return def;
+}
+
+const std::string& JsonValue::get_string() const {
+    if (auto* v = std::get_if<std::string>(&data_)) return *v;
+    return kEmptyString;
+}
+
+const JsonValue::Array& JsonValue::get_array() const {
+    if (auto* v = std::get_if<Array>(&data_)) return *v;
+    return kEmptyArray;
+}
+
+const JsonValue::Object& JsonValue::get_object() const {
+    if (auto* v = std::get_if<Object>(&data_)) return *v;
+    return kEmptyObject;
+}
+
+int64_t JsonValue::as_int(int64_t def) const {
+    if (auto* v = std::get_if<int64_t>(&data_)) return *v;
+    if (auto* v = std::get_if<double>(&data_)) return static_cast<int64_t>(*v);
+    return def;
+}
+
+double JsonValue::as_double(double def) const {
+    if (auto* v = std::get_if<double>(&data_)) return *v;
+    if (auto* v = std::get_if<int64_t>(&data_)) return static_cast<double>(*v);
+    return def;
+}
+
+uint64_t JsonValue::as_uint64(uint64_t def) const {
+    if (auto* v = std::get_if<int64_t>(&data_)) return static_cast<uint64_t>(*v);
+    if (auto* v = std::get_if<double>(&data_)) return static_cast<uint64_t>(*v);
+    return def;
+}
+
+// ── Object access ───────────────────────────────────────────────────────────
+
+bool JsonValue::contains(const std::string& key) const {
+    if (auto* obj = std::get_if<Object>(&data_))
+        return obj->find(key) != obj->end();
+    return false;
+}
+
+const JsonValue& JsonValue::operator[](const std::string& key) const {
+    if (auto* obj = std::get_if<Object>(&data_)) {
+        auto it = obj->find(key);
+        if (it != obj->end()) return it->second;
+    }
+    return kNull;
+}
+
+const JsonValue& JsonValue::at(const std::string& key) const {
+    return (*this)[key];
+}
+
+// ── Array access ────────────────────────────────────────────────────────────
+
+const JsonValue& JsonValue::operator[](size_t index) const {
+    if (auto* arr = std::get_if<Array>(&data_)) {
+        if (index < arr->size()) return (*arr)[index];
+    }
+    return kNull;
+}
+
+size_t JsonValue::size() const {
+    if (auto* arr = std::get_if<Array>(&data_)) return arr->size();
+    if (auto* obj = std::get_if<Object>(&data_)) return obj->size();
+    return 0;
+}
+
+bool JsonValue::empty() const {
+    return size() == 0;
+}
+
+JsonValue::Object::const_iterator JsonValue::begin() const {
+    if (auto* obj = std::get_if<Object>(&data_)) return obj->begin();
+    return kEmptyObject.begin();
+}
+
+JsonValue::Object::const_iterator JsonValue::end() const {
+    if (auto* obj = std::get_if<Object>(&data_)) return obj->end();
+    return kEmptyObject.end();
+}
+
+// ── Parser ──────────────────────────────────────────────────────────────────
+
+namespace {
+
+class Parser {
+   public:
+    explicit Parser(const std::string& input) : src_(input), pos_(0) {}
+
+    JsonValue parse() {
+        skipWhitespace();
+        if (pos_ >= src_.size()) return JsonValue::null();
+        auto val = parseValue();
+        return val;
+    }
+
+   private:
+    const std::string& src_;
+    size_t pos_;
+
+    char peek() const { return pos_ < src_.size() ? src_[pos_] : '\0'; }
+    char advance() { return pos_ < src_.size() ? src_[pos_++] : '\0'; }
+
+    void skipWhitespace() {
+        while (pos_ < src_.size() && std::isspace(static_cast<unsigned char>(src_[pos_])))
+            ++pos_;
+    }
+
+    bool consume(char c) {
+        skipWhitespace();
+        if (peek() == c) { advance(); return true; }
+        return false;
+    }
+
+    void expect(char c) {
+        skipWhitespace();
+        if (advance() != c)
+            throw std::runtime_error("expected '" + std::string(1, c) + "'");
+    }
+
+    JsonValue parseValue() {
+        skipWhitespace();
+        char c = peek();
+        if (c == '{') return parseObject();
+        if (c == '[') return parseArray();
+        if (c == '"') return parseString();
+        if (c == 't' || c == 'f') return parseBool();
+        if (c == 'n') return parseNull();
+        if (c == '-' || std::isdigit(static_cast<unsigned char>(c)))
+            return parseNumber();
+        throw std::runtime_error("unexpected character");
+    }
+
+    JsonValue parseObject() {
+        expect('{');
+        JsonValue::Object obj;
+        if (consume('}')) return JsonValue::object(std::move(obj));
+
+        do {
+            skipWhitespace();
+            std::string key = parseRawString();
+            expect(':');
+            obj[std::move(key)] = parseValue();
+        } while (consume(','));
+
+        expect('}');
+        return JsonValue::object(std::move(obj));
+    }
+
+    JsonValue parseArray() {
+        expect('[');
+        JsonValue::Array arr;
+        if (consume(']')) return JsonValue::array(std::move(arr));
+
+        do {
+            arr.push_back(parseValue());
+        } while (consume(','));
+
+        expect(']');
+        return JsonValue::array(std::move(arr));
+    }
+
+    JsonValue parseString() {
+        return JsonValue::string(parseRawString());
+    }
+
+    std::string parseRawString() {
+        expect('"');
+        std::string result;
+        result.reserve(32);
+        while (pos_ < src_.size()) {
+            char c = src_[pos_++];
+            if (c == '"') return result;
+            if (c == '\\') {
+                if (pos_ >= src_.size()) break;
+                char e = src_[pos_++];
+                switch (e) {
+                    case '"':  result += '"';  break;
+                    case '\\': result += '\\'; break;
+                    case '/':  result += '/';  break;
+                    case 'n':  result += '\n'; break;
+                    case 'r':  result += '\r'; break;
+                    case 't':  result += '\t'; break;
+                    case 'b':  result += '\b'; break;
+                    case 'f':  result += '\f'; break;
+                    case 'u': {
+                        // Skip 4 hex digits (simplified: just output '?')
+                        size_t end = std::min(pos_ + 4, src_.size());
+                        pos_ = end;
+                        result += '?';
+                        break;
+                    }
+                    default: result += e; break;
+                }
+            } else {
+                result += c;
+            }
+        }
+        return result;
+    }
+
+    JsonValue parseNumber() {
+        size_t start = pos_;
+        bool isFloat = false;
+
+        if (peek() == '-') advance();
+        while (std::isdigit(static_cast<unsigned char>(peek()))) advance();
+
+        if (peek() == '.') {
+            isFloat = true;
+            advance();
+            while (std::isdigit(static_cast<unsigned char>(peek()))) advance();
+        }
+        if (peek() == 'e' || peek() == 'E') {
+            isFloat = true;
+            advance();
+            if (peek() == '+' || peek() == '-') advance();
+            while (std::isdigit(static_cast<unsigned char>(peek()))) advance();
+        }
+
+        std::string numStr = src_.substr(start, pos_ - start);
+        if (isFloat) {
+            return JsonValue::number(std::stod(numStr));
+        }
+        // Try int64 first; fall back to double for very large numbers
+        try {
+            size_t idx = 0;
+            int64_t val = std::stoll(numStr, &idx);
+            if (idx == numStr.size()) return JsonValue::integer(val);
+        } catch (...) {}
+        return JsonValue::number(std::stod(numStr));
+    }
+
+    JsonValue parseBool() {
+        if (src_.compare(pos_, 4, "true") == 0) {
+            pos_ += 4;
+            return JsonValue::boolean(true);
+        }
+        if (src_.compare(pos_, 5, "false") == 0) {
+            pos_ += 5;
+            return JsonValue::boolean(false);
+        }
+        throw std::runtime_error("invalid boolean");
+    }
+
+    JsonValue parseNull() {
+        if (src_.compare(pos_, 4, "null") == 0) {
+            pos_ += 4;
+            return JsonValue::null();
+        }
+        throw std::runtime_error("invalid null");
+    }
+};
+
+}  // namespace
+
+// ── Public parse functions ──────────────────────────────────────────────────
+
+JsonValue parseJson(const std::string& input) {
+    try {
+        Parser p(input);
+        return p.parse();
+    } catch (...) {
+        return JsonValue::null();
+    }
+}
+
+std::vector<JsonValue> loadJsonLines(const std::string& path) {
+    std::vector<JsonValue> records;
+    if (path.empty()) return records;
+
+    std::ifstream file(path);
+    if (!file.is_open()) return records;
+
+    std::string line;
+    while (std::getline(file, line)) {
+        if (line.empty() || line[0] != '{') continue;
+        auto val = parseJson(line);
+        if (!val.is_null()) records.push_back(std::move(val));
+    }
+    return records;
+}
+
+}  // namespace report
+}  // namespace gpufl

--- a/include/gpufl/report/json_reader.hpp
+++ b/include/gpufl/report/json_reader.hpp
@@ -1,0 +1,150 @@
+#pragma once
+
+#include <cstdint>
+#include <map>
+#include <string>
+#include <variant>
+#include <vector>
+
+namespace gpufl {
+namespace report {
+
+// Minimal JSON value type for reading NDJSON log files.
+// Supports: null, bool, int64, double, string, array, object.
+class JsonValue {
+   public:
+    using Object = std::map<std::string, JsonValue>;
+    using Array = std::vector<JsonValue>;
+
+    enum class Type { Null, Bool, Int, Double, String, Array, Object };
+
+    JsonValue() : data_(Null{}) {}
+
+    // Construction helpers
+    static JsonValue null() { return {}; }
+    static JsonValue boolean(bool v) { JsonValue j; j.data_ = v; return j; }
+    static JsonValue integer(int64_t v) { JsonValue j; j.data_ = v; return j; }
+    static JsonValue number(double v) { JsonValue j; j.data_ = v; return j; }
+    static JsonValue string(std::string v) { JsonValue j; j.data_ = std::move(v); return j; }
+    static JsonValue array(Array v) { JsonValue j; j.data_ = std::move(v); return j; }
+    static JsonValue object(Object v) { JsonValue j; j.data_ = std::move(v); return j; }
+
+    Type type() const;
+
+    bool is_null() const { return type() == Type::Null; }
+    bool is_bool() const { return type() == Type::Bool; }
+    bool is_int() const { return type() == Type::Int; }
+    bool is_double() const { return type() == Type::Double; }
+    bool is_number() const { return is_int() || is_double(); }
+    bool is_string() const { return type() == Type::String; }
+    bool is_array() const { return type() == Type::Array; }
+    bool is_object() const { return type() == Type::Object; }
+
+    // Value accessors (return defaults if wrong type)
+    bool get_bool(bool def = false) const;
+    int64_t get_int(int64_t def = 0) const;
+    double get_double(double def = 0.0) const;
+    const std::string& get_string() const;
+    const Array& get_array() const;
+    const Object& get_object() const;
+
+    // Convenience: get_int that also works on doubles
+    int64_t as_int(int64_t def = 0) const;
+    double as_double(double def = 0.0) const;
+    uint64_t as_uint64(uint64_t def = 0) const;
+
+    // Object key access
+    bool contains(const std::string& key) const;
+    const JsonValue& operator[](const std::string& key) const;
+    const JsonValue& at(const std::string& key) const;
+
+    // Array index access
+    const JsonValue& operator[](size_t index) const;
+    size_t size() const;
+    bool empty() const;
+
+    // Object iteration
+    Object::const_iterator begin() const;
+    Object::const_iterator end() const;
+
+    // Shorthand: value<T>(key, default)
+    template <typename T>
+    T value(const std::string& key, const T& def) const;
+
+   private:
+    struct Null {};
+    std::variant<Null, bool, int64_t, double, std::string, Array, Object> data_;
+    static const JsonValue kNull;
+    static const std::string kEmptyString;
+    static const Array kEmptyArray;
+    static const Object kEmptyObject;
+};
+
+// Parse a single JSON string into a JsonValue. Returns null on failure.
+JsonValue parseJson(const std::string& input);
+
+// Parse an NDJSON file into a vector of JsonValue objects.
+std::vector<JsonValue> loadJsonLines(const std::string& path);
+
+// ── Template implementations ────────────────────────────────────────────────
+
+template <>
+inline std::string JsonValue::value(const std::string& key, const std::string& def) const {
+    if (!is_object()) return def;
+    auto it = std::get<Object>(data_).find(key);
+    if (it == std::get<Object>(data_).end() || !it->second.is_string()) return def;
+    return it->second.get_string();
+}
+
+template <>
+inline int64_t JsonValue::value(const std::string& key, const int64_t& def) const {
+    if (!is_object()) return def;
+    auto it = std::get<Object>(data_).find(key);
+    if (it == std::get<Object>(data_).end()) return def;
+    return it->second.as_int(def);
+}
+
+template <>
+inline uint64_t JsonValue::value(const std::string& key, const uint64_t& def) const {
+    if (!is_object()) return def;
+    auto it = std::get<Object>(data_).find(key);
+    if (it == std::get<Object>(data_).end()) return def;
+    return it->second.as_uint64(def);
+}
+
+template <>
+inline int JsonValue::value(const std::string& key, const int& def) const {
+    return static_cast<int>(value<int64_t>(key, def));
+}
+
+template <>
+inline unsigned JsonValue::value(const std::string& key, const unsigned& def) const {
+    if (!is_object()) return def;
+    auto it = std::get<Object>(data_).find(key);
+    if (it == std::get<Object>(data_).end()) return def;
+    return static_cast<unsigned>(it->second.as_int(def));
+}
+
+template <>
+inline double JsonValue::value(const std::string& key, const double& def) const {
+    if (!is_object()) return def;
+    auto it = std::get<Object>(data_).find(key);
+    if (it == std::get<Object>(data_).end()) return def;
+    return it->second.as_double(def);
+}
+
+template <>
+inline float JsonValue::value(const std::string& key, const float& def) const {
+    return static_cast<float>(value<double>(key, static_cast<double>(def)));
+}
+
+template <>
+inline bool JsonValue::value(const std::string& key, const bool& def) const {
+    if (!is_object()) return def;
+    auto it = std::get<Object>(data_).find(key);
+    if (it == std::get<Object>(data_).end() || !it->second.is_bool()) return def;
+    return it->second.get_bool(def);
+}
+
+}  // namespace report
+}  // namespace gpufl

--- a/include/gpufl/report/text_report.cpp
+++ b/include/gpufl/report/text_report.cpp
@@ -1,0 +1,802 @@
+#include "gpufl/report/text_report.hpp"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <map>
+#include <numeric>
+#include <sstream>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace gpufl {
+namespace report {
+
+namespace fs = std::filesystem;
+
+// ── Formatting helpers (file-local) ─────────────────────────────────────────
+
+namespace {
+
+const std::string SEP(79, '=');
+
+std::string fmtBytes(uint64_t n) {
+    std::ostringstream oss;
+    if (n == 0)               return "0 B";
+    if (n >= 1024ULL * 1024)  { oss << std::fixed << std::setprecision(1) << (n / 1048576.0) << " MB"; return oss.str(); }
+    if (n >= 1024)            { oss << std::fixed << std::setprecision(1) << (n / 1024.0) << " KB"; return oss.str(); }
+    return std::to_string(n) + " B";
+}
+
+std::string fmtDuration(double ms) {
+    std::ostringstream oss;
+    if (ms >= 1000.0)      oss << std::fixed << std::setprecision(2) << (ms / 1000.0) << " s";
+    else if (ms >= 1.0)    oss << std::fixed << std::setprecision(2) << ms << " ms";
+    else                   oss << std::fixed << std::setprecision(2) << (ms * 1000.0) << " us";
+    return oss.str();
+}
+
+std::string fmtPower(double mw) {
+    std::ostringstream oss;
+    if (mw >= 1000.0) oss << std::fixed << std::setprecision(1) << (mw / 1000.0) << " W";
+    else              oss << std::fixed << std::setprecision(0) << mw << " mW";
+    return oss.str();
+}
+
+std::string shortenKernelName(const std::string& name) {
+    std::string s = name;
+    auto at = s.find('@');
+    if (at != std::string::npos) s = s.substr(0, at);
+    for (const auto* prefix : {"void ", "int ", "float ", "double ", "__global__ "}) {
+        if (s.rfind(prefix, 0) == 0) { s = s.substr(std::string(prefix).size()); break; }
+    }
+    auto tpl = s.find('<');
+    std::string funcPart = (tpl != std::string::npos) ? s.substr(0, tpl) : s;
+    auto paren = funcPart.find('(');
+    if (paren != std::string::npos) funcPart = funcPart.substr(0, paren);
+
+    std::vector<std::string> parts;
+    std::istringstream iss(funcPart);
+    std::string part;
+    while (std::getline(iss, part, ':'))
+        if (!part.empty()) parts.push_back(part);
+
+    std::string shortFunc = (parts.size() > 2)
+        ? parts[parts.size() - 2] + "::" + parts.back()
+        : funcPart;
+    if (tpl != std::string::npos) shortFunc += "<...>";
+    return shortFunc;
+}
+
+std::string truncate(const std::string& s, size_t maxLen) {
+    return (s.size() > maxLen) ? s.substr(0, maxLen - 3) + "..." : s;
+}
+
+const std::map<int, std::string> kCopyKindNames = {
+    {1, "HtoD"}, {2, "DtoH"}, {3, "HtoA"}, {4, "AtoH"},
+    {5, "AtoA"}, {6, "AtoD"}, {7, "DtoA"}, {8, "DtoD"},
+    {9, "HtoH"}, {10, "PtoP"},
+};
+
+std::string resolveCopyKind(int kind) {
+    auto it = kCopyKindNames.find(kind);
+    return (it != kCopyKindNames.end()) ? it->second : "Unknown(" + std::to_string(kind) + ")";
+}
+
+const std::map<int, std::string> kStallNames = {
+    {2,  "Instruction Fetch"},  {3,  "Execution Dependency"},
+    {4,  "Memory Dependency"},  {5,  "Texture"},
+    {6,  "Sync"},               {7,  "Constant Memory"},
+    {8,  "Pipe Busy"},          {9,  "Memory Throttle"},
+    {10, "Branch Resolving"},   {11, "Wait"},
+    {12, "Barrier"},            {13, "Sleeping"},
+};
+
+std::string resolveStallReason(int reason) {
+    auto it = kStallNames.find(reason);
+    return (it != kStallNames.end()) ? it->second : "Stall_" + std::to_string(reason);
+}
+
+// Resolve log file path for a given channel
+std::string resolveLogPath(const std::string& dir, const std::string& prefix,
+                           const std::string& channel) {
+    std::string base = prefix;
+    if (base.size() > 4 && base.substr(base.size() - 4) == ".log")
+        base = base.substr(0, base.size() - 4);
+
+    fs::path active = fs::path(dir) / (base + "." + channel + ".log");
+    if (fs::exists(active)) return active.string();
+
+    std::vector<std::pair<int, std::string>> candidates;
+    std::error_code ec;
+    for (auto& entry : fs::directory_iterator(dir, ec)) {
+        const std::string name = entry.path().filename().string();
+        const std::string pat = base + "." + channel + ".";
+        if (name.rfind(pat, 0) == 0) {
+            std::string rest = name.substr(pat.size());
+            auto dotPos = rest.find(".log");
+            if (dotPos != std::string::npos) {
+                try { candidates.emplace_back(std::stoi(rest.substr(0, dotPos)), entry.path().string()); }
+                catch (...) {}
+            }
+        }
+    }
+    if (!candidates.empty()) {
+        std::sort(candidates.begin(), candidates.end());
+        return candidates.front().second;
+    }
+    return {};
+}
+
+// Batch row helpers
+using ColIndex = std::unordered_map<std::string, size_t>;
+
+ColIndex buildColumnIndex(const JsonValue& cols) {
+    ColIndex ci;
+    const auto& arr = cols.get_array();
+    for (size_t i = 0; i < arr.size(); ++i)
+        ci[arr[i].get_string()] = i;
+    return ci;
+}
+
+int64_t rowInt(const JsonValue& row, const ColIndex& ci, const std::string& col, int64_t def = 0) {
+    auto it = ci.find(col);
+    return (it != ci.end()) ? row[it->second].as_int(def) : def;
+}
+
+uint64_t rowU64(const JsonValue& row, const ColIndex& ci, const std::string& col, uint64_t def = 0) {
+    auto it = ci.find(col);
+    return (it != ci.end()) ? row[it->second].as_uint64(def) : def;
+}
+
+// Functional: sort a map by value descending, return top-N as vector of pairs
+template <typename K, typename V, typename Fn>
+std::vector<std::pair<K, V>> sortedTopN(const std::map<K, V>& m, int n,
+                                         Fn valueFn) {
+    std::vector<std::pair<K, V>> vec(m.begin(), m.end());
+    std::sort(vec.begin(), vec.end(),
+              [&](const auto& a, const auto& b) { return valueFn(a.second) > valueFn(b.second); });
+    if (n > 0 && static_cast<int>(vec.size()) > n) vec.resize(n);
+    return vec;
+}
+
+}  // namespace
+
+// ── Constructor: parse log files ────────────────────────────────────────────
+
+TextReport::TextReport(const Options& opts) : top_n_(opts.top_n) {
+    parseLogFiles(opts);
+}
+
+void TextReport::parseLogFiles(const Options& opts) {
+    auto deviceRecords = loadJsonLines(resolveLogPath(opts.log_dir, opts.log_prefix, "device"));
+    auto scopeRecords  = loadJsonLines(resolveLogPath(opts.log_dir, opts.log_prefix, "scope"));
+    auto systemRecords = loadJsonLines(resolveLogPath(opts.log_dir, opts.log_prefix, "system"));
+
+    // Find the latest session_id (last job_start across all channels)
+    std::string latestSessionId;
+    auto findLatestSession = [&](const std::vector<JsonValue>& records) {
+        for (const auto& rec : records) {
+            std::string type = rec.value<std::string>("type", "");
+            if (type == "job_start" || type == "init") {
+                std::string sid = rec.value<std::string>("session_id", "");
+                if (!sid.empty()) latestSessionId = sid;
+            }
+        }
+    };
+    for (const auto* recs : {&deviceRecords, &scopeRecords, &systemRecords})
+        findLatestSession(*recs);
+
+    // Filter records to only the latest session
+    auto filterBySession = [&](std::vector<JsonValue>& records) {
+        if (latestSessionId.empty()) return;
+        records.erase(
+            std::remove_if(records.begin(), records.end(), [&](const JsonValue& rec) {
+                std::string sid = rec.value<std::string>("session_id", "");
+                // Keep records that match the latest session or have no session_id
+                return !sid.empty() && sid != latestSessionId;
+            }),
+            records.end());
+    };
+    filterBySession(deviceRecords);
+    filterBySession(scopeRecords);
+    filterBySession(systemRecords);
+
+    // Pass 1: dictionaries (needed before batch expansion)
+    std::unordered_map<int, std::string> kernel_dict, scope_name_dict, function_dict, metric_dict;
+    for (const auto* recs : {&deviceRecords, &scopeRecords, &systemRecords})
+        parseDictionaries(*recs, kernel_dict, scope_name_dict, function_dict, metric_dict);
+
+    // Pass 2: typed records
+    parseDeviceLog(deviceRecords, kernel_dict);
+    parseScopeLog(scopeRecords, scope_name_dict, function_dict, metric_dict);
+    parseSystemLog(systemRecords);
+}
+
+void TextReport::parseDictionaries(const std::vector<JsonValue>& records,
+                                   std::unordered_map<int, std::string>& kernel_dict,
+                                   std::unordered_map<int, std::string>& scope_name_dict,
+                                   std::unordered_map<int, std::string>& function_dict,
+                                   std::unordered_map<int, std::string>& metric_dict) {
+    auto merge = [](const JsonValue& obj, std::unordered_map<int, std::string>& dict) {
+        if (!obj.is_object()) return;
+        for (auto& [k, v] : obj)
+            dict[std::stoi(k)] = v.get_string();
+    };
+
+    for (const auto& rec : records) {
+        if (rec.value<std::string>("type", "") != "dictionary_update") continue;
+        merge(rec["kernel_dict"], kernel_dict);
+        merge(rec["scope_name_dict"], scope_name_dict);
+        merge(rec["function_dict"], function_dict);
+        merge(rec["metric_dict"], metric_dict);
+    }
+}
+
+void TextReport::parseJobStart(const JsonValue& rec, SessionInfo& info) {
+    info.app_name = rec.value<std::string>("app", "");
+    info.session_id = rec.value<std::string>("session_id", "");
+    info.start_ns = rec.value<int64_t>("ts_ns", 0);
+
+    for (const char* field : {"gpu_static_devices", "cuda_static_devices", "rocm_static_devices"}) {
+        if (!rec.contains(field) || !rec[field].is_array() || rec[field].empty()) continue;
+        const auto& dev = rec[field][0];
+        info.gpu_name = dev.value<std::string>("name", "");
+        info.compute_major = dev.contains("compute_capability_major")
+            ? dev.value<int>("compute_capability_major", 0) : dev.value<int>("major", 0);
+        info.compute_minor = dev.contains("compute_capability_minor")
+            ? dev.value<int>("compute_capability_minor", 0) : dev.value<int>("minor", 0);
+        info.sm_count = dev.value<int>("multi_processor_count", 0);
+        info.shared_mem_per_block = dev.value<int>("shared_mem_per_block", 0);
+        info.regs_per_block = dev.value<int>("regs_per_block", 0);
+        info.l2_cache_size = dev.value<int>("l2_cache_size", 0);
+        break;
+    }
+
+    if (info.gpu_name.empty() && rec.contains("devices") &&
+        rec["devices"].is_array() && !rec["devices"].empty())
+        info.gpu_name = rec["devices"][0].value<std::string>("name", "");
+}
+
+void TextReport::parseDeviceLog(const std::vector<JsonValue>& records,
+                                const std::unordered_map<int, std::string>& kernel_dict) {
+    std::unordered_map<unsigned, JsonValue> details;
+
+    for (const auto& rec : records) {
+        const std::string type = rec.value<std::string>("type", "");
+
+        if ((type == "job_start" || type == "init") && info_.app_name.empty()) {
+            parseJobStart(rec, info_);
+        } else if (type == "kernel_event_batch") {
+            auto ci = buildColumnIndex(rec["columns"]);
+            int64_t base = rec.value<int64_t>("base_time_ns", 0);
+            std::string sid = rec.value<std::string>("session_id", "");
+
+            for (const auto& row : rec["rows"].get_array()) {
+                int64_t dur_ns = rowInt(row, ci, "duration_ns");
+                int kid = static_cast<int>(rowInt(row, ci, "kernel_id"));
+                auto it = kernel_dict.find(kid);
+
+                kernels_.push_back({
+                    /*name*/       (it != kernel_dict.end()) ? it->second : "kernel_" + std::to_string(kid),
+                    /*session_id*/ sid,
+                    /*start_ns*/   base + rowInt(row, ci, "dt_ns"),
+                    /*end_ns*/     base + rowInt(row, ci, "dt_ns") + dur_ns,
+                    /*duration_ms*/dur_ns / 1e6,
+                    /*stream_id*/  static_cast<uint32_t>(rowInt(row, ci, "stream_id")),
+                    /*corr_id*/    static_cast<unsigned>(rowInt(row, ci, "corr_id")),
+                    /*num_regs*/   static_cast<int>(rowInt(row, ci, "num_regs")),
+                    /*dyn_shared*/ static_cast<int>(rowInt(row, ci, "dyn_shared")),
+                    /*has_details*/rowInt(row, ci, "has_details") != 0,
+                });
+            }
+        } else if (type == "kernel_detail") {
+            details[rec.value<unsigned>("corr_id", 0u)] = rec;
+        } else if (type == "memcpy_event_batch") {
+            auto ci = buildColumnIndex(rec["columns"]);
+            int64_t base = rec.value<int64_t>("base_time_ns", 0);
+            for (const auto& row : rec["rows"].get_array()) {
+                int64_t dur_ns = rowInt(row, ci, "duration_ns");
+                memcpy_.push_back({
+                    base + rowInt(row, ci, "dt_ns"),
+                    dur_ns / 1e6,
+                    rowU64(row, ci, "bytes"),
+                    static_cast<int>(rowInt(row, ci, "copy_kind")),
+                });
+            }
+        } else if (type == "shutdown" && rec.contains("ts_ns")) {
+            info_.end_ns = rec["ts_ns"].as_int();
+        }
+    }
+
+    mergeKernelDetails(details);
+}
+
+void TextReport::mergeKernelDetails(std::unordered_map<unsigned, JsonValue>& details) {
+    for (auto& k : kernels_) {
+        auto it = details.find(k.corr_id);
+        if (it == details.end()) continue;
+        const auto& d = it->second;
+        k.grid              = d.value<std::string>("grid", "?");
+        k.block             = d.value<std::string>("block", "?");
+        k.occupancy         = d.value<float>("occupancy", -1.0f);
+        k.reg_occupancy     = d.value<float>("reg_occupancy", -1.0f);
+        k.smem_occupancy    = d.value<float>("smem_occupancy", -1.0f);
+        k.warp_occupancy    = d.value<float>("warp_occupancy", -1.0f);
+        k.block_occupancy   = d.value<float>("block_occupancy", -1.0f);
+        k.limiting_resource = d.value<std::string>("limiting_resource", "");
+        k.static_shared     = d.value<int>("static_shared", 0);
+        k.user_scope        = d.value<std::string>("user_scope", "");
+    }
+}
+
+void TextReport::parseScopeLog(const std::vector<JsonValue>& records,
+                               const std::unordered_map<int, std::string>& scope_name_dict,
+                               const std::unordered_map<int, std::string>& function_dict,
+                               const std::unordered_map<int, std::string>& metric_dict) {
+    auto lookupOr = [](const std::unordered_map<int, std::string>& dict, int id,
+                       const std::string& prefix) -> std::string {
+        auto it = dict.find(id);
+        return (it != dict.end()) ? it->second : prefix + std::to_string(id);
+    };
+
+    for (const auto& rec : records) {
+        const std::string type = rec.value<std::string>("type", "");
+
+        if ((type == "job_start" || type == "init") && info_.app_name.empty()) {
+            parseJobStart(rec, info_);
+        } else if (type == "scope_event_batch") {
+            auto ci = buildColumnIndex(rec["columns"]);
+            int64_t base = rec.value<int64_t>("base_time_ns", 0);
+            for (const auto& row : rec["rows"].get_array()) {
+                int name_id = static_cast<int>(rowInt(row, ci, "name_id"));
+                scope_events_.push_back({
+                    base + rowInt(row, ci, "dt_ns"),
+                    rowU64(row, ci, "scope_instance_id"),
+                    lookupOr(scope_name_dict, name_id, "scope_"),
+                    static_cast<int>(rowInt(row, ci, "event_type")),
+                });
+            }
+        } else if (type == "profile_sample_batch") {
+            auto ci = buildColumnIndex(rec["columns"]);
+            for (const auto& row : rec["rows"].get_array()) {
+                int fn_id = static_cast<int>(rowInt(row, ci, "function_id"));
+                int met_id = static_cast<int>(rowInt(row, ci, "metric_id"));
+                auto fn_it = function_dict.find(fn_id);
+                auto met_it = metric_dict.find(met_id);
+                profile_samples_.push_back({
+                    (fn_it != function_dict.end()) ? fn_it->second : "",
+                    (met_it != metric_dict.end()) ? met_it->second : "",
+                    rowU64(row, ci, "metric_value"),
+                    static_cast<int>(rowInt(row, ci, "stall_reason")),
+                    static_cast<int>(rowInt(row, ci, "sample_kind")),
+                });
+            }
+        }
+    }
+}
+
+void TextReport::parseSystemLog(const std::vector<JsonValue>& records) {
+    for (const auto& rec : records) {
+        const std::string type = rec.value<std::string>("type", "");
+
+        if ((type == "job_start" || type == "init") && info_.app_name.empty()) {
+            parseJobStart(rec, info_);
+        } else if (type == "device_metric_batch") {
+            auto ci = buildColumnIndex(rec["columns"]);
+            int64_t base = rec.value<int64_t>("base_time_ns", 0);
+            for (const auto& row : rec["rows"].get_array()) {
+                device_metrics_.push_back({
+                    base + rowInt(row, ci, "dt_ns"),
+                    static_cast<int>(rowInt(row, ci, "gpu_util")),
+                    static_cast<int>(rowInt(row, ci, "mem_util")),
+                    static_cast<int>(rowInt(row, ci, "temp_c")),
+                    static_cast<int>(rowInt(row, ci, "power_mw")),
+                    rowU64(row, ci, "used_mib"),
+                    static_cast<int>(rowInt(row, ci, "clock_sm")),
+                });
+            }
+        } else if (type == "host_metric_batch") {
+            auto ci = buildColumnIndex(rec["columns"]);
+            int64_t base = rec.value<int64_t>("base_time_ns", 0);
+            for (const auto& row : rec["rows"].get_array()) {
+                host_metrics_.push_back({
+                    base + rowInt(row, ci, "dt_ns"),
+                    rowInt(row, ci, "cpu_pct_x100") / 100.0,
+                    rowU64(row, ci, "ram_used_mib"),
+                    rowU64(row, ci, "ram_total_mib"),
+                });
+            }
+        } else if (type == "system_stop" && info_.end_ns == 0 && rec.contains("ts_ns")) {
+            info_.end_ns = rec["ts_ns"].as_int();
+        }
+    }
+}
+
+// ── Report generation ───────────────────────────────────────────────────────
+
+std::string TextReport::generate() const {
+    std::ostringstream out;
+    writeHeader(out);
+    writeSessionSummary(out);
+    writeKernelSummary(out);
+    writeTopKernels(out);
+    writeKernelDetails(out);
+    writeMemcpySummary(out);
+    writeSystemMetrics(out);
+    writeScopeSummary(out);
+    writeProfileAnalysis(out);
+    return out.str();
+}
+
+// ── Section writers ─────────────────────────────────────────────────────────
+
+void TextReport::writeHeader(std::ostringstream& out) const {
+    out << SEP << "\n"
+        << std::setw(52) << "GPU Flight Session Report" << "\n"
+        << SEP << "\n";
+}
+
+void TextReport::writeSessionSummary(std::ostringstream& out) const {
+    out << "\n" << SEP << "\n  Session Summary\n" << SEP << "\n";
+    out << "  Application:          " << (info_.app_name.empty() ? "unknown" : info_.app_name) << "\n";
+
+    if (!info_.session_id.empty())
+        out << "  Session ID:           " << info_.session_id << "\n";
+    if (info_.start_ns > 0 && info_.end_ns > 0)
+        out << "  Duration:             " << fmtDuration((info_.end_ns - info_.start_ns) / 1e6) << "\n";
+
+    if (!info_.gpu_name.empty()) {
+        out << "  GPU Device:           " << info_.gpu_name << "\n";
+        if (info_.compute_major > 0)
+            out << "    Compute:            " << info_.compute_major << "." << info_.compute_minor << "\n";
+        if (info_.sm_count > 0)
+            out << "    SMs:                " << info_.sm_count << "\n";
+        if (info_.shared_mem_per_block > 0)
+            out << "    Shared Mem/Block:   " << fmtBytes(info_.shared_mem_per_block) << "\n";
+        if (info_.regs_per_block > 0)
+            out << "    Registers/Block:    " << info_.regs_per_block << "\n";
+        if (info_.l2_cache_size > 0)
+            out << "    L2 Cache:           " << fmtBytes(info_.l2_cache_size) << "\n";
+    }
+}
+
+void TextReport::writeKernelSummary(std::ostringstream& out) const {
+    out << "\n" << SEP << "\n  Kernel Execution Summary\n" << SEP << "\n";
+    if (kernels_.empty()) { out << "  (No kernel data)\n"; return; }
+
+    // Functional: extract durations, compute stats via algorithms
+    std::vector<double> durations(kernels_.size());
+    std::transform(kernels_.begin(), kernels_.end(), durations.begin(),
+                   [](const KernelRecord& k) { return k.duration_ms; });
+
+    double totalMs = std::accumulate(durations.begin(), durations.end(), 0.0);
+    auto [minIt, maxIt] = std::minmax_element(durations.begin(), durations.end());
+    std::sort(durations.begin(), durations.end());
+
+    std::map<std::string, int> uniqueNames;
+    for (const auto& k : kernels_) uniqueNames[k.name]++;
+
+    out << "  Total Kernels:        " << kernels_.size() << "\n";
+    out << "  Unique Kernels:       " << uniqueNames.size() << "\n";
+    out << "  Total GPU Time:       " << fmtDuration(totalMs) << "\n";
+
+    if (info_.start_ns > 0 && info_.end_ns > 0) {
+        double sessionMs = (info_.end_ns - info_.start_ns) / 1e6;
+        if (sessionMs > 0)
+            out << "  GPU Busy:             " << std::fixed << std::setprecision(1)
+                << (totalMs / sessionMs * 100) << "%\n";
+    }
+
+    out << "  Avg Duration:         " << fmtDuration(totalMs / kernels_.size()) << "\n";
+    out << "  Median Duration:      " << fmtDuration(durations[durations.size() / 2]) << "\n";
+    out << "  Min Duration:         " << fmtDuration(*minIt) << "\n";
+    out << "  Max Duration:         " << fmtDuration(*maxIt) << "\n";
+}
+
+void TextReport::writeTopKernels(std::ostringstream& out) const {
+    out << "\n" << SEP << "\n  Top " << top_n_ << " Kernels by Total GPU Time\n" << SEP << "\n";
+    if (kernels_.empty()) { out << "  (No kernel data)\n"; return; }
+
+    // Aggregate per kernel name using AggStats
+    std::map<std::string, AggStats> grouped;
+    for (const auto& k : kernels_)
+        grouped[k.name].add(k.duration_ms);
+
+    auto ranked = sortedTopN(grouped, top_n_, [](const AggStats& s) { return s.total; });
+
+    out << "  " << std::left << std::setw(4) << "#"
+        << std::setw(40) << "Kernel"
+        << std::right << std::setw(6) << "Calls"
+        << std::setw(12) << "Total" << std::setw(12) << "Avg" << std::setw(12) << "Max" << "\n";
+    out << "  " << std::string(86, '-') << "\n";
+
+    int rank = 0;
+    for (const auto& [name, st] : ranked) {
+        out << "  " << std::left << std::setw(4) << ++rank
+            << std::setw(40) << truncate(shortenKernelName(name), 38)
+            << std::right << std::setw(6) << st.count
+            << std::setw(12) << fmtDuration(st.total)
+            << std::setw(12) << fmtDuration(st.avg())
+            << std::setw(12) << fmtDuration(st.max_val) << "\n";
+    }
+}
+
+void TextReport::writeKernelDetails(std::ostringstream& out) const {
+    out << "\n" << SEP << "\n  Kernel Details (Top " << top_n_ << ")\n" << SEP << "\n";
+
+    bool hasDetails = std::any_of(kernels_.begin(), kernels_.end(),
+                                  [](const KernelRecord& k) { return k.occupancy >= 0; });
+    if (!hasDetails || kernels_.empty()) { out << "  (No kernel detail data)\n"; return; }
+
+    // Rank by total GPU time
+    std::map<std::string, double> totalByName;
+    for (const auto& k : kernels_) totalByName[k.name] += k.duration_ms;
+    auto ranked = sortedTopN(totalByName, top_n_, [](double v) { return v; });
+
+    for (const auto& [name, _] : ranked) {
+        // Find representative kernel with detail data
+        auto rep = std::find_if(kernels_.begin(), kernels_.end(),
+                                [&](const KernelRecord& k) { return k.name == name && k.occupancy >= 0; });
+        if (rep == kernels_.end()) continue;
+
+        std::string shortName = shortenKernelName(name);
+        out << "\n  " << shortName << "\n  " << std::string(shortName.size(), '=') << "\n";
+        out << "    Grid:               " << rep->grid << "\n";
+        out << "    Block:              " << rep->block << "\n";
+
+        if (rep->occupancy >= 0)
+            out << "    Occupancy:          " << std::fixed << std::setprecision(1)
+                << (rep->occupancy * 100) << "%\n";
+
+        auto writeOcc = [&](const char* label, float val) {
+            if (val >= 0)
+                out << "    " << std::left << std::setw(20) << (std::string(label) + ":")
+                    << std::fixed << std::setprecision(1) << (val * 100) << "%\n";
+        };
+        writeOcc("Reg Occupancy", rep->reg_occupancy);
+        writeOcc("SMem Occupancy", rep->smem_occupancy);
+        writeOcc("Warp Occupancy", rep->warp_occupancy);
+        writeOcc("Block Occupancy", rep->block_occupancy);
+
+        if (!rep->limiting_resource.empty())
+            out << "    Limiting Resource:  " << rep->limiting_resource << "\n";
+        if (rep->num_regs > 0)
+            out << "    Registers/Thread:   " << rep->num_regs << "\n";
+        out << "    Shared Memory:      " << fmtBytes(rep->dyn_shared)
+            << " dyn + " << fmtBytes(rep->static_shared) << " static\n";
+    }
+}
+
+void TextReport::writeMemcpySummary(std::ostringstream& out) const {
+    out << "\n" << SEP << "\n  Memory Transfer Summary\n" << SEP << "\n";
+    if (memcpy_.empty()) { out << "  (No memory transfer data)\n"; return; }
+
+    uint64_t totalBytes = std::accumulate(memcpy_.begin(), memcpy_.end(), uint64_t(0),
+                                          [](uint64_t sum, const MemcpyRecord& m) { return sum + m.bytes; });
+
+    out << "  Total Transfers:      " << memcpy_.size() << "\n";
+    out << "  Total Bytes:          " << fmtBytes(totalBytes) << "\n\n";
+
+    // Group by copy_kind
+    std::map<int, std::vector<const MemcpyRecord*>> grouped;
+    for (const auto& m : memcpy_) grouped[m.copy_kind].push_back(&m);
+
+    out << "  " << std::left << std::setw(12) << "Direction"
+        << std::right << std::setw(8) << "Count"
+        << std::setw(16) << "Total Bytes" << std::setw(18) << "Avg Throughput" << "\n";
+    out << "  " << std::string(54, '-') << "\n";
+
+    for (const auto& [kind, recs] : grouped) {
+        uint64_t kb = std::accumulate(recs.begin(), recs.end(), uint64_t(0),
+                                      [](uint64_t s, const MemcpyRecord* r) { return s + r->bytes; });
+        double totalDurNs = std::accumulate(recs.begin(), recs.end(), 0.0,
+                                            [](double s, const MemcpyRecord* r) { return s + r->duration_ms * 1e6; });
+        std::string tp;
+        if (totalDurNs > 0) {
+            std::ostringstream toss;
+            toss << std::fixed << std::setprecision(2) << (static_cast<double>(kb) / totalDurNs) << " GB/s";
+            tp = toss.str();
+        }
+        out << "  " << std::left << std::setw(12) << resolveCopyKind(kind)
+            << std::right << std::setw(8) << recs.size()
+            << std::setw(16) << fmtBytes(kb) << std::setw(18) << tp << "\n";
+    }
+}
+
+void TextReport::writeSystemMetrics(std::ostringstream& out) const {
+    out << "\n" << SEP << "\n  System Metrics\n" << SEP << "\n";
+    if (device_metrics_.empty() && host_metrics_.empty()) {
+        out << "  (No system metric data)\n"; return;
+    }
+
+    if (!device_metrics_.empty()) {
+        out << "  GPU Metrics:\n";
+
+        // Functional aggregation with accumulate
+        struct GpuAgg { double sumUtil=0, maxUtil=0, minUtil=1e9, sumTemp=0, maxTemp=0,
+                               sumPow=0, maxPow=0, sumClk=0; uint64_t maxMem=0; int clkN=0; int n=0; };
+        auto agg = std::accumulate(device_metrics_.begin(), device_metrics_.end(), GpuAgg{},
+            [](GpuAgg a, const DeviceMetricRecord& m) {
+                a.sumUtil += m.gpu_util; a.maxUtil = std::max(a.maxUtil, (double)m.gpu_util);
+                a.minUtil = std::min(a.minUtil, (double)m.gpu_util);
+                a.sumTemp += m.temp_c;   a.maxTemp = std::max(a.maxTemp, (double)m.temp_c);
+                a.sumPow  += m.power_mw; a.maxPow  = std::max(a.maxPow, (double)m.power_mw);
+                a.maxMem = std::max(a.maxMem, m.used_mib);
+                if (m.clock_sm > 0) { a.sumClk += m.clock_sm; a.clkN++; }
+                a.n++; return a;
+            });
+
+        out << "    Utilization:        avg " << std::fixed << std::setprecision(1) << (agg.sumUtil / agg.n)
+            << "%  peak " << std::setprecision(0) << agg.maxUtil << "%  min " << agg.minUtil << "%\n";
+        out << "    Temperature:        avg " << std::setprecision(1) << (agg.sumTemp / agg.n)
+            << " C  peak " << std::setprecision(0) << agg.maxTemp << " C\n";
+        out << "    Power:              avg " << fmtPower(agg.sumPow / agg.n) << "  peak " << fmtPower(agg.maxPow) << "\n";
+        out << "    VRAM Usage:         peak " << agg.maxMem << " MiB\n";
+        if (agg.clkN > 0)
+            out << "    SM Clock:           avg " << std::setprecision(0) << (agg.sumClk / agg.clkN) << " MHz\n";
+    }
+
+    if (!host_metrics_.empty()) {
+        if (!device_metrics_.empty()) out << "\n";
+        out << "  Host Metrics:\n";
+
+        struct HostAgg { double sumCpu=0, maxCpu=0; uint64_t maxRam=0, totalRam=0; int n=0; };
+        auto agg = std::accumulate(host_metrics_.begin(), host_metrics_.end(), HostAgg{},
+            [](HostAgg a, const HostMetricRecord& m) {
+                a.sumCpu += m.cpu_pct; a.maxCpu = std::max(a.maxCpu, m.cpu_pct);
+                a.maxRam = std::max(a.maxRam, m.ram_used_mib);
+                if (m.ram_total_mib > 0) a.totalRam = m.ram_total_mib;
+                a.n++; return a;
+            });
+
+        out << "    CPU Utilization:    avg " << std::fixed << std::setprecision(1)
+            << (agg.sumCpu / agg.n) << "%  peak " << agg.maxCpu << "%\n";
+        if (agg.totalRam > 0)
+            out << "    RAM Usage:          peak " << agg.maxRam << " / " << agg.totalRam
+                << " MiB (" << std::setprecision(1) << (agg.maxRam * 100.0 / agg.totalRam) << "%)\n";
+    }
+}
+
+void TextReport::writeScopeSummary(std::ostringstream& out) const {
+    out << "\n" << SEP << "\n  Scope Summary\n" << SEP << "\n";
+
+    bool hasKernelScopes = std::any_of(kernels_.begin(), kernels_.end(),
+                                       [](const KernelRecord& k) { return !k.user_scope.empty(); });
+    if (scope_events_.empty() && !hasKernelScopes) { out << "  (No scope data)\n"; return; }
+
+    // Scope event timing (begin/end pairs)
+    if (!scope_events_.empty()) {
+        std::unordered_map<uint64_t, int64_t> beginTimes;
+        std::unordered_map<uint64_t, std::string> beginNames;
+        std::map<std::string, AggStats> stats;
+
+        for (const auto& se : scope_events_) {
+            if (se.event_type == 0) {
+                beginTimes[se.scope_instance_id] = se.ts_ns;
+                beginNames[se.scope_instance_id] = se.name;
+            } else if (se.event_type == 1) {
+                auto it = beginTimes.find(se.scope_instance_id);
+                if (it != beginTimes.end())
+                    stats[beginNames[se.scope_instance_id]].add((se.ts_ns - it->second) / 1e6);
+            }
+        }
+
+        if (!stats.empty()) {
+            auto ranked = sortedTopN(stats, 0, [](const AggStats& s) { return s.total; });
+            out << "  Scope Timing:\n";
+            out << "  " << std::left << std::setw(30) << "Scope"
+                << std::right << std::setw(6) << "Calls"
+                << std::setw(12) << "Total" << std::setw(12) << "Avg" << std::setw(12) << "Max" << "\n";
+            out << "  " << std::string(72, '-') << "\n";
+            for (const auto& [name, st] : ranked)
+                out << "  " << std::left << std::setw(30) << truncate(name, 28)
+                    << std::right << std::setw(6) << st.count
+                    << std::setw(12) << fmtDuration(st.total)
+                    << std::setw(12) << fmtDuration(st.avg())
+                    << std::setw(12) << fmtDuration(st.max_val) << "\n";
+        }
+    }
+
+    // GPU time by scope (from kernel user_scope)
+    if (hasKernelScopes) {
+        std::map<std::string, AggStats> scopeGpu;
+        for (const auto& k : kernels_) {
+            if (k.user_scope.empty()) continue;
+            auto pipe = k.user_scope.find('|');
+            scopeGpu[(pipe != std::string::npos) ? k.user_scope.substr(0, pipe) : k.user_scope]
+                .add(k.duration_ms);
+        }
+
+        if (!scopeGpu.empty()) {
+            auto ranked = sortedTopN(scopeGpu, 0, [](const AggStats& s) { return s.total; });
+            out << "\n  GPU Time by Scope:\n";
+            out << "  " << std::left << std::setw(30) << "Scope"
+                << std::right << std::setw(8) << "Kernels"
+                << std::setw(14) << "GPU Time" << std::setw(12) << "Avg" << "\n";
+            out << "  " << std::string(64, '-') << "\n";
+            for (const auto& [name, sg] : ranked)
+                out << "  " << std::left << std::setw(30) << truncate(name, 28)
+                    << std::right << std::setw(8) << sg.count
+                    << std::setw(14) << fmtDuration(sg.total)
+                    << std::setw(12) << fmtDuration(sg.avg()) << "\n";
+        }
+    }
+}
+
+void TextReport::writeProfileAnalysis(std::ostringstream& out) const {
+    out << "\n" << SEP << "\n  Profile / SASS Analysis\n" << SEP << "\n";
+    if (profile_samples_.empty()) { out << "  (No profile sample data)\n"; return; }
+
+    // Stall reason distribution
+    std::map<std::string, uint64_t> stallCounts;
+    for (const auto& ps : profile_samples_)
+        if (ps.stall_reason > 1)
+            stallCounts[resolveStallReason(ps.stall_reason)] += ps.metric_value;
+
+    if (!stallCounts.empty()) {
+        uint64_t totalStalls = std::accumulate(stallCounts.begin(), stallCounts.end(), uint64_t(0),
+                                               [](uint64_t s, const auto& p) { return s + p.second; });
+
+        out << "  Stall Reason Distribution:\n";
+        out << "  " << std::left << std::setw(30) << "Reason"
+            << std::right << std::setw(10) << "Samples" << std::setw(8) << "Pct" << "\n";
+        out << "  " << std::string(48, '-') << "\n";
+
+        auto ranked = sortedTopN(stallCounts, 0, [](uint64_t v) { return static_cast<double>(v); });
+        for (const auto& [reason, count] : ranked)
+            out << "  " << std::left << std::setw(30) << reason
+                << std::right << std::setw(10) << count
+                << std::setw(7) << std::fixed << std::setprecision(1) << (count * 100.0 / totalStalls) << "%\n";
+
+        // Per-kernel stall breakdown
+        std::map<std::string, uint64_t> kernStalls;
+        for (const auto& ps : profile_samples_)
+            if (ps.stall_reason > 1 && !ps.function_name.empty())
+                kernStalls[ps.function_name] += ps.metric_value;
+
+        if (!kernStalls.empty()) {
+            auto topKern = sortedTopN(kernStalls, top_n_, [](uint64_t v) { return static_cast<double>(v); });
+            out << "\n  Top " << top_n_ << " Kernels by Stall Samples:\n";
+            for (const auto& [fn, count] : topKern)
+                out << "    " << std::left << std::setw(52) << truncate(shortenKernelName(fn), 50)
+                    << std::right << std::setw(8) << count << " samples\n";
+        }
+    }
+
+    // SASS metrics summary
+    std::map<std::string, uint64_t> metricSums;
+    for (const auto& ps : profile_samples_)
+        if (!ps.metric_name.empty())
+            metricSums[ps.metric_name] += ps.metric_value;
+
+    if (!metricSums.empty()) {
+        auto ranked = sortedTopN(metricSums, 0, [](uint64_t v) { return static_cast<double>(v); });
+        out << "\n  SASS Metrics Summary:\n";
+        out << "  " << std::left << std::setw(50) << "Metric"
+            << std::right << std::setw(12) << "Total" << "\n";
+        out << "  " << std::string(62, '-') << "\n";
+        for (const auto& [metric, total] : ranked)
+            out << "  " << std::left << std::setw(50) << truncate(metric, 48)
+                << std::right << std::setw(12) << total << "\n";
+
+        // Thread divergence analysis
+        auto warpIt = metricSums.find("smsp__sass_inst_executed");
+        auto threadIt = metricSums.find("smsp__sass_thread_inst_executed");
+        if (warpIt != metricSums.end() && threadIt != metricSums.end() && warpIt->second > 0) {
+            double ratio = static_cast<double>(threadIt->second) / warpIt->second;
+            out << "\n  Thread Divergence Analysis:\n";
+            out << "    Warp Instructions:    " << warpIt->second << "\n";
+            out << "    Thread Instructions:  " << threadIt->second << "\n";
+            out << "    Avg Threads/Warp:     " << std::fixed << std::setprecision(1) << ratio << " / 32\n";
+            out << "    Warp Efficiency:      " << std::setprecision(1) << (ratio / 32.0 * 100) << "%\n";
+        }
+    }
+}
+
+}  // namespace report
+}  // namespace gpufl

--- a/include/gpufl/report/text_report.cpp
+++ b/include/gpufl/report/text_report.cpp
@@ -622,11 +622,11 @@ void TextReport::writeSystemMetrics(std::ostringstream& out) const {
                                sumPow=0, maxPow=0, sumClk=0; uint64_t maxMem=0; int clkN=0; int n=0; };
         auto agg = std::accumulate(device_metrics_.begin(), device_metrics_.end(), GpuAgg{},
             [](GpuAgg a, const DeviceMetricRecord& m) {
-                a.sumUtil += m.gpu_util; a.maxUtil = std::max(a.maxUtil, (double)m.gpu_util);
-                a.minUtil = std::min(a.minUtil, (double)m.gpu_util);
-                a.sumTemp += m.temp_c;   a.maxTemp = std::max(a.maxTemp, (double)m.temp_c);
-                a.sumPow  += m.power_mw; a.maxPow  = std::max(a.maxPow, (double)m.power_mw);
-                a.maxMem = std::max(a.maxMem, m.used_mib);
+                a.sumUtil += m.gpu_util; a.maxUtil = (std::max)(a.maxUtil, (double)m.gpu_util);
+                a.minUtil = (std::min)(a.minUtil, (double)m.gpu_util);
+                a.sumTemp += m.temp_c;   a.maxTemp = (std::max)(a.maxTemp, (double)m.temp_c);
+                a.sumPow  += m.power_mw; a.maxPow  = (std::max)(a.maxPow, (double)m.power_mw);
+                a.maxMem = (std::max)(a.maxMem, m.used_mib);
                 if (m.clock_sm > 0) { a.sumClk += m.clock_sm; a.clkN++; }
                 a.n++; return a;
             });
@@ -648,8 +648,8 @@ void TextReport::writeSystemMetrics(std::ostringstream& out) const {
         struct HostAgg { double sumCpu=0, maxCpu=0; uint64_t maxRam=0, totalRam=0; int n=0; };
         auto agg = std::accumulate(host_metrics_.begin(), host_metrics_.end(), HostAgg{},
             [](HostAgg a, const HostMetricRecord& m) {
-                a.sumCpu += m.cpu_pct; a.maxCpu = std::max(a.maxCpu, m.cpu_pct);
-                a.maxRam = std::max(a.maxRam, m.ram_used_mib);
+                a.sumCpu += m.cpu_pct; a.maxCpu = (std::max)(a.maxCpu, m.cpu_pct);
+                a.maxRam = (std::max)(a.maxRam, m.ram_used_mib);
                 if (m.ram_total_mib > 0) a.totalRam = m.ram_total_mib;
                 a.n++; return a;
             });

--- a/include/gpufl/report/text_report.hpp
+++ b/include/gpufl/report/text_report.hpp
@@ -107,7 +107,7 @@ class TextReport {
         int count = 0;
         double total = 0;
         double max_val = 0;
-        void add(double v) { count++; total += v; max_val = std::max(max_val, v); }
+        void add(double v) { count++; total += v; max_val = (std::max)(max_val, v); }
         double avg() const { return count > 0 ? total / count : 0; }
     };
 

--- a/include/gpufl/report/text_report.hpp
+++ b/include/gpufl/report/text_report.hpp
@@ -1,0 +1,158 @@
+#pragma once
+
+#include <cstdint>
+#include <map>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "gpufl/report/json_reader.hpp"
+
+namespace gpufl {
+namespace report {
+
+class TextReport {
+   public:
+    struct Options {
+        std::string log_dir;
+        std::string log_prefix;
+        int top_n = 10;
+    };
+
+    explicit TextReport(const Options& opts);
+
+    std::string generate() const;
+
+   private:
+    // ── Data records ────────────────────────────────────────────────────────
+
+    struct KernelRecord {
+        std::string name;
+        std::string session_id;
+        int64_t start_ns = 0;
+        int64_t end_ns = 0;
+        double duration_ms = 0;
+        uint32_t stream_id = 0;
+        unsigned corr_id = 0;
+        int num_regs = 0;
+        int dyn_shared = 0;
+        bool has_details = false;
+        std::string grid;
+        std::string block;
+        float occupancy = -1;
+        float reg_occupancy = -1;
+        float smem_occupancy = -1;
+        float warp_occupancy = -1;
+        float block_occupancy = -1;
+        std::string limiting_resource;
+        int static_shared = 0;
+        std::string user_scope;
+    };
+
+    struct MemcpyRecord {
+        int64_t start_ns = 0;
+        double duration_ms = 0;
+        uint64_t bytes = 0;
+        int copy_kind = 0;
+    };
+
+    struct DeviceMetricRecord {
+        int64_t ts_ns = 0;
+        int gpu_util = 0;
+        int mem_util = 0;
+        int temp_c = 0;
+        int power_mw = 0;
+        uint64_t used_mib = 0;
+        int clock_sm = 0;
+    };
+
+    struct HostMetricRecord {
+        int64_t ts_ns = 0;
+        double cpu_pct = 0;
+        uint64_t ram_used_mib = 0;
+        uint64_t ram_total_mib = 0;
+    };
+
+    struct ScopeEventRecord {
+        int64_t ts_ns = 0;
+        uint64_t scope_instance_id = 0;
+        std::string name;
+        int event_type = 0;
+    };
+
+    struct ProfileSampleRecord {
+        std::string function_name;
+        std::string metric_name;
+        uint64_t metric_value = 0;
+        int stall_reason = 0;
+        int sample_kind = 0;
+    };
+
+    struct SessionInfo {
+        std::string app_name;
+        std::string session_id;
+        int64_t start_ns = 0;
+        int64_t end_ns = 0;
+        std::string gpu_name;
+        int compute_major = 0;
+        int compute_minor = 0;
+        int sm_count = 0;
+        int shared_mem_per_block = 0;
+        int regs_per_block = 0;
+        int l2_cache_size = 0;
+    };
+
+    // Aggregation helper used by multiple sections
+    struct AggStats {
+        int count = 0;
+        double total = 0;
+        double max_val = 0;
+        void add(double v) { count++; total += v; max_val = std::max(max_val, v); }
+        double avg() const { return count > 0 ? total / count : 0; }
+    };
+
+    // ── Parsed state ────────────────────────────────────────────────────────
+
+    SessionInfo info_;
+    std::vector<KernelRecord> kernels_;
+    std::vector<MemcpyRecord> memcpy_;
+    std::vector<DeviceMetricRecord> device_metrics_;
+    std::vector<HostMetricRecord> host_metrics_;
+    std::vector<ScopeEventRecord> scope_events_;
+    std::vector<ProfileSampleRecord> profile_samples_;
+    int top_n_;
+
+    // ── Parsing (constructor helpers) ────────────────────────────────────────
+
+    void parseLogFiles(const Options& opts);
+    void parseDictionaries(const std::vector<JsonValue>& records,
+                           std::unordered_map<int, std::string>& kernel_dict,
+                           std::unordered_map<int, std::string>& scope_name_dict,
+                           std::unordered_map<int, std::string>& function_dict,
+                           std::unordered_map<int, std::string>& metric_dict);
+    void parseDeviceLog(const std::vector<JsonValue>& records,
+                        const std::unordered_map<int, std::string>& kernel_dict);
+    void parseScopeLog(const std::vector<JsonValue>& records,
+                       const std::unordered_map<int, std::string>& scope_name_dict,
+                       const std::unordered_map<int, std::string>& function_dict,
+                       const std::unordered_map<int, std::string>& metric_dict);
+    void parseSystemLog(const std::vector<JsonValue>& records);
+    void mergeKernelDetails(std::unordered_map<unsigned, JsonValue>& details);
+
+    static void parseJobStart(const JsonValue& record, SessionInfo& info);
+
+    // ── Section writers ─────────────────────────────────────────────────────
+
+    void writeHeader(std::ostringstream& out) const;
+    void writeSessionSummary(std::ostringstream& out) const;
+    void writeKernelSummary(std::ostringstream& out) const;
+    void writeTopKernels(std::ostringstream& out) const;
+    void writeKernelDetails(std::ostringstream& out) const;
+    void writeMemcpySummary(std::ostringstream& out) const;
+    void writeSystemMetrics(std::ostringstream& out) const;
+    void writeScopeSummary(std::ostringstream& out) const;
+    void writeProfileAnalysis(std::ostringstream& out) const;
+};
+
+}  // namespace report
+}  // namespace gpufl

--- a/python/gpufl/report/__init__.py
+++ b/python/gpufl/report/__init__.py
@@ -1,0 +1,1 @@
+from .text_report import TextReport, generate_report

--- a/python/gpufl/report/text_report.py
+++ b/python/gpufl/report/text_report.py
@@ -1,0 +1,516 @@
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pandas as pd
+
+from gpufl.analyzer.analyzer import (
+    GpuFlightSession,
+    _fmt_bytes,
+    _shorten_kernel_name,
+    _STALL_NAMES,
+)
+
+_COPY_KIND_NAMES = {
+    1: "HtoD", 2: "DtoH", 3: "HtoA", 4: "AtoH",
+    5: "AtoA", 6: "AtoD", 7: "DtoA", 8: "DtoD",
+    9: "HtoH", 10: "PtoP",
+}
+
+_SEP = "=" * 79
+_THIN_SEP = "-" * 79
+
+
+def _resolve_copy_kind(val):
+    if isinstance(val, str):
+        return val
+    return _COPY_KIND_NAMES.get(int(val), f"Unknown({val})")
+
+
+def _fmt_duration(ms):
+    if ms >= 1000:
+        return f"{ms / 1000:.2f} s"
+    if ms >= 1:
+        return f"{ms:.2f} ms"
+    return f"{ms * 1000:.2f} us"
+
+
+def _fmt_power(mw):
+    if mw >= 1000:
+        return f"{mw / 1000:.1f} W"
+    return f"{mw:.0f} mW"
+
+
+class TextReport:
+    def __init__(self, session: GpuFlightSession, top_n: int = 10):
+        self.session = session
+        self.top_n = top_n
+
+    def generate(self) -> str:
+        sections = [
+            self._section_header(),
+            self._section_session_summary(),
+            self._section_kernel_summary(),
+            self._section_top_kernels(),
+            self._section_kernel_details(),
+            self._section_memcpy_summary(),
+            self._section_system_metrics(),
+            self._section_scope_summary(),
+            self._section_profile_analysis(),
+        ]
+        return "\n".join("\n".join(s) for s in sections) + "\n"
+
+    def save(self, path: str) -> None:
+        Path(path).write_text(self.generate(), encoding="utf-8")
+
+    def print(self, file=None) -> None:
+        print(self.generate(), file=file or sys.stdout)
+
+    # -- Sections ----------------------------------------------------------
+
+    def _section_header(self) -> list[str]:
+        now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+        return [
+            _SEP,
+            "GPU Flight Session Report".center(79),
+            f"Generated: {now}".center(79),
+            _SEP,
+        ]
+
+    def _section_session_summary(self) -> list[str]:
+        s = self.session
+        lines = ["", _SEP, "  Session Summary", _SEP]
+
+        app = s.app_name
+        if app is None and not s.kernels.empty and "app" in s.kernels.columns:
+            app = s.kernels.iloc[0].get("app")
+        lines.append(f"  Application:          {app or 'unknown'}")
+
+        # Session ID
+        sid = None
+        if not s.kernels.empty and "session_id" in s.kernels.columns:
+            sid = s.kernels.iloc[0].get("session_id")
+        if sid is None and not s.device_metrics.empty and "session_id" in s.device_metrics.columns:
+            sid = s.device_metrics.iloc[0].get("session_id")
+        if sid:
+            lines.append(f"  Session ID:           {sid}")
+
+        # Duration
+        if s.session_start_ns is not None and s.session_end_ns is not None:
+            dur_ms = (s.session_end_ns - s.session_start_ns) / 1e6
+            lines.append(f"  Duration:             {_fmt_duration(dur_ms)}")
+        elif not s.kernels.empty:
+            dur_ms = (s.kernels["end_ns"].max() - s.kernels["start_ns"].min()) / 1e6
+            lines.append(f"  Duration (kernel):    {_fmt_duration(dur_ms)}")
+
+        # GPU device info
+        if s.static_devices:
+            for dev in s.static_devices:
+                name = dev.get("name", "Unknown GPU")
+                lines.append(f"  GPU Device:           {name}")
+                cc_major = dev.get("compute_capability_major", dev.get("major"))
+                cc_minor = dev.get("compute_capability_minor", dev.get("minor"))
+                if cc_major is not None and cc_minor is not None:
+                    lines.append(f"    Compute:            {cc_major}.{cc_minor}")
+                sm = dev.get("multi_processor_count")
+                if sm is not None:
+                    lines.append(f"    SMs:                {sm}")
+                smem = dev.get("shared_mem_per_block")
+                if smem is not None:
+                    lines.append(f"    Shared Mem/Block:   {_fmt_bytes(smem)}")
+                regs = dev.get("regs_per_block")
+                if regs is not None:
+                    lines.append(f"    Registers/Block:    {regs}")
+                l2 = dev.get("l2_cache_size")
+                if l2 is not None:
+                    lines.append(f"    L2 Cache:           {_fmt_bytes(l2)}")
+
+        return lines
+
+    def _section_kernel_summary(self) -> list[str]:
+        lines = ["", _SEP, "  Kernel Execution Summary", _SEP]
+        k = self.session.kernels
+        if k.empty:
+            lines.append("  (No kernel data)")
+            return lines
+
+        total = len(k)
+        unique = k["name"].nunique() if "name" in k.columns else "?"
+        gpu_time_ms = k["duration_ms"].sum() if "duration_ms" in k.columns else 0
+        avg_ms = k["duration_ms"].mean() if "duration_ms" in k.columns else 0
+        med_ms = k["duration_ms"].median() if "duration_ms" in k.columns else 0
+        min_ms = k["duration_ms"].min() if "duration_ms" in k.columns else 0
+        max_ms = k["duration_ms"].max() if "duration_ms" in k.columns else 0
+
+        lines.append(f"  Total Kernels:        {total}")
+        lines.append(f"  Unique Kernels:       {unique}")
+        lines.append(f"  Total GPU Time:       {_fmt_duration(gpu_time_ms)}")
+
+        # GPU busy %
+        s = self.session
+        if s.session_start_ns is not None and s.session_end_ns is not None:
+            total_dur_ms = (s.session_end_ns - s.session_start_ns) / 1e6
+            if total_dur_ms > 0:
+                busy_pct = gpu_time_ms / total_dur_ms * 100
+                lines.append(f"  GPU Busy:             {busy_pct:.1f}%")
+
+        lines.append(f"  Avg Duration:         {_fmt_duration(avg_ms)}")
+        lines.append(f"  Median Duration:      {_fmt_duration(med_ms)}")
+        lines.append(f"  Min Duration:         {_fmt_duration(min_ms)}")
+        lines.append(f"  Max Duration:         {_fmt_duration(max_ms)}")
+        return lines
+
+    def _section_top_kernels(self) -> list[str]:
+        lines = ["", _SEP, f"  Top {self.top_n} Kernels by Total GPU Time", _SEP]
+        k = self.session.kernels
+        if k.empty or "name" not in k.columns or "duration_ms" not in k.columns:
+            lines.append("  (No kernel data)")
+            return lines
+
+        grouped = (
+            k.groupby("name")["duration_ms"]
+            .agg(["count", "sum", "mean", "max"])
+            .sort_values("sum", ascending=False)
+            .head(self.top_n)
+        )
+
+        hdr = f"  {'#':<4}{'Kernel':<40}{'Calls':>6}{'Total':>12}{'Avg':>12}{'Max':>12}"
+        lines.append(hdr)
+        lines.append("  " + "-" * 86)
+
+        for i, (name, row) in enumerate(grouped.iterrows(), 1):
+            short, _ = _shorten_kernel_name(str(name))
+            if len(short) > 38:
+                short = short[:35] + "..."
+            lines.append(
+                f"  {i:<4}{short:<40}{int(row['count']):>6}"
+                f"{_fmt_duration(row['sum']):>12}"
+                f"{_fmt_duration(row['mean']):>12}"
+                f"{_fmt_duration(row['max']):>12}"
+            )
+
+        return lines
+
+    def _section_kernel_details(self) -> list[str]:
+        lines = ["", _SEP, f"  Kernel Details (Top {self.top_n})", _SEP]
+        k = self.session.kernels
+        if k.empty or "occupancy" not in k.columns:
+            lines.append("  (No kernel detail data)")
+            return lines
+
+        # Show details for top kernels by total GPU time
+        grouped = (
+            k.groupby("name")["duration_ms"]
+            .sum()
+            .sort_values(ascending=False)
+            .head(self.top_n)
+        )
+
+        for name in grouped.index:
+            subset = k[k["name"] == name]
+            short, _ = _shorten_kernel_name(str(name))
+            lines.append(f"\n  {short}")
+            lines.append(f"  {'=' * len(short)}")
+
+            # Use the first row with detail data as representative
+            row = subset.iloc[0]
+
+            grid = row.get("grid", "?")
+            block = row.get("block", "?")
+            lines.append(f"    Grid:               {grid}")
+            lines.append(f"    Block:              {block}")
+
+            occ = row.get("occupancy")
+            if pd.notna(occ):
+                lines.append(f"    Occupancy:          {float(occ) * 100:.1f}%")
+            for key, label in [
+                ("reg_occupancy", "Reg Occupancy"),
+                ("smem_occupancy", "SMem Occupancy"),
+                ("warp_occupancy", "Warp Occupancy"),
+                ("block_occupancy", "Block Occupancy"),
+            ]:
+                val = row.get(key)
+                if pd.notna(val):
+                    lines.append(f"    {label + ':':<20}{float(val) * 100:.1f}%")
+
+            lim = row.get("limiting_resource")
+            if pd.notna(lim):
+                lines.append(f"    Limiting Resource:  {lim}")
+
+            regs = row.get("num_regs")
+            if pd.notna(regs):
+                lines.append(f"    Registers/Thread:   {int(regs)}")
+
+            dyn_shared = row.get("dyn_shared_bytes", row.get("dyn_shared"))
+            static_shared = row.get("static_shared_bytes", row.get("static_shared"))
+            if pd.notna(dyn_shared) or pd.notna(static_shared):
+                d = int(dyn_shared) if pd.notna(dyn_shared) else 0
+                s = int(static_shared) if pd.notna(static_shared) else 0
+                lines.append(f"    Shared Memory:      {_fmt_bytes(d)} dyn + {_fmt_bytes(s)} static")
+
+        return lines
+
+    def _section_memcpy_summary(self) -> list[str]:
+        lines = ["", _SEP, "  Memory Transfer Summary", _SEP]
+        m = self.session.memcpy
+        if m.empty:
+            lines.append("  (No memory transfer data)")
+            return lines
+
+        total_xfers = len(m)
+        total_bytes = m["bytes"].sum() if "bytes" in m.columns else 0
+        lines.append(f"  Total Transfers:      {total_xfers}")
+        lines.append(f"  Total Bytes:          {_fmt_bytes(total_bytes)}")
+        lines.append("")
+
+        if "copy_kind" in m.columns:
+            hdr = f"  {'Direction':<12}{'Count':>8}{'Total Bytes':>16}{'Avg Throughput':>18}"
+            lines.append(hdr)
+            lines.append("  " + "-" * 54)
+
+            for kind, group in m.groupby("copy_kind"):
+                kind_name = _resolve_copy_kind(kind)
+                count = len(group)
+                total_b = group["bytes"].sum() if "bytes" in group.columns else 0
+                avg_tp = ""
+                if "throughput_gbps" in group.columns:
+                    tp = group["throughput_gbps"].mean()
+                    if pd.notna(tp):
+                        avg_tp = f"{tp:.2f} GB/s"
+                lines.append(
+                    f"  {kind_name:<12}{count:>8}{_fmt_bytes(total_b):>16}{avg_tp:>18}"
+                )
+
+        return lines
+
+    def _section_system_metrics(self) -> list[str]:
+        lines = ["", _SEP, "  System Metrics", _SEP]
+        dm = self.session.device_metrics
+        hm = self.session.host_metrics
+
+        has_gpu = not dm.empty and "gpu_util" in dm.columns
+        has_host = not hm.empty and "cpu_pct" in hm.columns
+
+        if not has_gpu and not has_host:
+            lines.append("  (No system metric data)")
+            return lines
+
+        if has_gpu:
+            lines.append("  GPU Metrics:")
+            lines.append(f"    Utilization:        avg {dm['gpu_util'].mean():.1f}%  "
+                         f"peak {dm['gpu_util'].max():.0f}%  "
+                         f"min {dm['gpu_util'].min():.0f}%")
+
+            if "temp_c" in dm.columns:
+                lines.append(f"    Temperature:        avg {dm['temp_c'].mean():.1f} C  "
+                             f"peak {dm['temp_c'].max():.0f} C")
+
+            if "power_mw" in dm.columns:
+                lines.append(f"    Power:              avg {_fmt_power(dm['power_mw'].mean())}  "
+                             f"peak {_fmt_power(dm['power_mw'].max())}")
+
+            if "used_mib" in dm.columns:
+                lines.append(f"    VRAM Usage:         peak {int(dm['used_mib'].max())} MiB")
+
+            if "clock_sm" in dm.columns:
+                sm = pd.to_numeric(dm["clock_sm"], errors="coerce").dropna()
+                if not sm.empty:
+                    lines.append(f"    SM Clock:           avg {sm.mean():.0f} MHz  "
+                                 f"peak {sm.max():.0f} MHz")
+
+        if has_host:
+            lines.append("")
+            lines.append("  Host Metrics:")
+            lines.append(f"    CPU Utilization:    avg {hm['cpu_pct'].mean():.1f}%  "
+                         f"peak {hm['cpu_pct'].max():.1f}%")
+            if "ram_used_mib" in hm.columns and "ram_total_mib" in hm.columns:
+                peak_ram = int(hm["ram_used_mib"].max())
+                total_ram = int(hm["ram_total_mib"].iloc[0])
+                lines.append(f"    RAM Usage:          peak {peak_ram} / {total_ram} MiB "
+                             f"({peak_ram / total_ram * 100:.1f}%)")
+
+        return lines
+
+    def _section_scope_summary(self) -> list[str]:
+        lines = ["", _SEP, "  Scope Summary", _SEP]
+        se = self.session.scope_events
+        k = self.session.kernels
+
+        has_scope_events = not se.empty and "event_type" in se.columns
+        has_kernel_scopes = (
+            not k.empty
+            and "user_scope" in k.columns
+            and k["user_scope"].notna().any()
+        )
+
+        if not has_scope_events and not has_kernel_scopes:
+            lines.append("  (No scope data)")
+            return lines
+
+        # Scope events (begin/end pairs)
+        if has_scope_events:
+            begins = se[se["event_type"] == 0].copy()
+            ends = se[se["event_type"] == 1].copy()
+
+            if not begins.empty and not ends.empty:
+                pairs = begins.merge(
+                    ends[["scope_instance_id", "ts_ns"]],
+                    on="scope_instance_id",
+                    suffixes=("_begin", "_end"),
+                )
+                if not pairs.empty:
+                    pairs["duration_ms"] = (pairs["ts_ns_end"] - pairs["ts_ns_begin"]) / 1e6
+                    scope_stats = (
+                        pairs.groupby("name")["duration_ms"]
+                        .agg(["count", "sum", "mean", "max"])
+                        .sort_values("sum", ascending=False)
+                    )
+
+                    lines.append("  Scope Timing:")
+                    hdr = f"  {'Scope':<30}{'Calls':>6}{'Total':>12}{'Avg':>12}{'Max':>12}"
+                    lines.append(hdr)
+                    lines.append("  " + "-" * 72)
+                    for name, row in scope_stats.iterrows():
+                        sname = str(name)
+                        if len(sname) > 28:
+                            sname = sname[:25] + "..."
+                        lines.append(
+                            f"  {sname:<30}{int(row['count']):>6}"
+                            f"{_fmt_duration(row['sum']):>12}"
+                            f"{_fmt_duration(row['mean']):>12}"
+                            f"{_fmt_duration(row['max']):>12}"
+                        )
+
+        # GPU time per scope (from kernel user_scope)
+        if has_kernel_scopes:
+            lines.append("")
+            lines.append("  GPU Time by Scope:")
+            scope_col = k["user_scope"].apply(
+                lambda x: str(x).split("|")[0] if pd.notna(x) else None
+            )
+            k_with_scope = k.copy()
+            k_with_scope["_scope"] = scope_col
+            k_with_scope = k_with_scope[k_with_scope["_scope"].notna()]
+
+            scope_gpu = (
+                k_with_scope.groupby("_scope")["duration_ms"]
+                .agg(["count", "sum", "mean"])
+                .sort_values("sum", ascending=False)
+            )
+
+            hdr = f"  {'Scope':<30}{'Kernels':>8}{'GPU Time':>14}{'Avg':>12}"
+            lines.append(hdr)
+            lines.append("  " + "-" * 64)
+            for name, row in scope_gpu.iterrows():
+                sname = str(name)
+                if len(sname) > 28:
+                    sname = sname[:25] + "..."
+                lines.append(
+                    f"  {sname:<30}{int(row['count']):>8}"
+                    f"{_fmt_duration(row['sum']):>14}"
+                    f"{_fmt_duration(row['mean']):>12}"
+                )
+
+        return lines
+
+    def _section_profile_analysis(self) -> list[str]:
+        lines = ["", _SEP, "  Profile / SASS Analysis", _SEP]
+        samples = self.session.scopes
+
+        if samples.empty:
+            lines.append("  (No profile sample data)")
+            return lines
+
+        # Check for stall reason data
+        has_stalls = "reason_name" in samples.columns and samples["reason_name"].notna().any()
+        has_sass = "metric_name" in samples.columns and samples["metric_name"].notna().any()
+
+        if not has_stalls and not has_sass:
+            lines.append("  (No stall or SASS metric data)")
+            return lines
+
+        # Stall reason distribution
+        if has_stalls:
+            stall_data = samples[samples["reason_name"].notna()]
+            stall_counts = stall_data.groupby("reason_name")["sample_count"].sum()
+            total_stalls = stall_counts.sum()
+
+            if total_stalls > 0:
+                lines.append("  Stall Reason Distribution:")
+                hdr = f"  {'Reason':<30}{'Samples':>10}{'Pct':>8}"
+                lines.append(hdr)
+                lines.append("  " + "-" * 48)
+                for reason, count in stall_counts.sort_values(ascending=False).items():
+                    pct = count / total_stalls * 100
+                    lines.append(f"  {str(reason):<30}{int(count):>10}{pct:>7.1f}%")
+
+                # Per-kernel stall breakdown
+                if "function_name" in stall_data.columns:
+                    lines.append("")
+                    lines.append(f"  Top {self.top_n} Kernels by Stall Samples:")
+                    kern_stalls = (
+                        stall_data.groupby("function_name")["sample_count"]
+                        .sum()
+                        .sort_values(ascending=False)
+                        .head(self.top_n)
+                    )
+                    for fn, count in kern_stalls.items():
+                        short, _ = _shorten_kernel_name(str(fn))
+                        if len(short) > 50:
+                            short = short[:47] + "..."
+                        lines.append(f"    {short:<52}{int(count):>8} samples")
+
+        # SASS metrics summary
+        if has_sass:
+            lines.append("")
+            lines.append("  SASS Metrics Summary:")
+
+            sass = samples[samples["metric_name"].notna()]
+            metric_sums = (
+                sass.groupby("metric_name")["metric_value"]
+                .sum()
+                .sort_values(ascending=False)
+            )
+
+            hdr = f"  {'Metric':<50}{'Total':>12}"
+            lines.append(hdr)
+            lines.append("  " + "-" * 62)
+            for metric, total in metric_sums.items():
+                mname = str(metric)
+                if len(mname) > 48:
+                    mname = mname[:45] + "..."
+                lines.append(f"  {mname:<50}{int(total):>12}")
+
+            # Divergence analysis: thread_inst / warp_inst ratio
+            warp_metric = "smsp__sass_inst_executed"
+            thread_metric = "smsp__sass_thread_inst_executed"
+            if warp_metric in metric_sums.index and thread_metric in metric_sums.index:
+                warp_total = metric_sums[warp_metric]
+                thread_total = metric_sums[thread_metric]
+                if warp_total > 0:
+                    # For a warp of 32 threads, thread/warp ratio should be 32 if no divergence
+                    ratio = thread_total / warp_total
+                    efficiency = ratio / 32.0 * 100
+                    lines.append("")
+                    lines.append(f"  Thread Divergence Analysis:")
+                    lines.append(f"    Warp Instructions:    {int(warp_total)}")
+                    lines.append(f"    Thread Instructions:  {int(thread_total)}")
+                    lines.append(f"    Avg Threads/Warp:     {ratio:.1f} / 32")
+                    lines.append(f"    Warp Efficiency:      {efficiency:.1f}%")
+
+        return lines
+
+
+def generate_report(
+    log_dir: str,
+    log_prefix: str = "gfl_block",
+    session_id: str = None,
+    top_n: int = 10,
+    output_path: str = None,
+) -> str:
+    session = GpuFlightSession(log_dir, session_id=session_id, log_prefix=log_prefix)
+    report = TextReport(session, top_n=top_n)
+    text = report.generate()
+    if output_path:
+        report.save(output_path)
+    return text


### PR DESCRIPTION
## Description
Add GPU profiling report generation

  Implement a text-based report module that summarizes GPU profiling
  session data after shutdown. The report parses NDJSON log files
  (device, scope, system) and outputs kernel execution stats, memory
  transfer throughput, system metrics, scope timing, and SASS/divergence
  analysis.

  Key changes:
  - Add report::TextReport class with built-in JSON parser (no external deps)
  - Add gpufl::generateReport() public API, callable after gpufl::shutdown()
  - Filter CPU iGPU devices (Raphael/Ryzen) from AMD ROCm telemetry
  - Report only the latest session when log files contain multiple runs
  - Support both console output and file export

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update

## Testing
## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas