### PR TITLE
fix: ring buffer dropped the data when CAS on the slot failed. SASS m…

### DIFF
--- a/include/gpufl/core/monitor.hpp
+++ b/include/gpufl/core/monitor.hpp
@@ -14,8 +14,12 @@ namespace gpufl {
 
 /// Size of the global monitor ring buffer.  Must be large enough to hold
 /// a full SASS metrics flush: N_PCs × 4_metrics × N_SM_instances.
-/// 8192 supports kernels with ~2K unique PC offsets without data loss.
-inline constexpr size_t kMonitorBufferSize = 8192;
+/// 65536 supports kernels with ~16K unique PC offsets without data loss
+/// and absorbs multi-scope SASS bursts before the consumer drains them
+/// — at 8192 the buffer overran during sass_divergence_demo's 6 scopes
+/// and dropped the kernel activity records that arrive last at
+/// cuptiActivityFlushAll().
+inline constexpr size_t kMonitorBufferSize = 65536;
 
 /// Global ring buffer shared between profiling engines (producers) and
 /// the monitor collector thread (consumer).  Declared here so all

--- a/include/gpufl/core/ring_buffer.hpp
+++ b/include/gpufl/core/ring_buffer.hpp
@@ -3,6 +3,7 @@
 #include <array>
 #include <atomic>
 #include <cstddef>
+#include <thread>
 #include <type_traits>
 
 namespace gpufl {
@@ -36,15 +37,35 @@ class RingBuffer {
         size_t index = headIdx & MASK;
 
         Slot* slot = &buffer_[index];
-        SlotState expected = SlotState::FREE;
 
-        // Try to transition FREE -> WRITING
+        // Wait for the slot to become FREE. On wraparound the slot still
+        // holds READY data the consumer hasn't drained yet — without this
+        // backpressure, bursty producers (e.g. SASS metric drain pushing
+        // thousands of samples in a tight loop) overrun the ring and
+        // silently drop later records (kernel activity records that arrive
+        // last at cuptiActivityFlushAll were the original symptom).
+        //
+        // Bounded wait so a truly stuck consumer cannot deadlock CUPTI
+        // callback threads. ~100 spins (~µs) then ~1000 yields (~1 ms
+        // total) is comfortably long enough for the collector to drain
+        // a few records and short enough that an actually-dead consumer
+        // doesn't block CUPTI for noticeable time.
+        constexpr int kSpinAttempts = 100;
+        constexpr int kYieldAttempts = 1000;
+        for (int i = 0; i < kSpinAttempts; ++i) {
+            if (slot->state.load(std::memory_order_acquire) == SlotState::FREE)
+                break;
+        }
+        for (int i = 0; i < kYieldAttempts; ++i) {
+            if (slot->state.load(std::memory_order_acquire) == SlotState::FREE)
+                break;
+            std::this_thread::yield();
+        }
+
+        SlotState expected = SlotState::FREE;
         if (!slot->state.compare_exchange_strong(expected, SlotState::WRITING,
                                                  std::memory_order_acquire,
                                                  std::memory_order_relaxed)) {
-            // Failure: The buffer is full (the tail hasn't caught up),
-            // or another thread is still messing with this slot (rare race).
-            // For a profiler, we DROP the packet
             return false;
         }
 


### PR DESCRIPTION
…etric drains push thousands of records in tight loops at every onScopeStop;

## Description
## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

## Testing
## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas