### PR TITLE
adds comprehensive AMD GPU support to the profiling and reporting pip…

### DIFF
--- a/include/gpufl/backends/amd/rocm_collector.cpp
+++ b/include/gpufl/backends/amd/rocm_collector.cpp
@@ -245,6 +245,67 @@ DeviceSample BuildTelemetrySample(const uint32_t deviceIndex) {
 
     sample.temp_c = ReadTemperatureC(deviceIndex);
 
+    // Junction temperature
+    {
+        int64_t milliC = 0;
+        if (IsSuccess(rsmi_dev_temp_metric_get(
+                deviceIndex, RSMI_TEMP_TYPE_JUNCTION, RSMI_TEMP_CURRENT, &milliC)) &&
+            milliC > 0) {
+            sample.temp_junction_c = static_cast<unsigned int>(milliC / kMillidegreesPerDegree);
+        }
+    }
+
+    // Memory temperature
+    {
+        int64_t milliC = 0;
+        if (IsSuccess(rsmi_dev_temp_metric_get(
+                deviceIndex, RSMI_TEMP_TYPE_MEMORY, RSMI_TEMP_CURRENT, &milliC)) &&
+            milliC > 0) {
+            sample.temp_mem_c = static_cast<unsigned int>(milliC / kMillidegreesPerDegree);
+        }
+    }
+
+    // Fan speed percentage
+    {
+        int64_t speed = 0;
+        uint64_t maxSpeed = 0;
+        if (IsSuccess(rsmi_dev_fan_speed_get(deviceIndex, 0, &speed)) &&
+            IsSuccess(rsmi_dev_fan_speed_max_get(deviceIndex, 0, &maxSpeed)) &&
+            maxSpeed > 0 && speed >= 0) {
+            sample.fan_speed_pct = static_cast<unsigned int>(
+                static_cast<uint64_t>(speed) * 100 / maxSpeed);
+        }
+    }
+
+    // GFX voltage
+    {
+        int64_t milliV = 0;
+        if (IsSuccess(rsmi_dev_volt_metric_get(
+                deviceIndex, RSMI_VOLT_TYPE_VDDGFX, RSMI_VOLT_CURRENT, &milliV)) &&
+            milliV > 0) {
+            sample.voltage_mv = static_cast<unsigned int>(milliV);
+        }
+    }
+
+    // Cumulative energy
+    {
+        uint64_t energy = 0;
+        float resolution = 0;
+        uint64_t timestamp = 0;
+        if (IsSuccess(rsmi_dev_energy_count_get(deviceIndex, &energy, &resolution, &timestamp))) {
+            sample.energy_uj = energy;
+        }
+    }
+
+    // ECC error counts
+    {
+        rsmi_error_count_t ec{};
+        if (IsSuccess(rsmi_dev_ecc_count_get(deviceIndex, RSMI_GPU_BLOCK_UMC, &ec))) {
+            sample.ecc_corrected = ec.correctable_err;
+            sample.ecc_uncorrected = ec.uncorrectable_err;
+        }
+    }
+
     uint64_t powerUw = 0;
     RSMI_POWER_TYPE powerType = RSMI_INVALID_POWER;
     if (IsSuccess(rsmi_dev_power_get(deviceIndex, &powerUw, &powerType)) &&
@@ -380,6 +441,20 @@ RocmCollector::RocmCollector() {
     if (static_info_available_) {
         static_device_count_ = ProbeHipDeviceCount(nullptr).second;
     }
+    resolveDeviceNames();
+#endif
+}
+
+void RocmCollector::resolveDeviceNames() {
+#if GPUFL_HAS_HIP
+    int count = 0;
+    if (hipGetDeviceCount(&count) != hipSuccess) return;
+    for (int i = 0; i < count; ++i) {
+        hipDeviceProp_t prop{};
+        if (hipGetDeviceProperties(&prop, i) == hipSuccess && IsGpuHipDevice(prop)) {
+            hip_device_names_[i] = prop.name;
+        }
+    }
 #endif
 }
 
@@ -406,7 +481,16 @@ std::vector<DeviceSample> RocmCollector::sampleAll() {
             GFL_LOG_DEBUG("[RocmCollector] skipping CPU iGPU SMI device index=", i);
             continue;
         }
-        out.push_back(BuildTelemetrySample(i));
+        auto sample = BuildTelemetrySample(i);
+        // SMI may return hex product ID (e.g. "0x7550") instead of full name.
+        // Use the HIP device name if available and SMI name looks like a hex ID.
+        if (!sample.name.empty() && sample.name[0] == '0' && sample.name.size() > 1 &&
+            sample.name[1] == 'x') {
+            auto nit = hip_device_names_.find(sample.device_id);
+            if (nit != hip_device_names_.end())
+                sample.name = nit->second;
+        }
+        out.push_back(std::move(sample));
     }
 #endif
     return out;

--- a/include/gpufl/backends/amd/rocm_collector.hpp
+++ b/include/gpufl/backends/amd/rocm_collector.hpp
@@ -1,5 +1,6 @@
 #pragma once
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #include "gpufl/core/backend_interfaces.hpp"
@@ -24,10 +25,13 @@ class RocmCollector : public IUnifiedGpuCollector {
     static bool IsStaticInfoAvailable(std::string* reason = nullptr);
 
    private:
+    void resolveDeviceNames();
+
     bool telemetry_initialized_ = false;
     bool static_info_available_ = false;
     uint32_t telemetry_device_count_ = 0;
     int static_device_count_ = 0;
+    std::unordered_map<int, std::string> hip_device_names_;  // device_id -> full name from HIP
 };
 
 }  // namespace gpufl::amd

--- a/include/gpufl/backends/amd/rocprofiler_backend.cpp
+++ b/include/gpufl/backends/amd/rocprofiler_backend.cpp
@@ -21,6 +21,9 @@
 #include <rocprofiler-sdk/external_correlation.h>
 #include <rocprofiler-sdk/rocprofiler.h>
 
+#include <unistd.h>
+#include <zlib.h>
+
 #include "gpufl/core/common.hpp"
 #include "gpufl/core/debug_logger.hpp"
 #include "gpufl/core/monitor.hpp"
@@ -227,7 +230,9 @@ int RocprofilerBackend::toolInitialize() {
         return -1;
     }
 
-    const std::array<rocprofiler_tracing_operation_t, 1> code_object_ops = {
+    const std::array<rocprofiler_tracing_operation_t, 2> code_object_ops = {
+        static_cast<rocprofiler_tracing_operation_t>(
+            ROCPROFILER_CODE_OBJECT_LOAD),
         static_cast<rocprofiler_tracing_operation_t>(
             ROCPROFILER_CODE_OBJECT_DEVICE_KERNEL_SYMBOL_REGISTER),
     };
@@ -349,8 +354,22 @@ void RocprofilerBackend::callbackTracingShim(rocprofiler_callback_tracing_record
     auto* backend = static_cast<RocprofilerBackend*>(callback_data);
     if (!backend || record.kind != ROCPROFILER_CALLBACK_TRACING_CODE_OBJECT ||
         record.phase != ROCPROFILER_CALLBACK_PHASE_LOAD ||
-        record.operation != ROCPROFILER_CODE_OBJECT_DEVICE_KERNEL_SYMBOL_REGISTER ||
         record.payload == nullptr) {
+        return;
+    }
+
+    if (record.operation ==
+        static_cast<rocprofiler_tracing_operation_t>(ROCPROFILER_CODE_OBJECT_LOAD)) {
+        const auto* loadData =
+            static_cast<const rocprofiler_callback_tracing_code_object_load_data_t*>(
+                record.payload);
+        backend->handleCodeObjectLoad(*loadData);
+        return;
+    }
+
+    if (record.operation !=
+        static_cast<rocprofiler_tracing_operation_t>(
+            ROCPROFILER_CODE_OBJECT_DEVICE_KERNEL_SYMBOL_REGISTER)) {
         return;
     }
 
@@ -443,8 +462,17 @@ rocprofiler_status_t RocprofilerBackend::queryAgentsShim(
 
         backend->agent_types_[agent->id.handle] = agent->type;
         if (agent->type == ROCPROFILER_AGENT_TYPE_GPU) {
-            backend->gpu_device_ids_[agent->id.handle] =
-                std::max(agent->logical_node_type_id, 0);
+            int dev_id = std::max(agent->logical_node_type_id, 0);
+            backend->gpu_device_ids_[agent->id.handle] = dev_id;
+
+            GpuArchProps props{};
+            props.wave_front_size = agent->wave_front_size > 0 ? agent->wave_front_size : 64;
+            props.max_waves_per_cu = agent->max_waves_per_cu;
+            props.simd_per_cu = agent->simd_per_cu;
+            props.lds_size_bytes = agent->lds_size_in_kb * 1024;
+            props.cu_count = agent->cu_count;
+            props.workgroup_max_size = agent->workgroup_max_size;
+            backend->gpu_arch_props_[dev_id] = props;
         }
     }
 
@@ -486,6 +514,54 @@ uint32_t RocprofilerBackend::classifyMemcpyKind(const rocprofiler_agent_id_t src
         return 4;
     }
     return 0;
+}
+
+void RocprofilerBackend::handleCodeObjectLoad(
+    const rocprofiler_callback_tracing_code_object_load_data_t& data) {
+
+    std::vector<uint8_t> elf_bytes;
+
+    if (data.storage_type == ROCPROFILER_CODE_OBJECT_STORAGE_TYPE_MEMORY) {
+        const auto* ptr = reinterpret_cast<const uint8_t*>(data.memory_base);
+        if (ptr && data.memory_size > 0)
+            elf_bytes.assign(ptr, ptr + data.memory_size);
+    } else if (data.storage_type == ROCPROFILER_CODE_OBJECT_STORAGE_TYPE_FILE) {
+        // Read code object from file descriptor at load_base offset with load_size
+        if (data.storage_file >= 0 && data.load_size > 0) {
+            elf_bytes.resize(data.load_size);
+            auto saved = ::lseek(data.storage_file, 0, SEEK_CUR);
+            if (::lseek(data.storage_file, static_cast<off_t>(data.load_base), SEEK_SET) >= 0) {
+                auto rd = ::read(data.storage_file, elf_bytes.data(), data.load_size);
+                if (rd < 0 || static_cast<uint64_t>(rd) != data.load_size)
+                    elf_bytes.clear();
+            } else {
+                elf_bytes.clear();
+            }
+            if (saved >= 0) ::lseek(data.storage_file, saved, SEEK_SET);
+        }
+    }
+
+    if (elf_bytes.size() < 4) return;
+
+    // Verify ELF magic
+    if (elf_bytes[0] != 0x7f || elf_bytes[1] != 'E' ||
+        elf_bytes[2] != 'L' || elf_bytes[3] != 'F') {
+        return;
+    }
+
+    uint64_t crc = ::crc32(0L, elf_bytes.data(),
+                           static_cast<uInt>(elf_bytes.size()));
+
+    {
+        std::lock_guard<std::mutex> lock(code_object_mutex_);
+        if (enqueued_disasm_crcs_.count(crc)) return;
+        enqueued_disasm_crcs_.insert(crc);
+    }
+
+    GFL_LOG_DEBUG("[ROCProfilerBackend] code object loaded: id=", data.code_object_id,
+                  " size=", elf_bytes.size(), " crc=", crc);
+
+    Monitor::EnqueueCubinForDisassembly(crc, elf_bytes.data(), elf_bytes.size());
 }
 
 void RocprofilerBackend::handleKernelDispatch(
@@ -530,8 +606,82 @@ void RocprofilerBackend::handleKernelDispatch(
             const auto& meta = itr->second;
             out.num_regs = static_cast<int>(
                 meta.sgpr_count + meta.arch_vgpr_count + meta.accum_vgpr_count);
+            out.arch_vgpr_count = static_cast<int>(meta.arch_vgpr_count);
             if (out.static_shared == 0) out.static_shared = static_cast<int>(meta.group_segment_size);
             if (out.local_bytes == 0) out.local_bytes = static_cast<int>(meta.private_segment_size);
+        }
+    }
+
+    // Compute occupancy from architecture properties
+    {
+        int dev_id = static_cast<int>(out.device_id);
+        auto pit = gpu_arch_props_.find(dev_id);
+        if (pit != gpu_arch_props_.end()) {
+            const auto& props = pit->second;
+            int threadsPerBlock = out.block_x * out.block_y * out.block_z;
+            if (threadsPerBlock > 0 && props.max_waves_per_cu > 0 && props.wave_front_size > 0) {
+                int wavesPerBlock = (threadsPerBlock + static_cast<int>(props.wave_front_size) - 1)
+                                    / static_cast<int>(props.wave_front_size);
+                int maxWavesPerCU = static_cast<int>(props.max_waves_per_cu);
+
+                // Wave/workgroup limit
+                int waveBlocks = (wavesPerBlock > 0) ? (maxWavesPerCU / wavesPerBlock) : 0;
+
+                // LDS (shared memory) limit
+                int smemPerBlock = out.static_shared + out.dyn_shared;
+                int ldsBytes = static_cast<int>(props.lds_size_bytes);
+                int smemBlocks = (smemPerBlock > 0 && ldsBytes > 0) ? (ldsBytes / smemPerBlock) : waveBlocks;
+
+                // VGPR register limit
+                // Use arch_vgpr_count (not combined num_regs which includes SGPRs).
+                // RDNA architectures have 1536 VGPRs per SIMD unit, allocated per-wave
+                // in granularity of 16 VGPRs (RDNA 1/2) or 24 VGPRs (RDNA 3/4).
+                // We use the max_waves_per_cu / simd_per_cu to derive VGPRs per SIMD:
+                //   total_vgprs_per_simd = max_waves_per_simd * max_vgprs_per_wave
+                // For RDNA 3/4: 1536 VGPRs per SIMD, 2 SIMDs per CU = 3072 VGPRs/CU.
+                constexpr int kVgprAllocGranularity = 8;
+                constexpr int kVgprsPerSimd = 1536;  // RDNA standard
+                int vgprsPerThread = out.arch_vgpr_count;
+                int vgprsAligned = (vgprsPerThread > 0)
+                    ? (((vgprsPerThread + kVgprAllocGranularity - 1) / kVgprAllocGranularity)
+                       * kVgprAllocGranularity)
+                    : 0;
+                int regBlocks = waveBlocks;  // default: not limited by registers
+                if (vgprsAligned > 0 && props.simd_per_cu > 0) {
+                    int totalVgprsPerCU = kVgprsPerSimd * static_cast<int>(props.simd_per_cu);
+                    int regWavesPerCU = totalVgprsPerCU / vgprsAligned;
+                    regBlocks = (wavesPerBlock > 0) ? (regWavesPerCU / wavesPerBlock) : waveBlocks;
+                }
+
+                // Overall occupancy = minimum of all limits
+                int activeBlocks = (std::min)({waveBlocks, smemBlocks, regBlocks});
+                activeBlocks = (std::max)(activeBlocks, 0);
+
+                auto toOcc = [&](int blocks) -> float {
+                    return (maxWavesPerCU > 0 && wavesPerBlock > 0)
+                        ? (std::min)(1.0f, static_cast<float>(blocks * wavesPerBlock) / maxWavesPerCU)
+                        : 0.0f;
+                };
+
+                out.occupancy = toOcc(activeBlocks);
+                out.warp_occupancy = toOcc(waveBlocks);
+                out.smem_occupancy = toOcc(smemBlocks);
+                out.reg_occupancy = toOcc(regBlocks);
+                out.block_occupancy = 1.0f;  // AMD doesn't have a hard block-per-CU limit like NVIDIA
+                out.max_active_blocks = activeBlocks;
+
+                struct { float occ; const char* name; } limiters[] = {
+                    {out.warp_occupancy, "waves"},
+                    {out.reg_occupancy, "registers"},
+                    {out.smem_occupancy, "shared_mem"},
+                };
+                const char* limiting = "waves";
+                float minOcc = out.warp_occupancy;
+                for (auto& l : limiters) {
+                    if (l.occ < minOcc) { minOcc = l.occ; limiting = l.name; }
+                }
+                std::snprintf(out.limiting_resource, sizeof(out.limiting_resource), "%s", limiting);
+            }
         }
     }
 

--- a/include/gpufl/backends/amd/rocprofiler_backend.hpp
+++ b/include/gpufl/backends/amd/rocprofiler_backend.hpp
@@ -1,13 +1,17 @@
 #pragma once
 
 #include <atomic>
+#include <cstdint>
 #include <memory>
 #include <mutex>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
+#include <vector>
 
 #include <rocprofiler-sdk/agent.h>
 #include <rocprofiler-sdk/buffer_tracing.h>
+#include <rocprofiler-sdk/callback_tracing.h>
 #include <rocprofiler-sdk/fwd.h>
 #include <rocprofiler-sdk/registration.h>
 
@@ -62,6 +66,7 @@ class RocprofilerBackend final : public IMonitorBackend {
                               uint64_t end_timestamp,
                               const rocprofiler_async_correlation_id_t& correlation_id);
     void handleMemoryCopy(const rocprofiler_buffer_tracing_memory_copy_record_t& data);
+    void handleCodeObjectLoad(const rocprofiler_callback_tracing_code_object_load_data_t& data);
 
     std::string resolveKernelName(uint64_t kernel_id) const;
     int resolveDeviceId(rocprofiler_agent_id_t agent_id) const;
@@ -97,6 +102,21 @@ class RocprofilerBackend final : public IMonitorBackend {
     mutable std::mutex agent_mutex_;
     std::unordered_map<uint64_t, int> gpu_device_ids_;
     std::unordered_map<uint64_t, rocprofiler_agent_type_t> agent_types_;
+
+    // GPU architecture properties for occupancy calculation
+    struct GpuArchProps {
+        uint32_t wave_front_size = 64;
+        uint32_t max_waves_per_cu = 0;
+        uint32_t simd_per_cu = 0;
+        uint32_t lds_size_bytes = 0;  // per CU
+        uint32_t cu_count = 0;
+        uint32_t workgroup_max_size = 0;
+    };
+    std::unordered_map<int, GpuArchProps> gpu_arch_props_;  // device_id -> props
+
+    // Code object storage for ISA disassembly
+    mutable std::mutex code_object_mutex_;
+    std::unordered_set<uint64_t> enqueued_disasm_crcs_;
 
     MonitorOptions opts_{};
     rocprofiler_context_id_t context_{};

--- a/include/gpufl/core/activity_record.hpp
+++ b/include/gpufl/core/activity_record.hpp
@@ -28,6 +28,7 @@ struct ActivityRecord {
     int local_bytes = 0;
     int const_bytes = 0;
     int num_regs = 0;
+    int arch_vgpr_count = 0;  // AMD: architecture VGPRs only (for occupancy calc)
     float occupancy = 0.0f;
 
     // Per-resource occupancy breakdown

--- a/include/gpufl/core/dictionary_manager.cpp
+++ b/include/gpufl/core/dictionary_manager.cpp
@@ -126,71 +126,136 @@ void DictionaryManager::flushDisassembly(Logger& logger,
             }
         }
 
-        // Run nvdisasm --print-code
+        // Detect platform and select disassembler
+        // AMD code objects are ELF with e_machine == EM_AMDGPU (0xE0)
+        bool isAmd = (bytes.size() >= 18 &&
+                      bytes[0] == 0x7f && bytes[1] == 'E' &&
+                      bytes[2] == 'L' && bytes[3] == 'F' &&
+                      (bytes[18] == 0xE0 && bytes[19] == 0x00));
+
         char cmd[640];
-        std::snprintf(cmd, sizeof(cmd),
-                      "/usr/local/cuda/bin/nvdisasm --print-code %s 2>/dev/null",
-                      tmpPath);
+        if (isAmd) {
+            // Discover llvm-objdump path
+            const char* rocmPath = std::getenv("ROCM_PATH");
+            if (rocmPath && rocmPath[0]) {
+                std::snprintf(cmd, sizeof(cmd),
+                              "%s/llvm/bin/llvm-objdump -d %s 2>/dev/null",
+                              rocmPath, tmpPath);
+            } else {
+                std::snprintf(cmd, sizeof(cmd),
+                              "/opt/rocm/llvm/bin/llvm-objdump -d %s 2>/dev/null",
+                              tmpPath);
+            }
+        } else {
+            std::snprintf(cmd, sizeof(cmd),
+                          "/usr/local/cuda/bin/nvdisasm --print-code %s 2>/dev/null",
+                          tmpPath);
+        }
+
         FILE* pipe = ::popen(cmd, "r");
         if (!pipe) {
             ::unlink(tmpPath);
-            GFL_LOG_ERROR("[flushDisassembly] popen failed — nvdisasm unavailable?");
+            GFL_LOG_ERROR("[flushDisassembly] popen failed — disassembler unavailable?");
             continue;
         }
 
-        // Parse nvdisasm output.
-        // Function labels appear as bare labels at column 0: "funcName:"
-        // (not starting with '.' or whitespace).
-        // Instructions appear with leading whitespace: "/*XXXX*/   INSTR ;"
         std::unordered_map<std::string,
                            std::vector<std::pair<uint32_t, std::string>>>
             funcEntries;
         std::string currentFunc;
+        uint64_t currentFuncBase = 0;
         char lineBuf[2048];
+
         while (std::fgets(lineBuf, sizeof(lineBuf), pipe)) {
             std::string raw = lineBuf;
-            // Strip trailing newline/CR
             while (!raw.empty() &&
                    (raw.back() == '\n' || raw.back() == '\r'))
                 raw.pop_back();
             if (raw.empty()) continue;
 
-            // Function label: starts at column 0, doesn't start with '.' or
-            // whitespace, ends with ':'. e.g. "_Z11vectorScalePiii:"
-            if (!std::isspace((unsigned char)raw[0]) && raw[0] != '.' &&
-                raw.back() == ':') {
-                currentFunc = raw.substr(0, raw.size() - 1);
-                if (!funcEntries.count(currentFunc))
-                    funcEntries[currentFunc] = {};
-                continue;
-            }
+            if (isAmd) {
+                // AMD llvm-objdump format:
+                // Function: "0000000000001F00 <_Z15vectorAddKernelPKiS0_Pii>:"
+                // Instruction: "\ts_clause 0x1  // 000000001F00: BF850001"
+                if (raw.rfind("Disassembly of", 0) == 0) continue;
 
-            // Instruction line: leading whitespace then "/*XXXX*/   INSTR ;"
-            if (currentFunc.empty()) continue;
-            const size_t start = raw.find_first_not_of(" \t");
-            if (start == std::string::npos) continue;
-            const std::string s = raw.substr(start);
+                // Function label: contains '<' and '>' and ends with ':'
+                auto langle = raw.find('<');
+                auto rangle = raw.find('>');
+                if (langle != std::string::npos && rangle != std::string::npos &&
+                    rangle > langle && raw.back() == ':') {
+                    currentFunc = raw.substr(langle + 1, rangle - langle - 1);
+                    // Parse base address from the leading hex
+                    std::string addrStr = raw.substr(0, raw.find_first_of(" \t"));
+                    try { currentFuncBase = std::stoull(addrStr, nullptr, 16); }
+                    catch (...) { currentFuncBase = 0; }
+                    if (!funcEntries.count(currentFunc))
+                        funcEntries[currentFunc] = {};
+                    continue;
+                }
 
-            if (s.rfind("/*", 0) != 0) continue;
-            const size_t end = s.find("*/");
-            if (end == std::string::npos) continue;
-            const std::string hexStr = s.substr(2, end - 2);
-            uint32_t pc = 0;
-            try {
-                pc = static_cast<uint32_t>(std::stoul(hexStr, nullptr, 16));
-            } catch (...) {
-                continue;
+                // Comment-only lines ("; %bb.0:")
+                size_t firstNonWs = raw.find_first_not_of(" \t");
+                if (firstNonWs != std::string::npos && raw[firstNonWs] == ';')
+                    continue;
+
+                if (currentFunc.empty()) continue;
+
+                // Instruction line: has "// XXXXXXXXXXXX:" comment
+                size_t commentPos = raw.find("// ");
+                if (commentPos == std::string::npos) continue;
+                std::string afterComment = raw.substr(commentPos + 3);
+                size_t colonPos = afterComment.find(':');
+                if (colonPos == std::string::npos) continue;
+
+                uint64_t absPC = 0;
+                try { absPC = std::stoull(afterComment.substr(0, colonPos), nullptr, 16); }
+                catch (...) { continue; }
+                uint32_t pc = static_cast<uint32_t>(absPC - currentFuncBase);
+
+                // Instruction text: before the "//" comment, trimmed
+                std::string ins = raw.substr(0, commentPos);
+                size_t insStart = ins.find_first_not_of(" \t");
+                if (insStart == std::string::npos) continue;
+                ins = ins.substr(insStart);
+                while (!ins.empty() && (ins.back() == ' ' || ins.back() == '\t'))
+                    ins.pop_back();
+                funcEntries[currentFunc].emplace_back(pc, std::move(ins));
+            } else {
+                // NVIDIA nvdisasm format:
+                // Function: "_Z11vectorScalePiii:"
+                // Instruction: "/*XXXX*/   INSTR ;"
+                if (!std::isspace((unsigned char)raw[0]) && raw[0] != '.' &&
+                    raw.back() == ':') {
+                    currentFunc = raw.substr(0, raw.size() - 1);
+                    if (!funcEntries.count(currentFunc))
+                        funcEntries[currentFunc] = {};
+                    continue;
+                }
+
+                if (currentFunc.empty()) continue;
+                const size_t start = raw.find_first_not_of(" \t");
+                if (start == std::string::npos) continue;
+                const std::string s = raw.substr(start);
+
+                if (s.rfind("/*", 0) != 0) continue;
+                const size_t end = s.find("*/");
+                if (end == std::string::npos) continue;
+                const std::string hexStr = s.substr(2, end - 2);
+                uint32_t pc = 0;
+                try { pc = static_cast<uint32_t>(std::stoul(hexStr, nullptr, 16)); }
+                catch (...) { continue; }
+                size_t insStart = s.find_first_not_of(" \t", end + 2);
+                if (insStart == std::string::npos) continue;
+                std::string ins = s.substr(insStart);
+                if (!ins.empty() && ins.back() == ';') ins.pop_back();
+                while (!ins.empty() && ins.back() == ' ') ins.pop_back();
+                funcEntries[currentFunc].emplace_back(pc, std::move(ins));
             }
-            size_t insStart = s.find_first_not_of(" \t", end + 2);
-            if (insStart == std::string::npos) continue;
-            std::string ins = s.substr(insStart);
-            // Remove trailing " ;"
-            if (!ins.empty() && ins.back() == ';') ins.pop_back();
-            while (!ins.empty() && ins.back() == ' ') ins.pop_back();
-            funcEntries[currentFunc].emplace_back(pc, std::move(ins));
         }
         GFL_LOG_DEBUG("[flushDisassembly] parsed ", funcEntries.size(),
-                      " functions from cubin crc=", crc);
+                      " functions from ", isAmd ? "code object" : "cubin",
+                      " crc=", crc);
         ::pclose(pipe);
         ::unlink(tmpPath);
 

--- a/include/gpufl/core/events.hpp
+++ b/include/gpufl/core/events.hpp
@@ -44,6 +44,15 @@ struct DeviceSample {
     unsigned int clock_sm = 0;   // MHz
     unsigned int clock_mem = 0;  // MHz
 
+    // Extended metrics (AMD ROCm SMI)
+    unsigned int fan_speed_pct = 0;    // Fan speed 0-100%
+    unsigned int temp_mem_c = 0;       // Memory temperature, Celsius
+    unsigned int temp_junction_c = 0;  // Junction temperature, Celsius
+    unsigned int voltage_mv = 0;       // GFX voltage, millivolts
+    uint64_t energy_uj = 0;            // Cumulative energy, microjoules
+    uint64_t ecc_corrected = 0;        // Correctable ECC error count
+    uint64_t ecc_uncorrected = 0;      // Uncorrectable ECC error count
+
     bool throttle_power;    // True if hitting Power CAp
     bool throttle_thermal;  // True if slowing down due to Heat
 
@@ -308,6 +317,16 @@ struct DeviceMetricBatchRow {
     unsigned power_mw  = 0;
     uint64_t used_mib  = 0;
     unsigned clock_sm  = 0;  // MHz
+    // Extended metrics
+    unsigned fan_speed_pct   = 0;  // %
+    unsigned temp_mem_c      = 0;  // Celsius
+    unsigned temp_junction_c = 0;  // Celsius
+    unsigned voltage_mv      = 0;  // millivolts
+    uint64_t energy_uj       = 0;  // cumulative microjoules
+    unsigned clock_mem       = 0;  // MHz
+    uint64_t pcie_bw_bps     = 0;  // bytes/sec (rx+tx combined)
+    uint64_t ecc_corrected   = 0;
+    uint64_t ecc_uncorrected = 0;
 };
 
 struct HostMetricBatchRow {

--- a/include/gpufl/core/model/batch_models.cpp
+++ b/include/gpufl/core/model/batch_models.cpp
@@ -108,7 +108,10 @@ std::string DeviceMetricBatchModel::buildJson() const {
         << ",\"session_id\":\"" << jsonEscape(session_id_) << '"'
         << ",\"batch_id\":" << batch_id_ << ",\"base_time_ns\":" << base
         << ",\"columns\":[\"dt_ns\",\"device_id\",\"gpu_util\","
-           "\"mem_util\",\"temp_c\",\"power_mw\",\"used_mib\",\"clock_sm\"]"
+           "\"mem_util\",\"temp_c\",\"power_mw\",\"used_mib\",\"clock_sm\","
+           "\"fan_speed_pct\",\"temp_mem_c\",\"temp_junction_c\","
+           "\"voltage_mv\",\"energy_uj\",\"clock_mem\","
+           "\"pcie_bw_bps\",\"ecc_corrected\",\"ecc_uncorrected\"]"
         << ",\"rows\":[";
 
     bool first = true;
@@ -117,7 +120,12 @@ std::string DeviceMetricBatchModel::buildJson() const {
         first = false;
         oss << '[' << (r.ts_ns - base) << ',' << r.device_id << ','
             << r.gpu_util << ',' << r.mem_util << ',' << r.temp_c << ','
-            << r.power_mw << ',' << r.used_mib << ',' << r.clock_sm << ']';
+            << r.power_mw << ',' << r.used_mib << ',' << r.clock_sm << ','
+            << r.fan_speed_pct << ',' << r.temp_mem_c << ','
+            << r.temp_junction_c << ',' << r.voltage_mv << ','
+            << r.energy_uj << ',' << r.clock_mem << ','
+            << r.pcie_bw_bps << ',' << r.ecc_corrected << ','
+            << r.ecc_uncorrected << ']';
     }
     oss << "]}";
     return oss.str();

--- a/include/gpufl/core/sampler.cpp
+++ b/include/gpufl/core/sampler.cpp
@@ -67,14 +67,23 @@ void Sampler::runLoop_() {
 
         for (const DeviceSample& d : collector_->sampleAll()) {
             DeviceMetricBatchRow row;
-            row.ts_ns     = ts;
-            row.device_id = d.device_id;
-            row.gpu_util  = d.gpu_util;
-            row.mem_util  = d.mem_util;
-            row.temp_c    = d.temp_c;
-            row.power_mw  = d.power_mw;
-            row.used_mib  = d.used_mib;
-            row.clock_sm  = d.clock_sm;
+            row.ts_ns            = ts;
+            row.device_id        = d.device_id;
+            row.gpu_util         = d.gpu_util;
+            row.mem_util         = d.mem_util;
+            row.temp_c           = d.temp_c;
+            row.power_mw         = d.power_mw;
+            row.used_mib         = d.used_mib;
+            row.clock_sm         = d.clock_sm;
+            row.fan_speed_pct    = d.fan_speed_pct;
+            row.temp_mem_c       = d.temp_mem_c;
+            row.temp_junction_c  = d.temp_junction_c;
+            row.voltage_mv       = d.voltage_mv;
+            row.energy_uj        = d.energy_uj;
+            row.clock_mem        = d.clock_mem;
+            row.pcie_bw_bps      = d.pcie_rx_bps + d.pcie_tx_bps;
+            row.ecc_corrected    = d.ecc_corrected;
+            row.ecc_uncorrected  = d.ecc_uncorrected;
             batch_.push(row);
         }
 

--- a/include/gpufl/report/text_report.cpp
+++ b/include/gpufl/report/text_report.cpp
@@ -398,6 +398,15 @@ void TextReport::parseSystemLog(const std::vector<JsonValue>& records) {
                     static_cast<int>(rowInt(row, ci, "power_mw")),
                     rowU64(row, ci, "used_mib"),
                     static_cast<int>(rowInt(row, ci, "clock_sm")),
+                    static_cast<int>(rowInt(row, ci, "fan_speed_pct")),
+                    static_cast<int>(rowInt(row, ci, "temp_mem_c")),
+                    static_cast<int>(rowInt(row, ci, "temp_junction_c")),
+                    static_cast<int>(rowInt(row, ci, "voltage_mv")),
+                    rowU64(row, ci, "energy_uj"),
+                    static_cast<int>(rowInt(row, ci, "clock_mem")),
+                    rowU64(row, ci, "pcie_bw_bps"),
+                    rowU64(row, ci, "ecc_corrected"),
+                    rowU64(row, ci, "ecc_uncorrected"),
                 });
             }
         } else if (type == "host_metric_batch") {
@@ -618,16 +627,59 @@ void TextReport::writeSystemMetrics(std::ostringstream& out) const {
         out << "  GPU Metrics:\n";
 
         // Functional aggregation with accumulate
-        struct GpuAgg { double sumUtil=0, maxUtil=0, minUtil=1e9, sumTemp=0, maxTemp=0,
-                               sumPow=0, maxPow=0, sumClk=0; uint64_t maxMem=0; int clkN=0; int n=0; };
+        struct GpuAgg {
+            double sumUtil=0, maxUtil=0, minUtil=1e9;
+            double sumTemp=0, maxTemp=0;
+            double sumJTemp=0, maxJTemp=0; int jTempN=0;
+            double sumMTemp=0, maxMTemp=0; int mTempN=0;
+            double sumPow=0, maxPow=0;
+            double sumVolt=0, maxVolt=0; int voltN=0;
+            double sumFan=0, maxFan=0; int fanN=0;
+            double sumClk=0, peakClk=0; int clkN=0;
+            double sumMemClk=0, peakMemClk=0; int memClkN=0;
+            double sumPcie=0, maxPcie=0; int pcieN=0;
+            uint64_t maxMem=0;
+            uint64_t lastEnergy=0, firstEnergy=0; bool hasEnergy=false;
+            uint64_t maxEccCorr=0, maxEccUncorr=0;
+            int n=0;
+        };
         auto agg = std::accumulate(device_metrics_.begin(), device_metrics_.end(), GpuAgg{},
             [](GpuAgg a, const DeviceMetricRecord& m) {
-                a.sumUtil += m.gpu_util; a.maxUtil = (std::max)(a.maxUtil, (double)m.gpu_util);
+                a.sumUtil += m.gpu_util;
+                a.maxUtil = (std::max)(a.maxUtil, (double)m.gpu_util);
                 a.minUtil = (std::min)(a.minUtil, (double)m.gpu_util);
-                a.sumTemp += m.temp_c;   a.maxTemp = (std::max)(a.maxTemp, (double)m.temp_c);
-                a.sumPow  += m.power_mw; a.maxPow  = (std::max)(a.maxPow, (double)m.power_mw);
-                a.maxMem = (std::max)(a.maxMem, m.used_mib);
-                if (m.clock_sm > 0) { a.sumClk += m.clock_sm; a.clkN++; }
+                a.sumTemp += m.temp_c;
+                a.maxTemp = (std::max)(a.maxTemp, (double)m.temp_c);
+                a.sumPow  += m.power_mw;
+                a.maxPow  = (std::max)(a.maxPow, (double)m.power_mw);
+                a.maxMem  = (std::max)(a.maxMem, m.used_mib);
+                if (m.clock_sm > 0) {
+                    a.sumClk += m.clock_sm; a.peakClk = (std::max)(a.peakClk, (double)m.clock_sm); a.clkN++;
+                }
+                if (m.temp_junction_c > 0) {
+                    a.sumJTemp += m.temp_junction_c; a.maxJTemp = (std::max)(a.maxJTemp, (double)m.temp_junction_c); a.jTempN++;
+                }
+                if (m.temp_mem_c > 0) {
+                    a.sumMTemp += m.temp_mem_c; a.maxMTemp = (std::max)(a.maxMTemp, (double)m.temp_mem_c); a.mTempN++;
+                }
+                if (m.voltage_mv > 0) {
+                    a.sumVolt += m.voltage_mv; a.maxVolt = (std::max)(a.maxVolt, (double)m.voltage_mv); a.voltN++;
+                }
+                if (m.fan_speed_pct > 0) {
+                    a.sumFan += m.fan_speed_pct; a.maxFan = (std::max)(a.maxFan, (double)m.fan_speed_pct); a.fanN++;
+                }
+                if (m.clock_mem > 0) {
+                    a.sumMemClk += m.clock_mem; a.peakMemClk = (std::max)(a.peakMemClk, (double)m.clock_mem); a.memClkN++;
+                }
+                if (m.pcie_bw_bps > 0) {
+                    a.sumPcie += m.pcie_bw_bps; a.maxPcie = (std::max)(a.maxPcie, (double)m.pcie_bw_bps); a.pcieN++;
+                }
+                if (m.energy_uj > 0) {
+                    if (!a.hasEnergy) { a.firstEnergy = m.energy_uj; a.hasEnergy = true; }
+                    a.lastEnergy = m.energy_uj;
+                }
+                a.maxEccCorr   = (std::max)(a.maxEccCorr, m.ecc_corrected);
+                a.maxEccUncorr = (std::max)(a.maxEccUncorr, m.ecc_uncorrected);
                 a.n++; return a;
             });
 
@@ -635,10 +687,42 @@ void TextReport::writeSystemMetrics(std::ostringstream& out) const {
             << "%  peak " << std::setprecision(0) << agg.maxUtil << "%  min " << agg.minUtil << "%\n";
         out << "    Temperature:        avg " << std::setprecision(1) << (agg.sumTemp / agg.n)
             << " C  peak " << std::setprecision(0) << agg.maxTemp << " C\n";
+        if (agg.jTempN > 0)
+            out << "    Junction Temp:      avg " << std::setprecision(1) << (agg.sumJTemp / agg.jTempN)
+                << " C  peak " << std::setprecision(0) << agg.maxJTemp << " C\n";
+        if (agg.mTempN > 0)
+            out << "    Memory Temp:        avg " << std::setprecision(1) << (agg.sumMTemp / agg.mTempN)
+                << " C  peak " << std::setprecision(0) << agg.maxMTemp << " C\n";
         out << "    Power:              avg " << fmtPower(agg.sumPow / agg.n) << "  peak " << fmtPower(agg.maxPow) << "\n";
+        if (agg.voltN > 0)
+            out << "    Voltage:            avg " << std::setprecision(0) << (agg.sumVolt / agg.voltN)
+                << " mV  peak " << agg.maxVolt << " mV\n";
+        if (agg.hasEnergy && agg.lastEnergy > agg.firstEnergy) {
+            double energyJ = (agg.lastEnergy - agg.firstEnergy) / 1e6;
+            if (energyJ >= 1000.0)
+                out << "    Energy:             " << std::setprecision(2) << (energyJ / 1000.0) << " kJ\n";
+            else
+                out << "    Energy:             " << std::setprecision(2) << energyJ << " J\n";
+        }
+        if (agg.fanN > 0)
+            out << "    Fan Speed:          avg " << std::setprecision(0) << (agg.sumFan / agg.fanN)
+                << "%  peak " << agg.maxFan << "%\n";
         out << "    VRAM Usage:         peak " << agg.maxMem << " MiB\n";
         if (agg.clkN > 0)
-            out << "    SM Clock:           avg " << std::setprecision(0) << (agg.sumClk / agg.clkN) << " MHz\n";
+            out << "    SM Clock:           avg " << std::setprecision(0) << (agg.sumClk / agg.clkN)
+                << " MHz  peak " << agg.peakClk << " MHz\n";
+        if (agg.memClkN > 0)
+            out << "    Memory Clock:       avg " << std::setprecision(0) << (agg.sumMemClk / agg.memClkN)
+                << " MHz  peak " << agg.peakMemClk << " MHz\n";
+        if (agg.pcieN > 0) {
+            double avgGbps = (agg.sumPcie / agg.pcieN) / 1e9;
+            double peakGbps = agg.maxPcie / 1e9;
+            out << "    PCIe Bandwidth:     avg " << std::setprecision(1) << avgGbps
+                << " GB/s  peak " << peakGbps << " GB/s\n";
+        }
+        if (agg.maxEccCorr > 0 || agg.maxEccUncorr > 0)
+            out << "    ECC Errors:         " << agg.maxEccCorr << " corrected, "
+                << agg.maxEccUncorr << " uncorrected\n";
     }
 
     if (!host_metrics_.empty()) {

--- a/include/gpufl/report/text_report.hpp
+++ b/include/gpufl/report/text_report.hpp
@@ -64,6 +64,15 @@ class TextReport {
         int power_mw = 0;
         uint64_t used_mib = 0;
         int clock_sm = 0;
+        int fan_speed_pct = 0;
+        int temp_mem_c = 0;
+        int temp_junction_c = 0;
+        int voltage_mv = 0;
+        uint64_t energy_uj = 0;
+        int clock_mem = 0;
+        uint64_t pcie_bw_bps = 0;
+        uint64_t ecc_corrected = 0;
+        uint64_t ecc_uncorrected = 0;
     };
 
     struct HostMetricRecord {


### PR DESCRIPTION
…eline, bringing it closer to feature parity with the NVIDIA backend.

## Description

Extended AMD Metrics (rocm_collector.cpp, events.hpp, sampler.cpp, batch_models.cpp)
  - Collect junction temperature, memory temperature, fan speed, GFX voltage, cumulative energy, PCIe bandwidth, and ECC error counts via
  ROCm SMI
  - Add 9 new fields to DeviceMetricBatchRow and serialize to NDJSON logs
  - Filter CPU iGPU devices (Raphael/Ryzen) from telemetry to prevent polluted metrics
  - Resolve device name via HIP when ROCm SMI returns hex product ID (e.g., "0x7550" -> "AMD Radeon RX 9070 XT")

  Occupancy Calculation (rocprofiler_backend.cpp, activity_record.hpp)
  - Compute theoretical occupancy for AMD kernels using GPU architecture properties from rocprofiler_agent_t (wavefront size, max waves per
   CU, SIMD count, LDS size)
  - Use arch_vgpr_count (not combined SGPR+VGPR) with correct RDNA register file size (1536 VGPRs per SIMD)
  - Identify limiting resource (waves, registers, or shared_mem)

  ISA Disassembly (rocprofiler_backend.cpp/.hpp, dictionary_manager.cpp)
  - Register ROCPROFILER_CODE_OBJECT_LOAD callback to capture ELF code objects
  - Compute CRC32 via zlib for deduplication
  - Support both file-descriptor and memory-based code object storage
  - Refactor flushDisassembly() for dual-platform support: runtime ELF detection (e_machine == 0xE0 for AMDGPU), vendor-specific parser for
   llvm-objdump (AMD) vs nvdisasm (NVIDIA)
  - Parse AMD llvm-objdump output format with function-relative PC offsets

  Report Enhancements (text_report.cpp/.hpp)
  - Display extended AMD metrics in report: junction/memory temp, voltage, energy, fan speed, memory clock, PCIe bandwidth, ECC errors
  - Metrics auto-hide when zero (backward compatible with NVIDIA logs)
  - Fix MSVC std::max/std::min macro conflict with (std::max)(...) workaround

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update

## Testing
## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas