### PR TITLE
Adding sass compressor to avoid the same repeated instructions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,7 @@ set_target_properties(gpufl PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 target_sources(gpufl PRIVATE
     include/gpufl/core/dictionary_manager.cpp
+    include/gpufl/core/sass_compressor.cpp
     include/gpufl/core/logger/logger.cpp
     include/gpufl/core/logger/log_rotator.cpp
     include/gpufl/core/model/batch_models.cpp

--- a/include/gpufl/backends/amd/rocprofiler_backend.cpp
+++ b/include/gpufl/backends/amd/rocprofiler_backend.cpp
@@ -30,10 +30,6 @@
 #include "gpufl/core/ring_buffer.hpp"
 #include "gpufl/core/trace_type.hpp"
 
-namespace gpufl {
-extern RingBuffer<ActivityRecord, 1024> g_monitorBuffer;
-}
-
 namespace gpufl::amd {
 namespace {
 

--- a/include/gpufl/backends/nvidia/cupti_backend.cpp
+++ b/include/gpufl/backends/nvidia/cupti_backend.cpp
@@ -34,8 +34,6 @@
 namespace gpufl {
 std::atomic<gpufl::CuptiBackend*> g_activeBackend{nullptr};
 
-extern RingBuffer<ActivityRecord, 1024> g_monitorBuffer;
-
 namespace {
 bool IsInsufficientPrivilege(CUptiResult res) {
     if (res == CUPTI_ERROR_INSUFFICIENT_PRIVILEGES) return true;

--- a/include/gpufl/backends/nvidia/engine/pc_sampling_engine.cpp
+++ b/include/gpufl/backends/nvidia/engine/pc_sampling_engine.cpp
@@ -23,8 +23,6 @@
 
 namespace gpufl {
 
-extern RingBuffer<ActivityRecord, 1024> g_monitorBuffer;
-
 namespace {
 bool IsInsufficientPrivilege(CUptiResult res) {
     if (res == CUPTI_ERROR_INSUFFICIENT_PRIVILEGES) return true;

--- a/include/gpufl/backends/nvidia/engine/sass_metrics_engine.cpp
+++ b/include/gpufl/backends/nvidia/engine/sass_metrics_engine.cpp
@@ -16,7 +16,6 @@
 
 namespace gpufl {
 
-extern RingBuffer<ActivityRecord, 1024> g_monitorBuffer;
 namespace {
 std::vector<const char*> kSassMetricNames = {
     "smsp__sass_inst_executed",

--- a/include/gpufl/backends/nvidia/kernel_launch_handler.cpp
+++ b/include/gpufl/backends/nvidia/kernel_launch_handler.cpp
@@ -6,16 +6,13 @@
 #include "gpufl/core/activity_record.hpp"
 #include "gpufl/core/common.hpp"
 #include "gpufl/core/debug_logger.hpp"
+#include "gpufl/core/monitor.hpp"
 #include "gpufl/core/ring_buffer.hpp"
 #include "gpufl/core/scope_registry.hpp"
 #include "gpufl/core/stack_registry.hpp"
 #include "gpufl/core/stack_trace.hpp"
 
 using gpufl::core::DemangleName;
-
-namespace gpufl {
-extern RingBuffer<ActivityRecord, 1024> g_monitorBuffer;
-}
 
 namespace gpufl {
 

--- a/include/gpufl/backends/nvidia/mem_transfer_handler.cpp
+++ b/include/gpufl/backends/nvidia/mem_transfer_handler.cpp
@@ -6,14 +6,11 @@
 #include "gpufl/core/activity_record.hpp"
 #include "gpufl/core/common.hpp"
 #include "gpufl/core/debug_logger.hpp"
+#include "gpufl/core/monitor.hpp"
 #include "gpufl/core/ring_buffer.hpp"
 #include "gpufl/core/scope_registry.hpp"
 #include "gpufl/core/stack_registry.hpp"
 #include "gpufl/core/stack_trace.hpp"
-
-namespace gpufl {
-extern RingBuffer<ActivityRecord, 1024> g_monitorBuffer;
-}
 
 namespace gpufl {
 

--- a/include/gpufl/backends/nvidia/resource_handler.cpp
+++ b/include/gpufl/backends/nvidia/resource_handler.cpp
@@ -1,5 +1,6 @@
 #include "gpufl/backends/nvidia/resource_handler.hpp"
 
+#include <cupti_pcsampling.h>
 #include <zlib.h>
 
 #include "gpufl/core/debug_logger.hpp"
@@ -49,18 +50,17 @@ void ResourceHandler::handle(CUpti_CallbackDomain domain, CUpti_CallbackId cbid,
             const void *cubinPtr = modData->pCubin;
             const size_t cubinSize = modData->cubinSize;
 
+            // CUPTI_CBID_RESOURCE_MODULE_PROFILED fires on every kernel
+            // launch when PC sampling is active, including for
+            // SASS-patched cubin variants.  Use the raw pointer as an
+            // O(1) sentinel — cubin memory is stable for the process
+            // lifetime.  We must NOT skip MODULE_PROFILED entirely:
+            // its cubin may have a different CRC than the original
+            // MODULE_LOADED cubin, and CUPTI's PC sampling data
+            // references that CRC for source correlation.
             {
                 std::lock_guard<std::mutex> lk(backend_->cubin_mu_);
                 if (backend_->seen_cubin_ptrs_.count(cubinPtr)) return;
-                // CUPTI_CBID_RESOURCE_MODULE_PROFILED fires on every kernel
-                // launch when PC sampling is active, including for
-                // SASS-patched cubin variants that have a different pointer
-                // than the original. Mark the pointer seen and bail out —
-                // the original cubin was already processed by MODULE_LOADED.
-                if (cbid == CUPTI_CBID_RESOURCE_MODULE_PROFILED) {
-                    backend_->seen_cubin_ptrs_.insert(cubinPtr);
-                    return;
-                }
                 backend_->seen_cubin_ptrs_.insert(cubinPtr);
             }
 
@@ -96,18 +96,30 @@ void ResourceHandler::workerLoop() {
             pending_.pop();
         }
 
-        // Compute the cubin CRC using zlib crc32 — this matches the algorithm
-        // CUPTI uses internally for the cubinCrc field in activity records
-        // (CUpti_ActivityKernel11, CUpti_ActivityPCSampling3, etc.).
+        // Compute the cubin CRC.  We prefer cuptiGetCubinCrc() because it
+        // returns the exact CRC that CUPTI uses in PC sampling records
+        // (CUpti_PCSamplingPCData::cubinCrc) and activity records.
         //
-        // We previously called cuptiGetCubinCrc() here, but that function
-        // acquires CUPTI's internal global lock, which is also held by
-        // cuptiSassMetricsEnable() while it patches loaded modules.  Even
-        // from this worker thread the call can therefore deadlock when
-        // cuptiSassMetricsEnable() is still running on another thread.
-        // Using zlib directly avoids all CUPTI locks.
+        // cuptiGetCubinCrc() acquires CUPTI's internal global lock, which
+        // can deadlock when called from a CUPTI callback while
+        // cuptiSassMetricsEnable() is patching modules.  However, this
+        // worker thread runs OUTSIDE the callback, so the deadlock does
+        // not apply here.  Fall back to zlib crc32 only if CUPTI fails.
         GFL_LOG_DEBUG("Computing CRC for cubin copy, size=", data.size());
-        const uint64_t cubinCrc = crc32(0, data.data(), static_cast<uInt>(data.size()));
+        uint64_t cubinCrc = 0;
+        {
+            CUpti_GetCubinCrcParams crcParams = {CUpti_GetCubinCrcParamsSize};
+            crcParams.cubin = data.data();
+            crcParams.cubinSize = data.size();
+            if (cuptiGetCubinCrc(&crcParams) == CUPTI_SUCCESS) {
+                cubinCrc = crcParams.cubinCrc;
+            } else {
+                // Fallback: zlib crc32 (may not match CUPTI's CRC on all
+                // driver versions, but better than nothing).
+                GFL_LOG_DEBUG("cuptiGetCubinCrc failed, falling back to zlib crc32");
+                cubinCrc = crc32(0, data.data(), static_cast<uInt>(data.size()));
+            }
+        }
 
         bool isNew = false;
         const uint8_t *enqueuePtr = nullptr;

--- a/include/gpufl/core/batch_buffer.hpp
+++ b/include/gpufl/core/batch_buffer.hpp
@@ -8,7 +8,7 @@ namespace gpufl {
 template <typename Row>
 class BatchBuffer {
    public:
-    static constexpr size_t kMaxRows = 512;
+    static constexpr size_t kMaxRows = 2048;
 
     void push(const Row& row) { rows_.push_back(row); }
     bool empty() const { return rows_.empty(); }

--- a/include/gpufl/core/dictionary_manager.cpp
+++ b/include/gpufl/core/dictionary_manager.cpp
@@ -7,6 +7,8 @@
 #include <sstream>
 #include <stdexcept>
 
+#include "gpufl/core/sass_compressor.hpp"
+
 #ifdef _WIN32
 #include <io.h>       // _open, _write, _close, _unlink, _mktemp_s
 #include <fcntl.h>    // _O_CREAT, _O_WRONLY, _O_BINARY
@@ -321,20 +323,28 @@ void DictionaryManager::flushDisassembly(Logger& logger,
 #endif
         std::remove(tmpPathStr.c_str());
 
-        // Emit one cubin_disassembly JSON message per function
+        // Emit one cubin_disassembly JSON message per function.
+        // SassCompressor detects runs of structurally identical instructions
+        // (same opcode + registers, differing only in immediates) and merges
+        // them into a single entry with "count": N.
         for (auto& [funcName, entries] : funcEntries) {
             if (entries.empty()) continue;
+            auto compressed = SassCompressor::compress(entries);
             std::ostringstream oss;
             oss << "{\"version\":1,\"type\":\"cubin_disassembly\",\"session_id\":\""
                 << model::jsonEscape(session_id) << "\",\"cubin_crc\":" << crc
                 << ",\"function_name\":\"" << model::jsonEscape(funcName)
                 << "\",\"entries\":[";
             bool first = true;
-            for (auto& [pc, sass] : entries) {
+            for (auto& [pc, sass, count] : compressed) {
                 if (!first) oss << ',';
                 first = false;
                 oss << "{\"pc\":" << pc << ",\"sass\":\""
-                    << model::jsonEscape(sass) << "\"}";
+                    << model::jsonEscape(sass) << "\"";
+                if (count > 1) {
+                    oss << ",\"count\":" << count;
+                }
+                oss << '}';
             }
             oss << "]}";
             logger.write(DictLine{oss.str()});

--- a/include/gpufl/core/monitor.cpp
+++ b/include/gpufl/core/monitor.cpp
@@ -23,7 +23,7 @@
 
 namespace gpufl {
 
-RingBuffer<ActivityRecord, 1024> g_monitorBuffer;
+RingBuffer<ActivityRecord, kMonitorBufferSize> g_monitorBuffer;
 
 static std::unique_ptr<IMonitorAdapter> g_adapter;
 static std::atomic g_initialized{false};

--- a/include/gpufl/core/monitor.hpp
+++ b/include/gpufl/core/monitor.hpp
@@ -4,11 +4,23 @@
 #include <cstdint>
 #include <string>
 
+#include "gpufl/core/activity_record.hpp"
 #include "gpufl/core/events.hpp"
+#include "gpufl/core/ring_buffer.hpp"
 #include "gpufl/core/stream_handle.hpp"
 #include "gpufl/core/trace_type.hpp"
 
 namespace gpufl {
+
+/// Size of the global monitor ring buffer.  Must be large enough to hold
+/// a full SASS metrics flush: N_PCs × 4_metrics × N_SM_instances.
+/// 8192 supports kernels with ~2K unique PC offsets without data loss.
+inline constexpr size_t kMonitorBufferSize = 8192;
+
+/// Global ring buffer shared between profiling engines (producers) and
+/// the monitor collector thread (consumer).  Declared here so all
+/// translation units use the same template instantiation.
+extern RingBuffer<ActivityRecord, kMonitorBufferSize> g_monitorBuffer;
 
 enum class MonitorBackendKind {
     Auto,

--- a/include/gpufl/core/sass_compressor.cpp
+++ b/include/gpufl/core/sass_compressor.cpp
@@ -1,0 +1,109 @@
+#include "gpufl/core/sass_compressor.hpp"
+
+#include <cctype>
+#include <sstream>
+
+namespace gpufl {
+
+std::string SassCompressor::normalizeForCompare(const std::string& sass) {
+    // Replace sequences of digits (optionally with sign, decimal point, 'e'
+    // exponent, and 'x' for hex prefix) with a single '#' placeholder.
+    // This collapses:
+    //   integer literals:  42, 0x1F, -3
+    //   float literals:    1.0099999904632568359, 9.999e-05
+    //   hex addresses:     0x380
+    //
+    // Register names like R0, UR4, SR_TID contain digits but are preceded
+    // by a letter, so we only replace digit sequences that are NOT preceded
+    // by a letter.
+    std::string out;
+    out.reserve(sass.size());
+
+    size_t i = 0;
+    const size_t len = sass.size();
+    while (i < len) {
+        char c = sass[i];
+
+        // Check if this is the start of a numeric literal.
+        // A number starts with a digit, or a sign followed by a digit,
+        // but NOT if the previous char is a letter (e.g. "R0", "UR4").
+        bool isNumStart = false;
+        if (std::isdigit(static_cast<unsigned char>(c))) {
+            isNumStart = out.empty() ||
+                         !std::isalpha(static_cast<unsigned char>(out.back()));
+        } else if ((c == '-' || c == '+') && i + 1 < len &&
+                   std::isdigit(static_cast<unsigned char>(sass[i + 1]))) {
+            // Signed literal like -3 or +1.5
+            // Only treat as number if preceded by a non-alphanumeric
+            isNumStart = out.empty() ||
+                         (!std::isalnum(static_cast<unsigned char>(out.back())) &&
+                          out.back() != '_');
+        }
+
+        if (isNumStart) {
+            // Skip over the entire numeric literal
+            if (c == '-' || c == '+') ++i;  // skip sign
+            // Skip hex prefix
+            if (i + 1 < len && sass[i] == '0' &&
+                (sass[i + 1] == 'x' || sass[i + 1] == 'X')) {
+                i += 2;
+                while (i < len && std::isxdigit(static_cast<unsigned char>(sass[i])))
+                    ++i;
+            } else {
+                // Decimal integer or float
+                while (i < len && std::isdigit(static_cast<unsigned char>(sass[i])))
+                    ++i;
+                // Decimal point
+                if (i < len && sass[i] == '.') {
+                    ++i;
+                    while (i < len &&
+                           std::isdigit(static_cast<unsigned char>(sass[i])))
+                        ++i;
+                }
+                // Exponent
+                if (i < len && (sass[i] == 'e' || sass[i] == 'E')) {
+                    ++i;
+                    if (i < len && (sass[i] == '+' || sass[i] == '-')) ++i;
+                    while (i < len &&
+                           std::isdigit(static_cast<unsigned char>(sass[i])))
+                        ++i;
+                }
+            }
+            out += '#';
+        } else {
+            out += c;
+            ++i;
+        }
+    }
+    return out;
+}
+
+bool SassCompressor::isSameShape(const std::string& a, const std::string& b) {
+    return normalizeForCompare(a) == normalizeForCompare(b);
+}
+
+std::vector<SassCompressor::CompressedEntry> SassCompressor::compress(
+    const std::vector<std::pair<uint32_t, std::string>>& entries) {
+    std::vector<CompressedEntry> result;
+    if (entries.empty()) return result;
+    result.reserve(entries.size());  // worst case: no compression
+
+    size_t i = 0;
+    while (i < entries.size()) {
+        const auto& [pc, sass] = entries[i];
+        const std::string normalized = normalizeForCompare(sass);
+
+        // Count consecutive entries with the same normalized form
+        size_t runEnd = i + 1;
+        while (runEnd < entries.size() &&
+               normalizeForCompare(entries[runEnd].second) == normalized) {
+            ++runEnd;
+        }
+
+        result.push_back({pc, sass, static_cast<uint32_t>(runEnd - i)});
+        i = runEnd;
+    }
+    return result;
+}
+
+}  // namespace gpufl

--- a/include/gpufl/core/sass_compressor.hpp
+++ b/include/gpufl/core/sass_compressor.hpp
@@ -1,0 +1,52 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace gpufl {
+
+/**
+ * @brief Compresses SASS disassembly by detecting runs of structurally
+ *        identical instructions (differing only in immediate operands).
+ *
+ * Designed for extensibility — new comparison strategies (e.g.,
+ * register-agnostic, predicate-agnostic) can be added as new methods
+ * without touching the call sites.
+ */
+class SassCompressor {
+   public:
+    struct CompressedEntry {
+        uint32_t pc;       ///< PC offset of the first instruction in the run
+        std::string sass;  ///< representative SASS text (first instruction)
+        uint32_t count;    ///< number of instructions (1 = no compression)
+    };
+
+    /**
+     * Compress a sorted vector of (pc, sass) entries using run-length
+     * encoding.  Consecutive instructions whose normalized form matches
+     * are merged into a single CompressedEntry with count > 1.
+     */
+    static std::vector<CompressedEntry> compress(
+        const std::vector<std::pair<uint32_t, std::string>>& entries);
+
+    /**
+     * Normalize a SASS instruction for structural comparison.
+     * Replaces integer and floating-point literals with '#', preserving
+     * the opcode, registers, and punctuation.
+     *
+     * Examples:
+     *   "FFMA R0, R3, 42, R0"                     → "FFMA R0, R3, #, R0"
+     *   "FFMA R0, R3, 1.009999990463..., R3"       → "FFMA R0, R3, #, R3"
+     *   "LDG.E R5, desc[UR6][R4.64]"               → "LDG.E R5, desc[UR6][R4.#]"
+     */
+    static std::string normalizeForCompare(const std::string& sass);
+
+    /**
+     * Check if two instructions are "same shape" — same opcode and
+     * register operands, differing only in immediate values.
+     */
+    static bool isSameShape(const std::string& a, const std::string& b);
+};
+
+}  // namespace gpufl


### PR DESCRIPTION
## Description
- Client: New SassCompressor class detects consecutive SASS instructions with the same opcode+register pattern (differing only in immediates) and emits a single entry with "count": N. Fully unrolled loops like 500 sequential FFMA R0, R3, 1..500, R0 now compress to 1 JSON entry instead of 500.
- Backend: CubinDisassemblyEvent.Entry accepts optional count field, stored as repeat_count column (V13 migration). IsaEntryDto returns it in the API response.
- Frontend: SassInstructionRow shows ×N badge when repeatCount > 1. SourceCorrelationView collapses same-shape SASS blocks. SassListingView uses react-window virtualization + collapsing. Shared isSameShape() logic extracted to sassCompression.ts.
- Agent: Fixed RandomAccessFile.readLine() UTF-8 encoding bug (em dash — → â€" corruption).
- Ring buffer: Increased from 1024→8192 entries to prevent silent data drops on large kernels.
- Resource handler: Restored cuptiGetCubinCrc() for correct CRC matching; stopped dropping MODULE_PROFILED cubins that broke source correlation.
## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update

## Testing
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas