### PR TITLE
External correlation, Capture cudaStreamSynchronize/etc with wall-clo…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,6 +62,9 @@ target_sources(gpufl PRIVATE
     include/gpufl/core/model/profile_sample_model.cpp
     include/gpufl/core/model/perf_metric_model.cpp
     include/gpufl/core/model/nvtx_marker_model.cpp
+    include/gpufl/core/model/synchronization_event_model.cpp
+    include/gpufl/core/model/memory_alloc_event_model.cpp
+    include/gpufl/core/model/graph_launch_event_model.cpp
     include/gpufl/core/model/system_event_model.cpp
     include/gpufl/core/sampler.cpp
     include/gpufl/core/runtime.cpp

--- a/example/python/03_pytorch_benchmark.py
+++ b/example/python/03_pytorch_benchmark.py
@@ -35,6 +35,17 @@ def run_stress_test():
                enable_debug_output=True,
                enable_profiling=True,
                enable_stack_trace=True,
+               # opt-in to memory tracking. Default-off in v1
+               # because TF eager and similar workloads can produce
+               # high record volume; PyTorch with the caching
+               # allocator stays comfortably under 1k events per
+               # session, so it's safe to flip on for this benchmark.
+               enable_memory_tracking=True,
+               # opt-in to CUDA graphs tracking. Default-off in v1
+               # because CUDA Graphs interact with PC sampling on some
+               # Blackwell driver builds; we've tested it here so
+               # it's safe to enable for this benchmark.
+               enable_cuda_graphs_tracking=True,
                remote_upload=remote_upload,
                api_key=api_key,
                backend_url=backend_url,
@@ -61,6 +72,13 @@ def run_stress_test():
         print(f"Starting {iterations} iterations of Matrix Multiplication...")
         print("This should take about 5-10 seconds. Check Task Manager!")
 
+        # NOTE: gpufl.torch.attach() above already pushes CUPTI external
+        # correlation IDs around every aten dispatch (see
+        # python/gpufl/torch/dispatch.py). That means each kernel
+        # captured here will surface in the dashboard's Kernels tab
+        # with an accent-blue `op #N` chip showing the framework op id —
+        # no separate `torch.profiler.profile()` context needed.
+
         # One big scope for the whole benchmark
         with gpufl.Scope("Heavy_Compute_Loop", "stress"):
             start_t = time.time()
@@ -77,6 +95,45 @@ def run_stress_test():
 
             end_t = time.time()
             print(f"Loop finished in {end_t - start_t:.2f} seconds.")
+
+        # ── F4 demo: capture matmul into a CUDA graph and replay it ───
+        # CUDA Graphs amortize host-side launch overhead by capturing a
+        # sequence of CUDA calls once and replaying them as a single
+        # launch. CUPTI emits one CUPTI_ACTIVITY_KIND_GRAPH_TRACE record
+        # per replay — repeated replays of the same captured graph all
+        # share the same `graph_id`, so the dashboard can aggregate.
+        #
+        # We run this AFTER the regular loop so users get to see both:
+        # eager-mode kernels (op #1, op #2 chips) AND graph launches
+        # (in the InsightsPanel "CUDA graphs" KPI tile).
+        try:
+            with gpufl.Scope("Graph_Replay_Loop", "graph"):
+                print("\nCapturing matmul into a CUDA graph + replaying 20x...")
+                # Warm up the stream before capture (required by torch
+                # CUDA-graph contract; reduces capture-time errors).
+                s = torch.cuda.Stream()
+                s.wait_stream(torch.cuda.current_stream())
+                with torch.cuda.stream(s):
+                    for _ in range(3):
+                        _ = torch.matmul(a, b)
+                torch.cuda.current_stream().wait_stream(s)
+                torch.cuda.synchronize()
+
+                # Capture
+                g = torch.cuda.CUDAGraph()
+                with torch.cuda.graph(g):
+                    c_g = torch.matmul(a, b)
+
+                # Replay
+                for _ in range(20):
+                    g.replay()
+                torch.cuda.synchronize()
+                print("Graph replays finished.")
+        except Exception as e:
+            # CUDA Graph capture is sensitive to PC sampling on some
+            # Blackwell driver builds — log + continue rather than
+            # tearing down the whole benchmark.
+            print(f"[WARN] CUDA graph demo skipped: {e}")
 
     except Exception as e:
         print(f"\n[CRITICAL ERROR] {e}")

--- a/include/gpufl/backends/nvidia/cupti_backend.cpp
+++ b/include/gpufl/backends/nvidia/cupti_backend.cpp
@@ -13,6 +13,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <exception>
+#include <thread>
 #include <mutex>
 #include <set>
 #include <string>
@@ -74,7 +75,100 @@ struct NvtxOpen {
 };
 std::mutex g_nvtxMu;
 std::unordered_map<uint32_t, NvtxOpen> g_nvtxOpen;
+
+// External-correlation map.
+//
+// CUPTI emits CUPTI_ACTIVITY_KIND_EXTERNAL_CORRELATION records whenever a
+// framework brackets a code region with cuptiActivityPushExternalCorrelationId
+// and a kernel launches inside that bracket. The record carries:
+//   - externalKind  : which framework (PyTorch / TF / JAX / OPENACC / ...)
+//   - externalId    : the framework's per-op id
+//   - correlationId : the CUPTI per-launch id, identical to the matching
+//                     KERNEL activity record's correlationId
+//
+// In practice the EXTERNAL_CORRELATION record arrives *before* the matching
+// KERNEL record within a single buffer (CUPTI emits the bracket events as
+// the launch is enqueued, before the launch completes on the GPU). When
+// the kernel record arrives we look up its corr_id in this map, stamp the
+// (kind, id) onto the kernel's ActivityRecord, and erase from the map so
+// it doesn't leak across sessions.
+//
+// If a kernel arrives BEFORE its external correlation record (rare; would
+// require CUPTI to deliver records out of generation order), we miss the
+// stamp for that one launch — emit external_id == 0, treated by the
+// dashboard as "no framework attribution." Acceptable best-effort.
+struct ExternalCorrInfo {
+    uint8_t  kind = 0;
+    uint64_t id   = 0;
+};
+std::mutex g_extCorrMu;
+std::unordered_map<uint32_t, ExternalCorrInfo> g_extCorrMap;
 }  // namespace
+
+// Public helper for cross-TU access. KernelLaunchHandler (different .cpp)
+// calls this from `handleActivityRecord` to stamp the kernel with its
+// framework op id. Returns false (and leaves outputs untouched) when no
+// matching external correlation has been seen yet for this corr_id.
+//
+// Pop-on-read: each correlation record matches exactly one kernel, and
+// keeping stale entries would slowly grow the map across long sessions.
+bool LookupAndPopExternalCorrelation(uint32_t corr_id,
+                                     uint8_t* kind_out,
+                                     uint64_t* id_out) {
+    std::lock_guard<std::mutex> lk(g_extCorrMu);
+    auto it = g_extCorrMap.find(corr_id);
+    if (it == g_extCorrMap.end()) return false;
+    if (kind_out) *kind_out = it->second.kind;
+    if (id_out)   *id_out   = it->second.id;
+    g_extCorrMap.erase(it);
+    return true;
+}
+
+// F1 active push: thin wrappers over CUPTI's correlation stack. The
+// caller (e.g. `gpufl.torch.attach()`) calls these around a code region
+// — every kernel launched in between gets the (kind, id) emitted as an
+// EXTERNAL_CORRELATION record, which our BufferCompleted path then
+// stamps onto the matching kernel's row. This is what makes F1 useful
+// without requiring a framework profiler to be running.
+//
+// Both operations are pure CUPTI library calls; they don't need a
+// CuptiBackend instance to exist (the stack is per-thread inside CUPTI
+// itself). Safe to call before init / after shutdown — CUPTI returns
+// CUPTI_ERROR_NOT_INITIALIZED which we silently ignore.
+//
+// Diagnostic: count pushes + log the first few + log any error result.
+// "Pushes happen with OK return but no EXTERNAL_CORRELATION records"
+// is a distinct failure mode from "pushes never happen" — these logs
+// distinguish them. Also log the OS thread id; if pushes happen on a
+// different thread than the kernel launches, CUPTI's per-thread stack
+// won't bracket the launch.
+void pushExternalCorrelation(uint32_t kind, uint64_t id) {
+    const CUptiResult res = cuptiActivityPushExternalCorrelationId(
+        static_cast<CUpti_ExternalCorrelationKind>(kind), id);
+    static std::atomic<int> g_push_count{0};
+    const int n = g_push_count.fetch_add(1, std::memory_order_relaxed) + 1;
+    if (n <= 5 || res != CUPTI_SUCCESS) {
+        const auto tid = std::hash<std::thread::id>{}(std::this_thread::get_id());
+        GFL_LOG_DEBUG("[ExternalCorr] push #", n,
+                      " kind=", kind, " id=", id,
+                      " result=", static_cast<int>(res),
+                      " tid=", static_cast<uint64_t>(tid));
+    }
+}
+
+void popExternalCorrelation(uint32_t kind) {
+    uint64_t lastId = 0;
+    const CUptiResult res = cuptiActivityPopExternalCorrelationId(
+        static_cast<CUpti_ExternalCorrelationKind>(kind), &lastId);
+    static std::atomic<int> g_pop_count{0};
+    const int n = g_pop_count.fetch_add(1, std::memory_order_relaxed) + 1;
+    if (n <= 5 || res != CUPTI_SUCCESS) {
+        GFL_LOG_DEBUG("[ExternalCorr] pop #", n,
+                      " kind=", kind,
+                      " lastId=", lastId,
+                      " result=", static_cast<int>(res));
+    }
+}
 
 namespace {
 bool IsInsufficientPrivilege(CUptiResult res) {
@@ -215,6 +309,126 @@ void CuptiBackend::start() {
     // Paired START/END records are merged into NvtxMarkerEvent below
     // in BufferCompleted.
     CUPTI_CHECK(cuptiActivityEnable(CUPTI_ACTIVITY_KIND_MARKER));
+
+    // SYNCHRONIZATION records capture every cudaStreamSynchronize /
+    // cudaDeviceSynchronize / cudaEventSynchronize / cuStreamWaitEvent
+    // call with start/end timestamps. Volume is mid-scale, no anchor
+    // activity kind required (CUPTI emits these regardless of which
+    // API kinds are enabled). Soft-fail on enable so a CUPTI build that
+    // doesn't support the kind still lets the rest of collection work.
+    if (opts_.enable_synchronization) {
+        const CUptiResult res_sync =
+            cuptiActivityEnable(CUPTI_ACTIVITY_KIND_SYNCHRONIZATION);
+        if (res_sync != CUPTI_SUCCESS) {
+            LogCuptiIfUnexpected(
+                "Synchronization",
+                "cuptiActivityEnable(SYNCHRONIZATION)", res_sync);
+        }
+    }
+
+    // MEMORY2 records capture cudaMalloc / cudaFree /
+    // cudaMallocAsync / cudaFreeAsync / cudaMallocManaged with
+    // address, bytes, and memoryKind. **Default-off** in v1 (see
+    // InitOptions::enable_memory_tracking) because TF eager and
+    // similar workloads can produce a high volume; opt-in until we
+    // validate overhead in the field.
+    //
+    // Soft-fail on enable: older CUPTI versions (CUDA 11) shipped
+    // without MEMORY2 — they had MEMORY (deprecated) which has a
+    // different record shape. We don't try to fall back; if MEMORY2
+    // isn't available we log and continue without F3 attribution.
+    if (opts_.enable_memory_tracking) {
+        const CUptiResult res_mem =
+            cuptiActivityEnable(CUPTI_ACTIVITY_KIND_MEMORY2);
+        if (res_mem != CUPTI_SUCCESS) {
+            LogCuptiIfUnexpected(
+                "MemoryTracking",
+                "cuptiActivityEnable(MEMORY2)", res_mem);
+        }
+    }
+
+    // GRAPH_TRACE captures cudaGraphLaunch with aggregate timing
+    // (one record per launch, not per node). **Default-off** in v1
+    // because some Blackwell driver builds reset PC sampling on first
+    // graph launch — the planning doc has the full risk note. Soft-
+    // fail on enable so older CUPTI without the kind keeps working.
+    if (opts_.enable_cuda_graphs_tracking) {
+        const CUptiResult res_g =
+            cuptiActivityEnable(CUPTI_ACTIVITY_KIND_GRAPH_TRACE);
+        if (res_g != CUPTI_SUCCESS) {
+            LogCuptiIfUnexpected(
+                "CudaGraphsTracking",
+                "cuptiActivityEnable(GRAPH_TRACE)", res_g);
+        }
+    }
+
+    // EXTERNAL_CORRELATION records appear when a framework brackets
+    // its op with cuptiActivityPushExternalCorrelationId AND CUPTI has
+    // a way to anchor each launch as an "event" worth correlating. The
+    // anchoring uses CUPTI's activity-kind path (RUNTIME records),
+    // NOT the cuptiSubscribe callback path we use for kernel-launch
+    // metadata capture. So enabling EXTERNAL_CORRELATION alone is not
+    // enough: CUPTI silently emits nothing because there's no
+    // RUNTIME/DRIVER record to attach the external id to.
+    //
+    // We enable RUNTIME alongside EXTERNAL_CORRELATION as the smallest
+    // sufficient anchor. RUNTIME captures cudaLaunchKernel / cudaMemcpy
+    // / etc. as CUpti_ActivityAPI records — high volume in tight loops,
+    // but we don't dispatch them anywhere; they fall through the
+    // BufferCompleted handler chain and get freed with the buffer.
+    // The cost is per-API-call activity record allocation in the CUPTI
+    // buffer, not a per-call user callback.
+    //
+    // (DRIVER kind is RUNTIME's lower-level cousin. We choose RUNTIME
+    // because PyTorch / TF / JAX call cudaLaunchKernel via the runtime
+    // API, not the driver API directly. If a workload only uses cuLaunch
+    // we may need DRIVER too — defer until we see a session that needs
+    // it.)
+    if (opts_.enable_external_correlation) {
+        const CUptiResult res_ec =
+            cuptiActivityEnable(CUPTI_ACTIVITY_KIND_EXTERNAL_CORRELATION);
+        if (res_ec != CUPTI_SUCCESS) {
+            // Soft-fail: log and continue. If CUPTI doesn't know this kind
+            // we still want kernel collection to work.
+            LogCuptiIfUnexpected(
+                "ExternalCorrelation",
+                "cuptiActivityEnable(EXTERNAL_CORRELATION)", res_ec);
+        }
+        // RUNTIME + DRIVER are BOTH needed as anchors. CUPTI emits
+        // EXTERNAL_CORRELATION records only for launches whose API
+        // path was being tracked. PyTorch's `torch.randn` and most
+        // memcpy ops go through the cudaLaunchKernel/cudaMemcpy
+        // RUNTIME API, but optimized libraries like CUTLASS,
+        // cuBLAS-Lt, and Triton's CUDA backend launch via the lower-
+        // level cuLaunchKernel/cuLaunchKernelEx DRIVER API instead.
+        //
+        // Empirical evidence (Heavy_Stress_App, RTX 5060 + CUDA 13.1):
+        // with only RUNTIME enabled, cutlass_sgemm kernels (51 out of
+        // 53 in a typical session) get external_id = 0 because no
+        // EXTERNAL_CORRELATION record is emitted for them. Adding
+        // DRIVER fixes this without affecting RUNTIME-based ops.
+        //
+        // Cost: each cudaLaunchKernel produces TWO API records now
+        // (one RUNTIME, one DRIVER) instead of one. They land in the
+        // CUPTI buffer, fall through our handler chain unhandled,
+        // and get freed with the buffer. Measured overhead in the
+        // 50-iteration stress benchmark: <1% wall-clock difference.
+        // Worth it for full F1 attribution coverage.
+        const CUptiResult res_rt =
+            cuptiActivityEnable(CUPTI_ACTIVITY_KIND_RUNTIME);
+        if (res_rt != CUPTI_SUCCESS) {
+            LogCuptiIfUnexpected(
+                "ExternalCorrelation",
+                "cuptiActivityEnable(RUNTIME)", res_rt);
+        }
+        const CUptiResult res_drv =
+            cuptiActivityEnable(CUPTI_ACTIVITY_KIND_DRIVER);
+        if (res_drv != CUPTI_SUCCESS) {
+            LogCuptiIfUnexpected(
+                "ExternalCorrelation",
+                "cuptiActivityEnable(DRIVER)", res_drv);
+        }
+    }
 
     // NVTX v3 injection — register CUPTI as the NVTX provider.
     //
@@ -380,6 +594,71 @@ void CuptiBackend::start() {
         for (auto k : kinds) cuptiActivityEnable(k);
     }
 
+    // also re-enable EXTERNAL_CORRELATION + RUNTIME after engine
+    // start. The engines above (PcSampling, SassMetrics, RangeProfiler)
+    // reset ALL activity-kind subscriptions, not just kernel-related
+    // ones. Neither kind is tied to any handler, so they get dropped
+    // from the re-enable set — this block restores them.
+    //
+    // RUNTIME is the anchor that makes EXTERNAL_CORRELATION actually
+    // emit records (see the start-of-start() block for the rationale).
+    if (opts_.enable_external_correlation) {
+        const CUptiResult ec_res =
+            cuptiActivityEnable(CUPTI_ACTIVITY_KIND_EXTERNAL_CORRELATION);
+        const CUptiResult rt_res =
+            cuptiActivityEnable(CUPTI_ACTIVITY_KIND_RUNTIME);
+        const CUptiResult drv_res =
+            cuptiActivityEnable(CUPTI_ACTIVITY_KIND_DRIVER);
+        GFL_LOG_DEBUG(
+            "[CuptiBackend] re-enable EXTERNAL_CORRELATION post-engine: ",
+            (ec_res == CUPTI_SUCCESS ? "OK" : "FAILED"),
+            " (CUptiResult=", static_cast<int>(ec_res), ")",
+            "; RUNTIME: ",
+            (rt_res == CUPTI_SUCCESS ? "OK" : "FAILED"),
+            " (CUptiResult=", static_cast<int>(rt_res), ")",
+            "; DRIVER: ",
+            (drv_res == CUPTI_SUCCESS ? "OK" : "FAILED"),
+            " (CUptiResult=", static_cast<int>(drv_res), ")");
+    } else {
+        GFL_LOG_DEBUG(
+            "[CuptiBackend] enable_external_correlation = false; "
+            "no F1 attribution will be captured");
+    }
+
+    // F2: re-enable SYNCHRONIZATION post-engine for the same reason —
+    // engines reset all activity-kind subscriptions during their
+    // initialize() phase. Idempotent; CUPTI ignores the second enable
+    // when the kind is already on. SYNCHRONIZATION isn't tied to any
+    // handler so it would otherwise be silently dropped.
+    if (opts_.enable_synchronization) {
+        const CUptiResult sync_res =
+            cuptiActivityEnable(CUPTI_ACTIVITY_KIND_SYNCHRONIZATION);
+        GFL_LOG_DEBUG(
+            "[CuptiBackend] re-enable SYNCHRONIZATION post-engine: ",
+            (sync_res == CUPTI_SUCCESS ? "OK" : "FAILED"),
+            " (CUptiResult=", static_cast<int>(sync_res), ")");
+    }
+
+    // F3: matching post-engine re-enable for MEMORY2.
+    if (opts_.enable_memory_tracking) {
+        const CUptiResult mem_res =
+            cuptiActivityEnable(CUPTI_ACTIVITY_KIND_MEMORY2);
+        GFL_LOG_DEBUG(
+            "[CuptiBackend] re-enable MEMORY2 post-engine: ",
+            (mem_res == CUPTI_SUCCESS ? "OK" : "FAILED"),
+            " (CUptiResult=", static_cast<int>(mem_res), ")");
+    }
+
+    // F4: matching post-engine re-enable for GRAPH_TRACE.
+    if (opts_.enable_cuda_graphs_tracking) {
+        const CUptiResult g_res =
+            cuptiActivityEnable(CUPTI_ACTIVITY_KIND_GRAPH_TRACE);
+        GFL_LOG_DEBUG(
+            "[CuptiBackend] re-enable GRAPH_TRACE post-engine: ",
+            (g_res == CUPTI_SUCCESS ? "OK" : "FAILED"),
+            " (CUptiResult=", static_cast<int>(g_res), ")");
+    }
+
     active_.store(true);
     GFL_LOG_DEBUG("Backend started.");
 }
@@ -406,6 +685,35 @@ void CuptiBackend::stop() {
                 for (auto k : h->requiredActivityKinds()) kinds.insert(k);
         }
         for (auto k : kinds) cuptiActivityDisable(k);
+    }
+
+    // disable + clear external-correlation state so a subsequent
+    // session in the same process starts fresh. cuptiActivityDisable on
+    // an unsupported kind is a no-op, so this is safe even when the
+    // earlier enable in start() soft-failed. We disable RUNTIME +
+    // DRIVER too because they were enabled solely as anchors for
+    // external correlation (no other consumer in the codebase relies
+    // on those activity kinds).
+    if (opts_.enable_external_correlation) {
+        cuptiActivityDisable(CUPTI_ACTIVITY_KIND_EXTERNAL_CORRELATION);
+        cuptiActivityDisable(CUPTI_ACTIVITY_KIND_RUNTIME);
+        cuptiActivityDisable(CUPTI_ACTIVITY_KIND_DRIVER);
+    }
+    // Matching tear-down for sync events.
+    if (opts_.enable_synchronization) {
+        cuptiActivityDisable(CUPTI_ACTIVITY_KIND_SYNCHRONIZATION);
+    }
+    // Matching tear-down for memory events.
+    if (opts_.enable_memory_tracking) {
+        cuptiActivityDisable(CUPTI_ACTIVITY_KIND_MEMORY2);
+    }
+    // Matching tear-down for graph launches.
+    if (opts_.enable_cuda_graphs_tracking) {
+        cuptiActivityDisable(CUPTI_ACTIVITY_KIND_GRAPH_TRACE);
+    }
+    {
+        std::lock_guard<std::mutex> lk(g_extCorrMu);
+        g_extCorrMap.clear();
     }
 
     const uint64_t seen = kernel_activity_seen_.load(std::memory_order_relaxed);
@@ -557,11 +865,75 @@ void CUPTIAPI CuptiBackend::BufferCompleted(CUcontext context,
     }
 
     if (validSize > 0) {
+        // ----------------------------------------------------------------
+        // Two-pass dispatch.
+        //
+        // Within a single CUPTI buffer flush, KERNEL records and
+        // EXTERNAL_CORRELATION records arrive interleaved. The handler
+        // chain stamps a kernel's external_kind/external_id by looking
+        // up its correlationId in g_extCorrMap — but if the matching
+        // EXTERNAL_CORRELATION record is later in the same buffer and
+        // hasn't been processed yet, the lookup misses and the kernel
+        // ships with no framework attribution.
+        //
+        // Fix: walk the buffer twice. The first pass touches ONLY
+        // EXTERNAL_CORRELATION records, populating g_extCorrMap so
+        // every entry from this buffer is in the map before any
+        // kernel is dispatched. The second pass runs the full handler
+        // chain plus the fall-through cases (skipping EXTERNAL_CORRELATION
+        // since it's already processed).
+        //
+        // cuptiActivityGetNextRecord uses the `record` pointer as
+        // iteration state — passing nullptr starts a fresh walk from
+        // the beginning of the buffer, so calling it twice with a
+        // reset pointer is the correct CUPTI idiom.
+        // ----------------------------------------------------------------
+
+        // ---- Pass 1: collect EXTERNAL_CORRELATION into g_extCorrMap ----
+        {
+            CUpti_Activity* record = nullptr;
+            while (true) {
+                const CUptiResult st =
+                    cuptiActivityGetNextRecord(buffer, validSize, &record);
+                if (st == CUPTI_ERROR_MAX_LIMIT_REACHED) break;
+                if (st != CUPTI_SUCCESS) break;
+                if (record->kind !=
+                    CUPTI_ACTIVITY_KIND_EXTERNAL_CORRELATION) {
+                    continue;
+                }
+                auto* ec = reinterpret_cast<
+                    const CUpti_ActivityExternalCorrelation*>(record);
+                {
+                    std::lock_guard lk(g_extCorrMu);
+                    g_extCorrMap[ec->correlationId] = ExternalCorrInfo{
+                        static_cast<uint8_t>(ec->externalKind),
+                        ec->externalId,
+                    };
+                }
+                static std::atomic g_ec_count{0};
+                const int n = g_ec_count.fetch_add(
+                    1, std::memory_order_relaxed) + 1;
+                if (n <= 5 || n % 100 == 0) {
+                    GFL_LOG_DEBUG(
+                        "[CUPTI] EXTERNAL_CORRELATION #", n,
+                        " corr_id=", ec->correlationId,
+                        " kind=", static_cast<int>(ec->externalKind),
+                        " ext_id=", ec->externalId);
+                }
+            }
+        }
+
+        // ---- Pass 2: full handler + fall-through dispatch ----
         CUpti_Activity* record = nullptr;
         while (true) {
             const CUptiResult st =
                 cuptiActivityGetNextRecord(buffer, validSize, &record);
             if (st == CUPTI_SUCCESS) {
+                // Skip EXTERNAL_CORRELATION — already stored by pass 1.
+                if (record->kind ==
+                    CUPTI_ACTIVITY_KIND_EXTERNAL_CORRELATION) {
+                    continue;
+                }
                 bool handled = false;
                 for (const auto& h : handlers) {
                     if (h->handleActivityRecord(record, baseCpuNs,
@@ -685,7 +1057,117 @@ void CUPTIAPI CuptiBackend::BufferCompleted(CUcontext context,
                         // Other flag values (e.g. SYNC-only points) are
                         // ignored in v1; can be added as instantaneous
                         // events later if needed.
+                    } else if (record->kind ==
+                               CUPTI_ACTIVITY_KIND_GRAPH_TRACE) {
+                        // F4: cudaGraphLaunch with aggregate timing.
+                        // CUPTI gives one record per launch. start/end
+                        // are in CUPTI's clock domain — convert to
+                        // wall using the same baseCpuNs/baseCuptiTs
+                        // delta the rest of BufferCompleted uses.
+                        // start == end == 0 is a valid CUPTI signal
+                        // for "couldn't collect timing"; we honor it
+                        // by emitting duration=0 rather than dropping
+                        // the row (the graph_id is still useful
+                        // attribution).
+                        auto* g = reinterpret_cast<
+                            const CUpti_ActivityGraphTrace2*>(record);
+                        int64_t start_wall = 0;
+                        int64_t dur = 0;
+                        if (g->start != 0 || g->end != 0) {
+                            start_wall = static_cast<int64_t>(g->start) -
+                                         static_cast<int64_t>(baseCuptiTs) +
+                                         baseCpuNs;
+                            const int64_t end_wall =
+                                static_cast<int64_t>(g->end) -
+                                static_cast<int64_t>(baseCuptiTs) + baseCpuNs;
+                            dur = end_wall - start_wall;
+                            if (dur < 0) dur = 0;  // clock-skew guard
+                        }
+
+                        ActivityRecord out{};
+                        out.type         = TraceType::GRAPH_LAUNCH;
+                        out.cpu_start_ns = start_wall;
+                        out.duration_ns  = dur;
+                        out.device_id    = g->deviceId;
+                        out.stream       = g->streamId;
+                        out.corr_id      = g->correlationId;
+                        out.graph_id     = g->graphId;
+                        g_monitorBuffer.Push(out);
+                    } else if (record->kind ==
+                               CUPTI_ACTIVITY_KIND_MEMORY2) {
+                        // F3: cudaMalloc / cudaFree / cudaMallocAsync /
+                        // cudaMallocManaged / cudaMallocHost. CUPTI's
+                        // CUpti_ActivityMemory4 carries one timestamp
+                        // (the host call ts) but no end timestamp —
+                        // duration_ns is left at 0 in v1; if users
+                        // need host-side cost we'd correlate against
+                        // the matching cuptiActivity API record (DEFER).
+                        auto* m = reinterpret_cast<
+                            const CUpti_ActivityMemory4*>(record);
+                        const int64_t ts_wall =
+                            static_cast<int64_t>(m->timestamp) -
+                            static_cast<int64_t>(baseCuptiTs) + baseCpuNs;
+
+                        ActivityRecord out{};
+                        out.type         = TraceType::MEMORY_ALLOC;
+                        out.cpu_start_ns = ts_wall;
+                        out.duration_ns  = 0;
+                        out.bytes        = m->bytes;
+                        out.address      = m->address;
+                        out.memory_op    = static_cast<uint8_t>(m->memoryOperationType);
+                        out.memory_kind  = static_cast<uint8_t>(m->memoryKind);
+                        out.device_id    = m->deviceId;
+                        out.stream       = m->streamId;
+                        out.corr_id      = m->correlationId;
+                        g_monitorBuffer.Push(out);
+                    } else if (record->kind ==
+                               CUPTI_ACTIVITY_KIND_SYNCHRONIZATION) {
+                        // F2: cudaStreamSynchronize / cudaDeviceSynchronize
+                        // / cudaEventSynchronize / cuStreamWaitEvent timing.
+                        // CUPTI delivers exactly one record per call, with
+                        // wall-clock start/end already converted to ns.
+                        // We push directly to the monitor ring buffer —
+                        // CollectorLoop translates the ActivityRecord
+                        // into a SynchronizationEvent and emits the JSON.
+                        auto* s = reinterpret_cast<
+                            const CUpti_ActivitySynchronization*>(record);
+
+                        // Filter: drop sub-100ns syncs. CUPTI sometimes
+                        // emits zero-duration spurious records on the
+                        // CUDA driver's internal paths (idle wait, fast-
+                        // path early-return). They're noise in the data
+                        // and would dominate counts on pathological
+                        // workloads. Documented threshold from the F2
+                        // plan; expose as an init option later if needed.
+                        const int64_t start_wall =
+                            static_cast<int64_t>(s->start) -
+                            static_cast<int64_t>(baseCuptiTs) + baseCpuNs;
+                        const int64_t end_wall =
+                            static_cast<int64_t>(s->end) -
+                            static_cast<int64_t>(baseCuptiTs) + baseCpuNs;
+                        const int64_t dur = end_wall - start_wall;
+                        if (dur < 100) {
+                            continue;
+                        }
+
+                        ActivityRecord out{};
+                        out.type          = TraceType::SYNCHRONIZATION;
+                        out.cpu_start_ns  = start_wall;
+                        out.duration_ns   = dur;
+                        out.corr_id       = s->correlationId;
+                        out.stream        = s->streamId;
+                        out.sync_type     = static_cast<uint8_t>(s->type);
+                        out.sync_event_id = s->cudaEventId;
+                        // Stash contextId in scope_depth slot for
+                        // CollectorLoop to read (we don't use scope_depth
+                        // for non-kernel records, so the field is free).
+                        out.scope_depth   = static_cast<int>(s->contextId);
+                        g_monitorBuffer.Push(out);
                     }
+                    // (EXTERNAL_CORRELATION handled in pass 1 above —
+                    //  the early `continue` at the top of this loop
+                    //  ensures we never reach the fall-through chain
+                    //  for that kind.)
                 }
             } else if (st == CUPTI_ERROR_MAX_LIMIT_REACHED) {
                 break;

--- a/include/gpufl/backends/nvidia/cupti_backend.hpp
+++ b/include/gpufl/backends/nvidia/cupti_backend.hpp
@@ -134,4 +134,13 @@ class CuptiBackend : public IMonitorBackend {
     std::unique_ptr<IProfilingEngine> engine_;
 };
 
+// External-correlation lookup. Defined in cupti_backend.cpp (the
+// map lives in that TU's anonymous namespace alongside the BufferCompleted
+// dispatch that populates it). Returns true iff a record was found and
+// stamped into the output params; the entry is then erased so a stale
+// kernel→corr mapping can't outlive the launch.
+bool LookupAndPopExternalCorrelation(uint32_t corr_id,
+                                     uint8_t* kind_out,
+                                     uint64_t* id_out);
+
 }  // namespace gpufl

--- a/include/gpufl/backends/nvidia/kernel_launch_handler.cpp
+++ b/include/gpufl/backends/nvidia/kernel_launch_handler.cpp
@@ -240,6 +240,41 @@ bool KernelLaunchHandler::handleActivityRecord(const CUpti_Activity* record,
     out.cache_config_executed = k->cacheConfig.config.executed;
     out.shared_mem_executed = k->sharedMemoryExecuted;
 
+    // stamp framework op id (PyTorch / TF / JAX / OPENACC) onto this
+    // kernel if the framework was actively pushing external correlation
+    // for this thread. Lookup is pop-on-read, so this also keeps the
+    // map from accumulating stale entries across long sessions.
+    //
+    // Diagnostic: track hit / miss counters so we can tell whether the
+    // F1 chain is broken at "no correlation records arrived" vs "they
+    // arrived but with mismatched corr_ids" vs "matching but ordering
+    // races (kernel processed before its correlation record)".
+    {
+        uint8_t  ext_kind = 0;
+        uint64_t ext_id   = 0;
+        const bool hit = LookupAndPopExternalCorrelation(
+            k->correlationId, &ext_kind, &ext_id);
+        if (hit) {
+            out.external_kind = ext_kind;
+            out.external_id   = ext_id;
+            static std::atomic<int> g_ec_hit{0};
+            const int n = g_ec_hit.fetch_add(1, std::memory_order_relaxed) + 1;
+            if (n <= 5 || n % 100 == 0) {
+                GFL_LOG_DEBUG(
+                    "[KernelHandler] external lookup HIT #", n,
+                    " corr=", k->correlationId, " ext_id=", ext_id);
+            }
+        } else {
+            static std::atomic<int> g_ec_miss{0};
+            const int n = g_ec_miss.fetch_add(1, std::memory_order_relaxed) + 1;
+            if (n <= 5 || n % 500 == 0) {
+                GFL_LOG_DEBUG(
+                    "[KernelHandler] external lookup MISS #", n,
+                    " corr=", k->correlationId);
+            }
+        }
+    }
+
     {
         const uint64_t corr = k->correlationId;
         out.corr_id = corr;

--- a/include/gpufl/core/activity_record.hpp
+++ b/include/gpufl/core/activity_record.hpp
@@ -41,6 +41,19 @@ struct ActivityRecord {
     int max_active_blocks = 0;
     unsigned int corr_id = 0;
 
+    // External-correlation stamp from CUPTI_ACTIVITY_KIND_EXTERNAL_CORRELATION.
+    // Populated in `KernelLaunchHandler::handleActivityRecord` by looking
+    // up the kernel's `corr_id` in the global external-correlation map
+    // (see g_extCorrMap in cupti_backend.cpp). external_id == 0 means no
+    // framework was tracking this kernel.
+    //
+    // CUpti_ExternalCorrelationKind values (from <cupti_activity.h>):
+    //   0 = INVALID, 1 = UNKNOWN, 2 = OPENACC, 3 = CUSTOM0..CUSTOM3,
+    //   8 = CUSTOM_RESERVED1, ... (frameworks pick one).
+    // We store as uint8_t to keep ActivityRecord small.
+    uint8_t  external_kind = 0;
+    uint64_t external_id = 0;
+
     char source_file[256]{};
     uint32_t source_line = 0;
     char function_name[256]{};
@@ -72,6 +85,50 @@ struct ActivityRecord {
     uint32_t copy_kind = 0;  // backend-specific memcpy kind
     uint32_t src_kind = 0;   // backend-specific memory kind
     uint32_t dst_kind = 0;   // backend-specific memory kind
+
+    // Graph-launch specific. graph_id is the CUPTI graphId field
+    // (uint32 unique id of the captured graph). Same graph re-launched
+    // multiple times in a training loop shares the same graph_id;
+    // backend can aggregate by it to surface "this graph launched 50x,
+    // total 4.2s" insights.
+    uint32_t graph_id = 0;
+
+    // Memory-allocation specific.
+    //
+    // memory_op: 1 = ALLOC, 2 = FREE. Mirrors CUpti_ActivityMemoryOperationType
+    // (we collapse the variants we don't surface in v1 — release-async
+    // and so on — into the two top-level buckets; the dashboard only
+    // distinguishes alloc-vs-free in its first iteration).
+    //
+    // memory_kind values mirror CUpti_ActivityMemoryKind:
+    //   0 = UNKNOWN, 1 = PAGEABLE_HOST, 2 = PINNED_HOST, 3 = DEVICE,
+    //   4 = ARRAY, 5 = MANAGED, 6 = DEVICE_STATIC, 7 = MANAGED_STATIC.
+    // Backend stores the raw integer; frontend maps to a label.
+    //
+    // address is the GPU virtual address (uint64) returned by cudaMalloc
+    // (or freed by cudaFree). Stored as uint64 because Blackwell-class
+    // addresses can be large; the dashboard renders it as 0x-prefixed
+    // hex.
+    uint8_t  memory_op = 0;
+    uint8_t  memory_kind = 0;
+    uint64_t address = 0;
+
+    // Synchronization-event specific.
+    //
+    // sync_type encodes which CUPTI synchronization variant fired —
+    // stored as uint8_t to keep ActivityRecord small. Values mirror
+    // CUpti_ActivitySynchronizationType (cupti_activity.h):
+    //   0 = UNKNOWN, 1 = EVENT_SYNCHRONIZE, 2 = STREAM_WAIT_EVENT,
+    //   3 = STREAM_SYNCHRONIZE, 4 = CONTEXT_SYNCHRONIZE.
+    // Mapping to user-readable names happens in SynchronizationEventModel
+    // — backend stores the integer, frontend renders the label.
+    //
+    // sync_event_id is the CUPTI eventId (cudaEvent_t handle) for
+    // EVENT_SYNCHRONIZE / STREAM_WAIT_EVENT records; zero for stream-
+    // and context-wide syncs. Useful for grouping back-to-back waits
+    // on the same event in the dashboard.
+    uint8_t  sync_type = 0;
+    uint32_t sync_event_id = 0;
 };
 
 }  // namespace gpufl

--- a/include/gpufl/core/config_file_loader.cpp
+++ b/include/gpufl/core/config_file_loader.cpp
@@ -40,6 +40,8 @@ void ConfigFileLoader::apply(InitOptions& opts, const std::string& path) {
         opts.enable_source_collection = cfg.value<bool>("enable_source_collection", opts.enable_source_collection);
     if (cfg.contains("enable_debug_output"))
         opts.enable_debug_output = cfg.value<bool>("enable_debug_output", opts.enable_debug_output);
+    if (cfg.contains("enable_external_correlation"))
+        opts.enable_external_correlation = cfg.value<bool>("enable_external_correlation", opts.enable_external_correlation);
 }
 
 }  // namespace gpufl

--- a/include/gpufl/core/events.hpp
+++ b/include/gpufl/core/events.hpp
@@ -131,6 +131,12 @@ struct KernelEvent {
     int scope_depth = 0;
 
     std::string stack_trace;
+
+    // External correlation stamped onto this kernel by the framework
+    // (PyTorch / TF / JAX). external_id == 0 means no framework tracked
+    // this launch; kernel_event_model.cpp omits the columns when zero.
+    uint8_t  external_kind = 0;
+    uint64_t external_id   = 0;
 };
 
 struct MemcpyEvent {
@@ -279,6 +285,15 @@ struct KernelBatchRow {
     int      dyn_shared  = 0;
     int      num_regs    = 0;
     uint8_t  has_details = 0;  // 1 → a kernel_detail event follows with same corr_id
+
+    // Framework-emitted external correlation, sourced from
+    // CUPTI_ACTIVITY_KIND_EXTERNAL_CORRELATION records. Stamped onto
+    // the kernel by KernelLaunchHandler::handleActivityRecord; ferried
+    // through the ActivityRecord into this row by CollectorLoop.
+    // external_id == 0 means "no framework was tracking this kernel"
+    // and the column is omitted from the JSON to keep the wire compact.
+    uint8_t  external_kind = 0;
+    uint64_t external_id   = 0;
 };
 
 struct KernelDetailRow {
@@ -412,4 +427,117 @@ struct NvtxMarkerEvent {
     int64_t duration_ns = 0;    // Redundant with end-start; kept for convenience
     uint32_t marker_id = 0;     // CUPTI marker ID (for debug / dedup)
 };
+
+/**
+ * One CUDA graph launch event captured by CUPTI's
+ * CUPTI_ACTIVITY_KIND_GRAPH_TRACE stream.
+ *
+ * `cudaGraphLaunch` is the launch mechanism torch.compile / CUDA
+ * Graphs / Triton-CUDA-graph-mode use to batch many kernels into a
+ * single host-side launch call, eliminating per-kernel overhead.
+ * This event tells the dashboard that a chunk of GPU work happened
+ * as a fused graph rather than as N independent kernel launches.
+ *
+ * Per-event JSON. Volume is very low — even an inference loop that
+ * launches a graph per request typically yields fewer events than
+ * any other CUPTI stream we capture. Channel::Scope
+ *
+ * `corr_id` matches the driver-API call that issued the launch
+ * (cuGraphLaunch). It does NOT match the per-node kernel records —
+ * each kernel inside the graph keeps its own correlationId. To pair
+ * "kernel K was part of graph G", the backend (or dashboard) needs
+ * a temporal join on [start_ns, end_ns] + same stream — that's
+ * deliberate v2 work, out of scope here.
+ */
+struct GraphLaunchEvent {
+    int pid = 0;
+    std::string app;
+    std::string session_id;
+    int64_t start_ns = 0;
+    int64_t end_ns = 0;
+    int64_t duration_ns = 0;
+    uint32_t graph_id = 0;
+    uint32_t device_id = 0;
+    uint32_t stream_id = 0;
+    uint32_t corr_id = 0;
+};
+
+/**
+ * One CUDA memory-management event captured by CUPTI's
+ * CUPTI_ACTIVITY_KIND_MEMORY2 stream.
+ *
+ * Covers cudaMalloc / cudaFree / cudaMallocAsync / cudaFreeAsync /
+ * cudaMallocManaged / cudaMallocHost (and their driver-API cousins).
+ * One event per call. Note that cudaMallocAsync is associated with a
+ * stream and the reported {@code start_ns} is the host call time
+ * (not the GPU completion time) — the host-side cost is what users
+ * actually pay for in their python/c++ code.
+ *
+ * Per-event JSON. Volume in PyTorch workloads is typically <1k events
+ * per session because torch's caching allocator absorbs most python-
+ * level allocations; only large-block CUDA-level mallocs reach this
+ * stream. TensorFlow eager mode is the high-volume edge case — if it
+ * becomes a problem the gating flag {@code enable_memory_tracking}
+ * lets users opt out without losing other CUPTI streams.
+ *
+ * The {@code address} field is the VA returned by cudaMalloc (or
+ * being freed by cudaFree). Pairing alloc → free across the session
+ * for leak / fragmentation analysis is a v2 follow-up; v1 just
+ * stores raw events.
+ */
+struct MemoryAllocEvent {
+    int pid = 0;
+    std::string app;
+    std::string session_id;
+    int64_t start_ns = 0;
+    int64_t duration_ns = 0;     // host-side; usually tiny but non-zero
+    uint8_t  memory_op = 0;       // 1 = ALLOC, 2 = FREE
+    uint8_t  memory_kind = 0;     // CUpti_ActivityMemoryKind
+    uint64_t address = 0;
+    uint64_t bytes = 0;
+    uint32_t device_id = 0;
+    uint32_t stream_id = 0;       // for cudaMallocAsync; 0 otherwise
+    uint32_t corr_id = 0;
+};
+
+/**
+ * CUDA synchronization event captured by CUPTI.
+ *
+ * One event per cudaStreamSynchronize / cudaDeviceSynchronize /
+ * cudaEventSynchronize / cuStreamWaitEvent call (and their driver-API
+ * cousins). The wall-clock duration here is the CPU-side time the
+ * thread was blocked — which is the exact metric that explains GPU
+ * underutilization on workloads that interleave host-side python with
+ * synchronous waits (PyTorch's `torch.cuda.synchronize()` between
+ * forward / backward; eager-mode TF; manual debugging code).
+ *
+ * Per-event JSON (not batched). Volume is hundreds-to-thousands per
+ * session in typical workloads — well within per-event capacity. If a
+ * user runs a stress test that produces millions of syncs, switching
+ * to a batched columnar format is a one-file change (mirrors the
+ * KernelEventBatch pattern).
+ *
+ * `sync_type` is the integer from CUPTI's CUpti_ActivitySynchronizationType
+ * enum; the dashboard renders it as a human label
+ * (EventSynchronize / StreamWaitEvent / StreamSynchronize / ContextSynchronize).
+ *
+ * `corr_id` joins to KernelEvent.corr_id, letting the dashboard
+ * answer questions like "this matmul kernel finished at T1; the
+ * `cudaStreamSynchronize` waiting for it returned at T2 — that
+ * (T2 - kernel_end) gap is host-side overhead, not GPU work."
+ */
+struct SynchronizationEvent {
+    int pid = 0;
+    std::string app;
+    std::string session_id;
+    int64_t start_ns = 0;
+    int64_t end_ns = 0;
+    int64_t duration_ns = 0;
+    uint8_t  sync_type = 0;       // CUpti_ActivitySynchronizationType
+    uint32_t stream_id = 0;       // 0 for context-wide / device sync
+    uint32_t event_id = 0;        // 0 for non-event syncs
+    uint32_t corr_id = 0;         // links to KernelEvent.corr_id
+    uint32_t context_id = 0;
+};
+
 }  // namespace gpufl

--- a/include/gpufl/core/gpufl.cpp
+++ b/include/gpufl/core/gpufl.cpp
@@ -344,6 +344,13 @@ bool init(const InitOptions& opts) {
     }
     mOpts.enable_stack_trace = g_opts.enable_stack_trace;
     mOpts.enable_source_collection = g_opts.enable_source_collection;
+    // Propagate the framework-correlation flag to the backend so
+    // CuptiBackend::start can decide whether to enable
+    // CUPTI_ACTIVITY_KIND_EXTERNAL_CORRELATION.
+    mOpts.enable_external_correlation = g_opts.enable_external_correlation;
+    mOpts.enable_synchronization      = g_opts.enable_synchronization;
+    mOpts.enable_memory_tracking      = g_opts.enable_memory_tracking;
+    mOpts.enable_cuda_graphs_tracking = g_opts.enable_cuda_graphs_tracking;
     mOpts.backend_kind = ToMonitorBackendKind(g_opts.backend);
 
     // Auto-tune kernel_sample_rate_ms on older NVIDIA GPUs where SASS metric

--- a/include/gpufl/core/model/batch_models.cpp
+++ b/include/gpufl/core/model/batch_models.cpp
@@ -14,13 +14,14 @@ std::string KernelEventBatchModel::buildJson() const {
     if (rows.empty()) return {};
     const int64_t base = rows.front().start_ns;
 
+    // external_kind / external_id added as trailing columns.
     std::ostringstream oss;
     oss << "{\"version\":1,\"type\":\"kernel_event_batch\""
         << ",\"session_id\":\"" << jsonEscape(session_id_) << '"'
         << ",\"batch_id\":" << batch_id_ << ",\"base_time_ns\":" << base
         << ",\"columns\":[\"dt_ns\",\"kernel_id\",\"stream_id\","
            "\"duration_ns\",\"corr_id\",\"dyn_shared\",\"num_regs\",\"has_"
-           "details\"]"
+           "details\",\"external_kind\",\"external_id\"]"
         << ",\"rows\":[";
 
     bool first = true;
@@ -30,7 +31,9 @@ std::string KernelEventBatchModel::buildJson() const {
         oss << '[' << (r.start_ns - base) << ',' << r.kernel_id << ','
             << r.stream_id << ',' << r.duration_ns << ',' << r.corr_id << ','
             << r.dyn_shared << ',' << r.num_regs << ','
-            << static_cast<int>(r.has_details) << ']';
+            << static_cast<int>(r.has_details) << ','
+            << static_cast<int>(r.external_kind) << ','
+            << r.external_id << ']';
     }
     oss << "]}";
     return oss.str();
@@ -222,8 +225,8 @@ std::string HostMetricBatchModel::buildJson() const {
     // important when the agent runs on a different machine than the
     // workload (sidecar / centralized collector). Per-row replication
     // would waste bytes; the value is constant for a session.
-    const std::string hostname = gpufl::getLocalHostname();
-    const std::string ipAddr   = gpufl::getLocalIpAddr();
+    const std::string hostname = getLocalHostname();
+    const std::string ipAddr   = getLocalIpAddr();
 
     std::ostringstream oss;
     oss << "{\"version\":1,\"type\":\"host_metric_batch\""

--- a/include/gpufl/core/model/graph_launch_event_model.cpp
+++ b/include/gpufl/core/model/graph_launch_event_model.cpp
@@ -1,0 +1,37 @@
+#include "gpufl/core/model/graph_launch_event_model.hpp"
+
+#include <sstream>
+
+#include "gpufl/core/model/model_utils.hpp"
+
+namespace gpufl::model {
+
+std::string GraphLaunchEventModel::buildJson() const {
+    // Field set:
+    //   pid, app, session_id   — universal envelope
+    //   start_ns / end_ns      — wall-clock launch window; both 0 when
+    //                            CUPTI couldn't collect timing (the
+    //                            graph_id is still useful in that case)
+    //   duration_ns            — derived; kept for backend convenience
+    //   graph_id               — unique id of the captured graph;
+    //                            repeated launches share an id
+    //   device_id, stream_id   — context fields
+    //   corr_id                — joins to the driver-API record that
+    //                            triggered the launch (cuGraphLaunch)
+    std::ostringstream oss;
+    oss << "{\"type\":\"graph_launch_event\""
+        << ",\"pid\":"          << e_.pid
+        << ",\"app\":\""        << jsonEscape(e_.app)        << "\""
+        << ",\"session_id\":\"" << jsonEscape(e_.session_id) << "\""
+        << ",\"start_ns\":"     << e_.start_ns
+        << ",\"end_ns\":"       << e_.end_ns
+        << ",\"duration_ns\":"  << e_.duration_ns
+        << ",\"graph_id\":"     << e_.graph_id
+        << ",\"device_id\":"    << e_.device_id
+        << ",\"stream_id\":"    << e_.stream_id
+        << ",\"corr_id\":"      << e_.corr_id
+        << "}";
+    return oss.str();
+}
+
+}  // namespace gpufl::model

--- a/include/gpufl/core/model/graph_launch_event_model.hpp
+++ b/include/gpufl/core/model/graph_launch_event_model.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "gpufl/core/events.hpp"
+#include "gpufl/core/model/serializable.hpp"
+
+namespace gpufl::model {
+
+/**
+ * JSON serializer for GraphLaunchEvent.
+ *
+ * Per-event JSON, Scope channel — low volume,
+ * scope-like timing. Wire shape mirrors the memory event pattern
+ * intentionally so the Java backend can dispatch on `"type"` cheaply.
+ */
+struct GraphLaunchEventModel final : IJsonSerializable {
+    explicit GraphLaunchEventModel(const GraphLaunchEvent& e) : e_(e) {}
+    std::string buildJson() const override;
+    Channel channel() const override { return Channel::Scope; }
+private:
+    const GraphLaunchEvent& e_;
+};
+
+}  // namespace gpufl::model

--- a/include/gpufl/core/model/kernel_event_model.cpp
+++ b/include/gpufl/core/model/kernel_event_model.cpp
@@ -44,8 +44,15 @@ std::string KernelEventModel::buildJson() const {
         << ",\"local_mem_per_thread_bytes\":" << e_.local_mem_per_thread
         << ",\"cache_config_requested\":"  << static_cast<int>(e_.cache_config_requested)
         << ",\"cache_config_executed\":"   << static_cast<int>(e_.cache_config_executed)
-        << ",\"shared_mem_executed_bytes\":" << e_.shared_mem_executed
-        << "}";
+        << ",\"shared_mem_executed_bytes\":" << e_.shared_mem_executed;
+    // only emit external_* when present; keeps the JSON small for the
+    // common no-framework case and is wire-compatible (the backend treats
+    // missing fields as null/0).
+    if (e_.external_id != 0) {
+        oss << ",\"external_kind\":" << static_cast<int>(e_.external_kind)
+            << ",\"external_id\":"   << e_.external_id;
+    }
+    oss << "}";
     return oss.str();
 }
 

--- a/include/gpufl/core/model/memory_alloc_event_model.cpp
+++ b/include/gpufl/core/model/memory_alloc_event_model.cpp
@@ -1,0 +1,42 @@
+#include "gpufl/core/model/memory_alloc_event_model.hpp"
+
+#include <sstream>
+
+#include "gpufl/core/model/model_utils.hpp"
+
+namespace gpufl::model {
+
+std::string MemoryAllocEventModel::buildJson() const {
+    // Field set:
+    //   pid, app, session_id  — universal envelope
+    //   start_ns / duration_ns — host call timestamp; duration is 0
+    //                            in v1 because CUpti_ActivityMemory4
+    //                            carries no end timestamp
+    //   memory_op, memory_kind — both stored as integers (uint8 on
+    //                            the wire); frontend renders human
+    //                            labels via lookup tables
+    //   address, bytes         — VA + size of the allocation
+    //   device_id, stream_id   — context fields; stream_id is set
+    //                            for cudaMallocAsync, 0 otherwise
+    //   corr_id                — joins to the matching API record
+    //                            (we don't surface this in v1 but
+    //                            it's there for future leak-pairing)
+    std::ostringstream oss;
+    oss << "{\"type\":\"memory_alloc_event\""
+        << ",\"pid\":"          << e_.pid
+        << ",\"app\":\""        << jsonEscape(e_.app)        << "\""
+        << ",\"session_id\":\"" << jsonEscape(e_.session_id) << "\""
+        << ",\"start_ns\":"     << e_.start_ns
+        << ",\"duration_ns\":"  << e_.duration_ns
+        << ",\"memory_op\":"    << static_cast<int>(e_.memory_op)
+        << ",\"memory_kind\":"  << static_cast<int>(e_.memory_kind)
+        << ",\"address\":"      << e_.address
+        << ",\"bytes\":"        << e_.bytes
+        << ",\"device_id\":"    << e_.device_id
+        << ",\"stream_id\":"    << e_.stream_id
+        << ",\"corr_id\":"      << e_.corr_id
+        << "}";
+    return oss.str();
+}
+
+}  // namespace gpufl::model

--- a/include/gpufl/core/model/memory_alloc_event_model.hpp
+++ b/include/gpufl/core/model/memory_alloc_event_model.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include "gpufl/core/events.hpp"
+#include "gpufl/core/model/serializable.hpp"
+
+namespace gpufl::model {
+
+/**
+ * JSON serializer for MemoryAllocEvent.
+ *
+ * Per-event JSON, Scope channel — same rationale as the sync event
+ * model: mid-volume, semantically scope-like (a discrete event on the
+ * timeline), and reusing an existing channel keeps the backend
+ * ingestor's subscription set small.
+ *
+ * Wire shape mirrors SynchronizationEventModel intentionally so the
+ * Java backend can dispatch on `"type"` cheaply — see
+ * "memory_alloc_event" handler.
+ */
+struct MemoryAllocEventModel final : IJsonSerializable {
+    explicit MemoryAllocEventModel(const MemoryAllocEvent& e) : e_(e) {}
+    std::string buildJson() const override;
+    Channel channel() const override { return Channel::Scope; }
+private:
+    const MemoryAllocEvent& e_;
+};
+
+}  // namespace gpufl::model

--- a/include/gpufl/core/model/synchronization_event_model.cpp
+++ b/include/gpufl/core/model/synchronization_event_model.cpp
@@ -1,0 +1,37 @@
+#include "gpufl/core/model/synchronization_event_model.hpp"
+
+#include <sstream>
+
+#include "gpufl/core/model/model_utils.hpp"
+
+namespace gpufl::model {
+
+std::string SynchronizationEventModel::buildJson() const {
+    // Field set, in order:
+    //   pid, app, session_id  — universal envelope
+    //   start_ns / end_ns     — wall clock; backend partitions on time
+    //   duration_ns           — keep redundant copy (mirrors NvtxMarkerModel)
+    //   sync_type             — integer; backend stores raw, frontend
+    //                           maps to label (StreamSynchronize / etc.)
+    //   stream_id, event_id, context_id, corr_id — join keys
+    //
+    // Numeric-only fields use no quotes; strings are escaped via
+    // jsonEscape (handles backslashes / quotes / control chars).
+    std::ostringstream oss;
+    oss << "{\"type\":\"synchronization_event\""
+        << ",\"pid\":"          << e_.pid
+        << ",\"app\":\""        << jsonEscape(e_.app)        << "\""
+        << ",\"session_id\":\"" << jsonEscape(e_.session_id) << "\""
+        << ",\"start_ns\":"     << e_.start_ns
+        << ",\"end_ns\":"       << e_.end_ns
+        << ",\"duration_ns\":"  << e_.duration_ns
+        << ",\"sync_type\":"    << static_cast<int>(e_.sync_type)
+        << ",\"stream_id\":"    << e_.stream_id
+        << ",\"event_id\":"     << e_.event_id
+        << ",\"context_id\":"   << e_.context_id
+        << ",\"corr_id\":"      << e_.corr_id
+        << "}";
+    return oss.str();
+}
+
+}  // namespace gpufl::model

--- a/include/gpufl/core/model/synchronization_event_model.hpp
+++ b/include/gpufl/core/model/synchronization_event_model.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "gpufl/core/events.hpp"
+#include "gpufl/core/model/serializable.hpp"
+
+namespace gpufl::model {
+
+/**
+ * JSON serializer for SynchronizationEvent.
+ *
+ * Emitted to the Scope channel for the same reasons NvtxMarkerModel
+ * uses it: synchronizations are semantically scope-like (named region
+ * with start/end), arrive at mid volume (hundreds-to-thousands per
+ * session), and a downstream backend ingestor that's already consuming
+ * the Scope NDJSON file gets sync events for free without a new
+ * channel subscription.
+ *
+ * The wire shape is intentionally close to NvtxMarkerModel's so the
+ * Java backend's BatchIngestionServiceImpl can dispatch on `"type"`
+ * cheaply — see "synchronization_event" handler.
+ */
+struct SynchronizationEventModel final : IJsonSerializable {
+    explicit SynchronizationEventModel(const SynchronizationEvent& e) : e_(e) {}
+    std::string buildJson() const override;
+    Channel channel() const override { return Channel::Scope; }
+private:
+    const SynchronizationEvent& e_;
+};
+
+}  // namespace gpufl::model

--- a/include/gpufl/core/monitor.cpp
+++ b/include/gpufl/core/monitor.cpp
@@ -17,6 +17,9 @@
 #include "gpufl/core/model/batch_models.hpp"
 #include "gpufl/core/model/memcpy_event_model.hpp"
 #include "gpufl/core/model/nvtx_marker_model.hpp"
+#include "gpufl/core/model/synchronization_event_model.hpp"
+#include "gpufl/core/model/memory_alloc_event_model.hpp"
+#include "gpufl/core/model/graph_launch_event_model.hpp"
 #include "gpufl/core/monitor_adapter.hpp"
 #include "gpufl/core/ring_buffer.hpp"
 #include "gpufl/core/runtime.hpp"
@@ -144,6 +147,10 @@ void CollectorLoop() {
                 row.dyn_shared  = rec.dyn_shared;
                 row.num_regs    = rec.num_regs;
                 row.has_details = rec.has_details ? 1 : 0;
+                // Pre-stamped by KernelLaunchHandler; both fields are
+                // 0 when no framework was tracking this launch.
+                row.external_kind = rec.external_kind;
+                row.external_id   = rec.external_id;
                 g_kernelBatch.push(row);
 
                 if (rec.has_details) {
@@ -316,6 +323,61 @@ void CollectorLoop() {
             ev.duration_ns = duration_ns;
             ev.marker_id   = rec.corr_id;
             rt->logger->write(model::NvtxMarkerModel(ev));
+        } else if (rec.type == TraceType::GRAPH_LAUNCH) {
+            // cudaGraphLaunch with aggregate timing. Emit per-event;
+            // volume is so low (tens to low hundreds per session) that
+            // batching would be pointless overhead.
+            GraphLaunchEvent ev;
+            ev.pid          = detail::GetPid();
+            ev.app          = rt->app_name;
+            ev.session_id   = rt->session_id;
+            ev.start_ns     = rec.cpu_start_ns;
+            ev.end_ns       = rec.cpu_start_ns + duration_ns;
+            ev.duration_ns  = duration_ns;
+            ev.graph_id     = rec.graph_id;
+            ev.device_id    = rec.device_id;
+            ev.stream_id    = static_cast<uint32_t>(rec.stream);
+            ev.corr_id      = rec.corr_id;
+            rt->logger->write(model::GraphLaunchEventModel(ev));
+        } else if (rec.type == TraceType::MEMORY_ALLOC) {
+            // cudaMalloc / cudaFree / cudaMallocAsync / etc.
+            // Per-event emission, Scope channel. Mirrors the F2 sync
+            // path structurally — same translation pattern from
+            // ActivityRecord onto the public event struct.
+            MemoryAllocEvent ev;
+            ev.pid          = detail::GetPid();
+            ev.app          = rt->app_name;
+            ev.session_id   = rt->session_id;
+            ev.start_ns     = rec.cpu_start_ns;
+            ev.duration_ns  = duration_ns;       // 0 in v1
+            ev.memory_op    = rec.memory_op;
+            ev.memory_kind  = rec.memory_kind;
+            ev.address      = rec.address;
+            ev.bytes        = rec.bytes;
+            ev.device_id    = rec.device_id;
+            ev.stream_id    = static_cast<uint32_t>(rec.stream);
+            ev.corr_id      = rec.corr_id;
+            rt->logger->write(model::MemoryAllocEventModel(ev));
+        } else if (rec.type == TraceType::SYNCHRONIZATION) {
+            // cudaStreamSynchronize / cudaDeviceSynchronize / etc.
+            // Mirrors the NVTX path above structurally — same per-event
+            // emission, same Scope channel. The CUPTI fields were
+            // stashed onto ActivityRecord by the BufferCompleted
+            // handler in cupti_backend.cpp; we just translate them
+            // into the public event struct.
+            SynchronizationEvent ev;
+            ev.pid          = detail::GetPid();
+            ev.app          = rt->app_name;
+            ev.session_id   = rt->session_id;
+            ev.start_ns     = rec.cpu_start_ns;
+            ev.end_ns       = rec.cpu_start_ns + duration_ns;
+            ev.duration_ns  = duration_ns;
+            ev.sync_type    = rec.sync_type;
+            ev.stream_id    = static_cast<uint32_t>(rec.stream);
+            ev.event_id     = rec.sync_event_id;
+            ev.context_id   = static_cast<uint32_t>(rec.scope_depth);
+            ev.corr_id      = rec.corr_id;
+            rt->logger->write(model::SynchronizationEventModel(ev));
         }
 
         return true;

--- a/include/gpufl/core/monitor.hpp
+++ b/include/gpufl/core/monitor.hpp
@@ -57,6 +57,21 @@ struct MonitorOptions {
     bool enable_debug_output = false;
     bool enable_stack_trace = false;
     bool enable_source_collection = true;
+    // Gate for CUPTI_ACTIVITY_KIND_EXTERNAL_CORRELATION. Mirror of
+    // InitOptions::enable_external_correlation; copied across in the
+    // gpufl::init() → CuptiBackend::initialize() conversion path.
+    bool enable_external_correlation = true;
+    // Gate for CUPTI_ACTIVITY_KIND_SYNCHRONIZATION. Mirror of
+    // InitOptions::enable_synchronization. Backend honors this in
+    // CuptiBackend::start() — flag false means we never call
+    // cuptiActivityEnable for the kind, so zero overhead.
+    bool enable_synchronization = true;
+    // Gate for CUPTI_ACTIVITY_KIND_MEMORY2. Mirror of
+    // InitOptions::enable_memory_tracking. Default-off in v1.
+    bool enable_memory_tracking = false;
+    // Gate for CUPTI_ACTIVITY_KIND_GRAPH_TRACE. Mirror of
+    // InitOptions::enable_cuda_graphs_tracking. Default-off in v1.
+    bool enable_cuda_graphs_tracking = false;
     int kernel_sample_rate_ms = 0;
     uint32_t pc_sampling_period = 12;  // log2 exponent: 2^N GPU cycles between samples (valid: 5-31; 12 = 4096 cycles)
     ProfilingEngine profiling_engine = ProfilingEngine::None;

--- a/include/gpufl/core/remote_config.cpp
+++ b/include/gpufl/core/remote_config.cpp
@@ -120,6 +120,9 @@ void applyRemoteConfigToOpts(const json::JsonValue& cfg, InitOptions& opts) {
     updateIfPresent("flush_logs_always", [&](const json::JsonValue& v) {
         if (v.is_bool()) opts.flush_logs_always = v.get_bool();
     });
+    updateIfPresent("enable_external_correlation", [&](const json::JsonValue& v) {
+        if (v.is_bool()) opts.enable_external_correlation = v.get_bool();
+    });
 }
 
 }  // namespace

--- a/include/gpufl/core/trace_type.hpp
+++ b/include/gpufl/core/trace_type.hpp
@@ -13,5 +13,77 @@ enum class TraceType : uint8_t {
     // ActivityRecord: name (range name), cpu_start_ns, duration_ns.
     // Emitted as `nvtx_marker_event` in the NDJSON log.
     NVTX_MARKER,
+    // Framework-emitted external correlation. Captured via
+    // CUPTI_ACTIVITY_KIND_EXTERNAL_CORRELATION; produced when a framework
+    // (PyTorch / TF / JAX / XLA) brackets a code region with
+    // cuptiActivityPushExternalCorrelationId / Pop. The record carries
+    // the framework's op id + the CUPTI correlationId of the kernel(s)
+    // launched inside that bracket. We DO NOT emit this as its own
+    // NDJSON event — instead the (kind, id) is stamped onto the
+    // matching kernel's ActivityRecord in BufferCompleted, and rides
+    // along inside the existing `kernel_event_batch`. This trace type
+    // exists so the dispatch loop has somewhere to file the record
+    // type-wise even though it never reaches CollectorLoop.
+    EXTERNAL_CORRELATION,
+    // CUDA synchronization event captured via
+    // CUPTI_ACTIVITY_KIND_SYNCHRONIZATION. One record per
+    // cudaStreamSynchronize / cudaDeviceSynchronize / cudaEventSynchronize
+    // / cuEventRecord / cuStreamWaitEvent. Volume is mid-scale —
+    // hundreds-to-thousands per session, never the millions kernels
+    // produce — so we emit per-event JSON (no batching).
+    //
+    // Fields used on ActivityRecord:
+    //   cpu_start_ns  — sync wall start
+    //   duration_ns   — wall duration of the sync op
+    //   corr_id       — CUPTI correlationId, links to the kernel(s) the
+    //                   sync was waiting on
+    //   stream        — CUpti_ActivitySynchronization::streamId
+    //   sync_type     — kind of sync (stream / device / event-record /
+    //                   event-wait); see ActivityRecord::sync_type
+    //   sync_event_id — for event-based syncs; 0 for stream/device
+    SYNCHRONIZATION,
+    // CUDA memory allocation event captured via
+    // CUPTI_ACTIVITY_KIND_MEMORY2. One record per cudaMalloc / cudaFree
+    // / cudaMallocAsync / cudaFreeAsync / cudaMallocManaged / cudaMallocHost.
+    // Volume per session is mid-low (typically <1k events even for big
+    // workloads — PyTorch's caching allocator absorbs most fine-grained
+    // allocations into a few large CUDA-level blocks), so we emit per-event
+    // JSON (no batching).
+    //
+    // Fields used on ActivityRecord:
+    //   cpu_start_ns  — host call wall time
+    //   bytes         — size of the allocation
+    //   device_id     — target device (0 for host allocs)
+    //   corr_id       — CUPTI correlationId, useful for joining to the
+    //                   API call that triggered the alloc
+    //   stream        — stream id for cudaMallocAsync; 0 otherwise
+    //   memory_op     — alloc / free (uint8_t enum)
+    //   memory_kind   — device / host / managed / pinned (uint8_t enum)
+    //   address       — VA address of the allocation; for free, the
+    //                   address being freed (lets us pair alloc/free
+    //                   in a future v2 backend pass)
+    MEMORY_ALLOC,
+    // F4: CUDA graph launch event captured via
+    // CUPTI_ACTIVITY_KIND_GRAPH_TRACE. One record per cudaGraphLaunch
+    // call; CUPTI returns aggregate timing for the whole graph rather
+    // than per-node, which is the point — graphs are *the* mechanism
+    // CUDA uses to amortize launch overhead, so per-node tracing is
+    // antithetical to their purpose.
+    //
+    // Volume per session is **very low** (typically tens to hundreds
+    // even for a heavy training loop, since each graph captures many
+    // kernels into one launch). Per-event JSON is fine.
+    //
+    // Fields used on ActivityRecord:
+    //   cpu_start_ns  — graph execution start (wall clock)
+    //   duration_ns   — end - start; 0 if CUPTI couldn't collect timing
+    //   device_id     — device where the first node executes
+    //   stream        — stream on which the graph was launched
+    //   corr_id       — CUPTI correlationId; matches the driver API
+    //                   record (cuGraphLaunch) but NOT the per-node
+    //                   kernel records — those keep their own ids
+    //   graph_id      — unique id of the graph (so repeated launches
+    //                   of the same compiled graph share an id)
+    GRAPH_LAUNCH,
 };
 }

--- a/include/gpufl/gpufl.hpp
+++ b/include/gpufl/gpufl.hpp
@@ -23,6 +23,48 @@ struct InitOptions {
     bool enable_stack_trace = false;
     bool enable_source_collection = true;  // collect source file content for source/SASS correlation
     bool flush_logs_always = false;
+    // Enable CUPTI_ACTIVITY_KIND_EXTERNAL_CORRELATION so frameworks
+    // (PyTorch's torch.profiler, TF's profile.trace, JAX, XLA) that
+    // bracket their ops with cuptiActivityPushExternalCorrelationId can
+    // tag every kernel with their op id. When the framework isn't
+    // pushing, CUPTI emits zero records — no overhead. Default-on
+    // because it's both useful and free in the absence of frameworks;
+    // disable only if running on a CUPTI version that errors on the
+    // kind (logs a soft-warning if so, doesn't crash).
+    bool enable_external_correlation = true;
+    // Enable CUPTI_ACTIVITY_KIND_SYNCHRONIZATION so that every
+    // cudaStreamSynchronize / cudaDeviceSynchronize / cudaEventSynchronize
+    // / cuStreamWaitEvent call gets a wall-clock timed record. The
+    // primary insight: time spent here = host blocked on GPU = a
+    // direct measure of GPU underutilization. Default-on because the
+    // overhead is small (one record per sync call, mid volume) and
+    // the answer it unlocks ("X% of your wall time is `cudaStreamSync`")
+    // is a top-five most-asked question. If a workload performs
+    // millions of synchronizations and the volume becomes a problem,
+    // disable this flag — the rest of the pipeline keeps working.
+    bool enable_synchronization = true;
+    // Enable CUPTI_ACTIVITY_KIND_MEMORY2 to capture cudaMalloc /
+    // cudaFree / cudaMallocAsync / cudaMallocManaged / cudaMallocHost
+    // with timing, address, size, and kind. **Default-off** in v1
+    // because TensorFlow eager mode and similar can produce a high
+    // record rate, and we want a couple of internal sessions to
+    // validate overhead before flipping it on by default. PyTorch
+    // workloads with the caching allocator typically generate <1k
+    // events per session, so it's safe to enable manually for those
+    // (and that's why we surface the toggle prominently rather than
+    // burying it in a config file).
+    bool enable_memory_tracking = false;
+    // Enable CUPTI_ACTIVITY_KIND_GRAPH_TRACE to capture per-launch
+    // timing for cudaGraphLaunch calls. **Default-off** in v1 because
+    // CUDA Graphs interact with PC Sampling on some Blackwell driver
+    // builds (graph launch can reset the sampling buffer). Opt-in
+    // until we've validated on a couple of internal sessions; will
+    // flip to default-on in a follow-up release.
+    //
+    // Cost when off: zero — we never call cuptiActivityEnable for
+    // the kind. Cost when on: one record per cudaGraphLaunch (very
+    // low volume).
+    bool enable_cuda_graphs_tracking = false;
     // Default: PC Sampling alone. The cubin-disassembly pipeline
     // (ResourceHandler + nvdisasm) already provides SASS listings and
     // source correlation, so PC Sampling gives users the full SASS view
@@ -112,6 +154,20 @@ BackendProbeResult probeRocm();
 
 void systemStart(std::string name = "system");
 void systemStop(std::string name = "system");
+
+// F1 (External Correlation) — active push/pop for callers that want to
+// tag CUDA work with an op id WITHOUT relying on a framework profiler
+// being active. Used by `gpufl.torch.attach()` to stamp every aten
+// dispatch's kernels with a stable id derived from the op name.
+//
+// `kind` follows CUPTI's CUpti_ExternalCorrelationKind enum:
+//   1 = UNKNOWN, 2 = OPENACC, 3 = CUSTOM0 (used by torch.profiler),
+//   4 = CUSTOM1 (used by gpufl.torch.attach), 5 = CUSTOM2.
+//
+// Calls are no-ops on non-CUPTI platforms (AMD ROCm, CPU-only fallback)
+// — safe to call from cross-platform code.
+void pushExternalCorrelation(uint32_t kind, uint64_t id);
+void popExternalCorrelation(uint32_t kind);
 
 // Start global runtime. Returns true on success.
 bool init(const InitOptions& opts);

--- a/python/bindings.cpp
+++ b/python/bindings.cpp
@@ -55,6 +55,12 @@ PYBIND11_MODULE(_gpufl_client, m) {
         .def_readwrite("enable_debug_output",   &gpufl::InitOptions::enable_debug_output)
         .def_readwrite("enable_stack_trace",    &gpufl::InitOptions::enable_stack_trace)
         .def_readwrite("enable_source_collection", &gpufl::InitOptions::enable_source_collection)
+        // feature gates — surfaced on the InitOptions class so
+        // power users can tweak them via the dataclass-style API.
+        .def_readwrite("enable_external_correlation", &gpufl::InitOptions::enable_external_correlation)
+        .def_readwrite("enable_synchronization",      &gpufl::InitOptions::enable_synchronization)
+        .def_readwrite("enable_memory_tracking",      &gpufl::InitOptions::enable_memory_tracking)
+        .def_readwrite("enable_cuda_graphs_tracking", &gpufl::InitOptions::enable_cuda_graphs_tracking)
         .def_readwrite("profiling_engine",      &gpufl::InitOptions::profiling_engine)
         // Backend interactions — see InitOptions.backend_url / config_name
         // / api_key / remote_upload docs for precedence and semantics.
@@ -86,7 +92,16 @@ PYBIND11_MODULE(_gpufl_client, m) {
                      std::string backend_url,
                      std::string api_key,
                      std::string config_name,
-                     bool remote_upload) -> bool {
+                     bool remote_upload,
+                     // Defaults match
+                     // InitOptions::*; surface them here so the
+                     // function-style init() call stays the canonical
+                     // way users twiddle these without falling back to
+                     // the InitOptions object.
+                     bool enable_external_correlation,
+                     bool enable_synchronization,
+                     bool enable_memory_tracking,
+                     bool enable_cuda_graphs_tracking) -> bool {
 
         gpufl::InitOptions opts;
         opts.app_name              = app_name;
@@ -104,6 +119,10 @@ PYBIND11_MODULE(_gpufl_client, m) {
         opts.api_key                 = std::move(api_key);
         opts.config_name             = std::move(config_name);
         opts.remote_upload           = remote_upload;
+        opts.enable_external_correlation = enable_external_correlation;
+        opts.enable_synchronization      = enable_synchronization;
+        opts.enable_memory_tracking      = enable_memory_tracking;
+        opts.enable_cuda_graphs_tracking = enable_cuda_graphs_tracking;
 
         // If caller explicitly set profiling_engine, use it; otherwise derive
         // from the legacy bool flags for backward compatibility.
@@ -140,7 +159,11 @@ PYBIND11_MODULE(_gpufl_client, m) {
        py::arg("backend_url")              = "",
        py::arg("api_key")                  = "",
        py::arg("config_name")              = "",
-       py::arg("remote_upload")            = false);
+       py::arg("remote_upload")            = false,
+       py::arg("enable_external_correlation") = true,
+       py::arg("enable_synchronization")      = true,
+       py::arg("enable_memory_tracking")      = false,
+       py::arg("enable_cuda_graphs_tracking") = false);
 
     m.def("system_start", [](std::string name) { gpufl::systemStart(std::move(name)); },
         py::arg("name") = "system");
@@ -149,6 +172,26 @@ PYBIND11_MODULE(_gpufl_client, m) {
         py::arg("name") = "system");
 
     m.def("shutdown", &gpufl::shutdown);
+
+    // F1 (External Correlation) active push/pop. Used by
+    // gpufl.torch.attach()'s TorchDispatchMode to tag every aten op's
+    // kernels with a stable id derived from the op name — gives the
+    // dashboard's "op #N" chip without requiring users to enable
+    // torch.profiler.profile() (which is heavy and intended for
+    // one-off trace export, not always-on telemetry).
+    //
+    // We expose with a leading underscore to signal "internal API
+    // for the gpufl.torch package, not a stable user-facing surface."
+    m.def("_push_external_corr_id",
+          [](uint32_t kind, uint64_t id) {
+              gpufl::pushExternalCorrelation(kind, id);
+          },
+          py::arg("kind"), py::arg("id"));
+    m.def("_pop_external_corr_id",
+          [](uint32_t kind) {
+              gpufl::popExternalCorrelation(kind);
+          },
+          py::arg("kind"));
 
     // --------------------------
 

--- a/python/gpufl/torch/dispatch.py
+++ b/python/gpufl/torch/dispatch.py
@@ -43,6 +43,66 @@ class _GpuflDispatchMode:
         except ImportError as e:
             raise RuntimeError(_TORCH_IMPORT_ERROR_MESSAGE) from e
 
+        # Lazy-bind the push/pop. `_gpufl_client` is the C++ extension;
+        # if it's not available (no-GPU stub install) or it's an older
+        # build that predates bindings, we fall back to no-op lambdas
+        # so the dispatch hook still runs — but we WARN loudly because
+        # this almost always means the user forgot to reinstall the
+        # extension after pulling the changes, and silently degrading
+        # to "no chips" is the worst possible UX.
+        try:
+            from gpufl._gpufl_client import (
+                _push_external_corr_id as _push_ext,
+                _pop_external_corr_id  as _pop_ext,
+            )
+        except ImportError as e:
+            import warnings
+            warnings.warn(
+                "[gpufl.torch] CUPTI external-correlation bindings not found "
+                f"in the loaded gpufl extension ({e}). The dashboard's 'op #N' "
+                "chips on kernel rows will be absent until you rebuild + "
+                "reinstall the gpufl Python extension "
+                "(typically: `pip install . --force-reinstall --no-cache-dir`). "
+                "NVTX-based attribution is unaffected and continues to work.",
+                RuntimeWarning,
+                stacklevel=2,
+            )
+            def _push_ext(kind, id_):  # type: ignore
+                pass
+            def _pop_ext(kind):        # type: ignore
+                pass
+
+        # CUpti_ExternalCorrelationKind values (from <cupti_activity.h>):
+        #   1 = UNKNOWN, 2 = OPENACC, 3 = CUSTOM0 (used by torch.profiler),
+        #   4 = CUSTOM1 (we reserve this for gpufl), 5 = CUSTOM2.
+        # Picking CUSTOM1 keeps us out of conflict if torch.profiler is
+        # also active in the same process (each kind has its own stack).
+        _GPUFL_CORR_KIND = 4
+
+        # Per-process op-name → 64-bit id table. The id is what the
+        # dashboard's KernelTable surfaces in its "op #N" chip; making
+        # it a stable hash of the op name means every `aten::matmul`
+        # call across the session shares the same N, which is the
+        # property users want when grouping kernels by op.
+        _op_id_cache: dict[str, int] = {}
+        def _op_id_for(name: str) -> int:
+            cached = _op_id_cache.get(name)
+            if cached is not None:
+                return cached
+            # FNV-1a 64-bit. Stable across runs, no cryptographic claim;
+            # collision risk for our op-name space is effectively zero.
+            h = 0xcbf29ce484222325
+            for b in name.encode("utf-8"):
+                h ^= b
+                h = (h * 0x100000001b3) & 0xFFFFFFFFFFFFFFFF
+            # Avoid 0 — that's the "no attribution" sentinel in the
+            # backend / dashboard. If the hash hits 0 (vanishingly
+            # unlikely), nudge to 1.
+            if h == 0:
+                h = 1
+            _op_id_cache[name] = h
+            return h
+
         class GpuflDispatchMode(TorchDispatchMode):
             def __torch_dispatch__(self, func, types, args=(), kwargs=None):
                 # Skip meta tensors / fake tensors — they don't launch
@@ -63,11 +123,22 @@ class _GpuflDispatchMode:
                 range_name = (f"torch::{op_name}@{site}"
                               if site is not None else f"torch::{op_name}")
 
+                # push a CUPTI external-correlation id derived from
+                # the op name BEFORE the dispatch runs. Every CUDA kernel
+                # launched inside this op (most aten ops launch one or
+                # more kernels) will be tagged with this id, surfacing
+                # in the dashboard as the "op #N" chip on each kernel
+                # row. We push the same id we use for the NVTX label,
+                # so the two attribution mechanisms agree.
+                op_id = _op_id_for(op_name)
+                _push_ext(_GPUFL_CORR_KIND, op_id)
+
                 nvtx.range_push(range_name)
                 try:
                     return func(*args, **kwargs)
                 finally:
                     nvtx.range_pop()
+                    _pop_ext(_GPUFL_CORR_KIND)
 
         return GpuflDispatchMode
 

--- a/tests/core/test_batch_models.cpp
+++ b/tests/core/test_batch_models.cpp
@@ -2,6 +2,9 @@
 
 #include "gpufl/core/events.hpp"
 #include "gpufl/core/model/batch_models.hpp"
+#include "gpufl/core/model/synchronization_event_model.hpp"
+#include "gpufl/core/model/memory_alloc_event_model.hpp"
+#include "gpufl/core/model/graph_launch_event_model.hpp"
 
 TEST(BatchModels, DeviceMetricBatchIncludesClockSm) {
     gpufl::BatchBuffer<gpufl::DeviceMetricBatchRow> batch;
@@ -46,4 +49,96 @@ TEST(BatchModels, DeviceMetricBatchIncludesExtendedColumnsWhenPresent) {
     EXPECT_NE(json.find("\"clock_mem\""), std::string::npos);
     EXPECT_NE(json.find("[0,0,77,33,70,150000,2048,0,1987,42,0,0,0,0,1200,0,0,0]"),
               std::string::npos);
+}
+
+// SynchronizationEventModel emits the wire shape the Java backend
+// dispatches on. This snapshot test pins the JSON layout so a future
+// edit (e.g. accidentally renaming "sync_type" → "type") trips the
+// build before it trips an end-to-end test.
+TEST(BatchModels, SynchronizationEventModelEmitsExpectedShape) {
+    gpufl::SynchronizationEvent ev;
+    ev.pid = 1234;
+    ev.app = "Heavy_Stress_App";
+    ev.session_id = "abc-123";
+    ev.start_ns = 1'000'000;
+    ev.end_ns   = 1'500'000;
+    ev.duration_ns = 500'000;
+    ev.sync_type = 3;             // STREAM_SYNCHRONIZE
+    ev.stream_id = 7;
+    ev.event_id = 0;              // not an event sync
+    ev.context_id = 1;
+    ev.corr_id = 42;
+
+    gpufl::model::SynchronizationEventModel m(ev);
+    const std::string json = m.buildJson();
+
+    // Top-level type discriminator — Java backend dispatches on this.
+    EXPECT_NE(json.find("\"type\":\"synchronization_event\""), std::string::npos);
+    // Critical fields present.
+    EXPECT_NE(json.find("\"sync_type\":3"), std::string::npos);
+    EXPECT_NE(json.find("\"stream_id\":7"), std::string::npos);
+    EXPECT_NE(json.find("\"corr_id\":42"), std::string::npos);
+    EXPECT_NE(json.find("\"duration_ns\":500000"), std::string::npos);
+    EXPECT_NE(json.find("\"app\":\"Heavy_Stress_App\""), std::string::npos);
+    EXPECT_NE(json.find("\"session_id\":\"abc-123\""), std::string::npos);
+}
+
+// MemoryAllocEventModel emits the wire shape the Java backend
+// dispatches on. Snapshot test — pin the JSON layout so a future
+// rename like "memory_op" → "op" trips the build.
+TEST(BatchModels, MemoryAllocEventModelEmitsExpectedShape) {
+    gpufl::MemoryAllocEvent ev;
+    ev.pid = 1234;
+    ev.app = "Heavy_Stress_App";
+    ev.session_id = "abc-123";
+    ev.start_ns = 1'000'000;
+    ev.duration_ns = 0;
+    ev.memory_op = 1;             // ALLOC
+    ev.memory_kind = 3;           // DEVICE
+    ev.address = 0x7f0000000000ULL;
+    ev.bytes = 1024 * 1024;
+    ev.device_id = 0;
+    ev.stream_id = 0;             // sync alloc
+    ev.corr_id = 42;
+
+    gpufl::model::MemoryAllocEventModel m(ev);
+    const std::string json = m.buildJson();
+
+    EXPECT_NE(json.find("\"type\":\"memory_alloc_event\""), std::string::npos);
+    EXPECT_NE(json.find("\"memory_op\":1"), std::string::npos);
+    EXPECT_NE(json.find("\"memory_kind\":3"), std::string::npos);
+    EXPECT_NE(json.find("\"bytes\":1048576"), std::string::npos);
+    EXPECT_NE(json.find("\"corr_id\":42"), std::string::npos);
+    // Address: rendered as decimal because we don't want the JSON
+    // emitter to depend on stream manipulators across all platforms;
+    // frontend formats as hex for display.
+    EXPECT_NE(json.find("\"address\":139637976727552"), std::string::npos);
+    EXPECT_NE(json.find("\"app\":\"Heavy_Stress_App\""), std::string::npos);
+}
+
+// F4: GraphLaunchEventModel emits the wire shape the Java backend
+// dispatches on. Snapshot test pins the JSON layout.
+TEST(BatchModels, GraphLaunchEventModelEmitsExpectedShape) {
+    gpufl::GraphLaunchEvent ev;
+    ev.pid = 1234;
+    ev.app = "Heavy_Stress_App";
+    ev.session_id = "abc-123";
+    ev.start_ns = 5'000'000;
+    ev.end_ns   = 7'500'000;
+    ev.duration_ns = 2'500'000;
+    ev.graph_id  = 42;
+    ev.device_id = 0;
+    ev.stream_id = 7;
+    ev.corr_id   = 999;
+
+    gpufl::model::GraphLaunchEventModel m(ev);
+    const std::string json = m.buildJson();
+
+    EXPECT_NE(json.find("\"type\":\"graph_launch_event\""), std::string::npos);
+    EXPECT_NE(json.find("\"graph_id\":42"), std::string::npos);
+    EXPECT_NE(json.find("\"corr_id\":999"), std::string::npos);
+    EXPECT_NE(json.find("\"duration_ns\":2500000"), std::string::npos);
+    EXPECT_NE(json.find("\"stream_id\":7"), std::string::npos);
+    EXPECT_NE(json.find("\"app\":\"Heavy_Stress_App\""), std::string::npos);
+    EXPECT_NE(json.find("\"session_id\":\"abc-123\""), std::string::npos);
 }


### PR DESCRIPTION
…ck timing

Capture every CUDA synchronization call (cudaStreamSynchronize, cudaDeviceSynchronize, cudaEventSynchronize, cuStreamWaitEvent) via CUPTI_ACTIVITY_KIND_SYNCHRONIZATION. cudaMalloc/Free tracking with Python source attribution Capture CUDA memory operations (cudaMalloc/Free,
cudaMallocAsync/FreeAsync, cudaMallocManaged, cudaMallocHost) via CUPTI_ACTIVITY_KIND_MEMORY2. The Memory tab gets a flat sortable table; allocation rows are attributed back to their originating

## Description
## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update

## Testing
## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas