### PR TITLE
update: gpufl-agent has a new way to build the backend url. Apply cha…

### DIFF
--- a/Dockerfile.monitor
+++ b/Dockerfile.monitor
@@ -5,9 +5,13 @@
 #
 # Run:
 #   docker run --gpus all \
-#     -e GPUFL_HTTP_URL=http://my-backend:8080/api/v1/events/ \
+#     -e GPUFL_HTTP_HOST=https://api.gpuflight.com \
 #     -e GPUFL_HTTP_TOKEN=gfl_... \
 #     gpufl/monitor:latest
+#
+# GPUFL_HTTP_HOST is just the scheme+host. The agent appends the
+# /api/{version}/events/<type> path automatically; override the
+# version with GPUFL_HTTP_API_VERSION when the backend cuts v2 etc.
 #
 # The Java agent JAR is pulled from the pre-built ghcr.io/gpu-flight/gpufl-agent image.
 # No local gpufl-agent checkout is required.

--- a/Dockerfile.monitor.amd
+++ b/Dockerfile.monitor.amd
@@ -7,9 +7,13 @@
 #   docker run -d \
 #     --device /dev/kfd --device /dev/dri \
 #     --group-add video --group-add render \
-#     -e GPUFL_HTTP_URL=http://my-backend:8080/api/v1/events/ \
+#     -e GPUFL_HTTP_HOST=https://api.gpuflight.com \
 #     -e GPUFL_HTTP_TOKEN=gfl_... \
 #     gpufl/monitor-amd:latest
+#
+# GPUFL_HTTP_HOST is just the scheme+host. The agent appends the
+# /api/{version}/events/<type> path automatically; override the
+# version with GPUFL_HTTP_API_VERSION when the backend cuts v2 etc.
 #
 # The Java agent JAR is pulled from the pre-built ghcr.io/gpu-flight/gpufl-agent image.
 # No local gpufl-agent checkout is required.

--- a/Dockerfile.monitor.supervisord.conf
+++ b/Dockerfile.monitor.supervisord.conf
@@ -21,7 +21,9 @@ stderr_logfile_maxbytes=0
 ;   GPUFL_SOURCE_FOLDER  — must match the log dir used by gpufl-monitor
 ;   GPUFL_SOURCE_PREFIX  — must match GPUFL_MONITOR_LOG_DIR base name (default: session)
 ;   GPUFL_PUBLISHER_TYPE — http or kafka
-;   GPUFL_HTTP_URL       — e.g. http://backend:8080/api/v1/events/
+;   GPUFL_HTTP_HOST      — scheme+host, e.g. https://api.gpuflight.com
+;                          (agent appends /api/{version}/events/<type> automatically)
+;   GPUFL_HTTP_API_VERSION — optional; defaults to v1
 ;   GPUFL_HTTP_TOKEN     — Bearer token
 ;   GPUFL_LOG_TYPES      — default: device,scope,system (override to restrict channels)
 ;   GPUFL_CURSOR_FILE    — default: ./cursor.json (override for persistence across restarts)

--- a/daemon/README.md
+++ b/daemon/README.md
@@ -79,7 +79,7 @@ docker build \
 Copy `.env.example` to `.env` and set the required variables, then:
 
 ```bash
-GPUFL_HTTP_URL=https://your-backend/api/v1/events/ \
+GPUFL_HTTP_HOST=https://your-backend \
 GPUFL_HTTP_TOKEN=gfl_your_token_here \
 docker compose -f docker-compose.monitor.yml up -d
 ```
@@ -99,7 +99,7 @@ docker compose -f docker-compose.monitor.yml down
 ### AMD
 
 ```bash
-GPUFL_HTTP_URL=https://your-backend/api/v1/events/ \
+GPUFL_HTTP_HOST=https://your-backend \
 GPUFL_HTTP_TOKEN=gfl_your_token_here \
 docker compose -f docker-compose.monitor.amd.yml up -d
 ```
@@ -127,7 +127,7 @@ docker run -d \
   --name gpufl-monitor \
   --gpus all \
   --restart unless-stopped \
-  -e GPUFL_HTTP_URL=https://your-backend/api/v1/events/ \
+  -e GPUFL_HTTP_HOST=https://your-backend \
   -e GPUFL_HTTP_TOKEN=gfl_your_token_here \
   -v gpufl-cursor:/var/gpufl/monitor \
   gpufl/monitor:latest
@@ -141,7 +141,7 @@ docker run -d \
   --device /dev/kfd --device /dev/dri \
   --group-add video --group-add render \
   --restart unless-stopped \
-  -e GPUFL_HTTP_URL=https://your-backend/api/v1/events/ \
+  -e GPUFL_HTTP_HOST=https://your-backend \
   -e GPUFL_HTTP_TOKEN=gfl_your_token_here \
   -v gpufl-cursor-amd:/var/gpufl/monitor \
   gpufl/monitor-amd:latest
@@ -175,7 +175,8 @@ The named volume persists the agent's read cursor so it resumes from where it le
 | Variable | Default | Description |
 |---|---|---|
 | `GPUFL_PUBLISHER_TYPE` | `http` | Publisher backend: `http` or `kafka` |
-| `GPUFL_HTTP_URL` | *(required)* | Backend ingest URL, e.g. `https://app.gpuflight.io/api/v1/events/` |
+| `GPUFL_HTTP_HOST` | *(required)* | Backend scheme+host, e.g. `https://api.gpuflight.com`. The agent appends `/api/{version}/events/<type>` automatically. |
+| `GPUFL_HTTP_API_VERSION` | `v1` | Backend API version. Bump when the backend cuts v2 etc. |
 | `GPUFL_HTTP_TOKEN` | *(empty)* | Bearer token for the backend API |
 | `GPUFL_HTTP_TIMEOUT_SEC` | `10` | HTTP request timeout in seconds |
 

--- a/docker-compose.monitor.amd.yml
+++ b/docker-compose.monitor.amd.yml
@@ -22,9 +22,13 @@ services:
       GPUFL_LOG_TYPES: ${GPUFL_LOG_TYPES:-device,scope,system}
       GPUFL_CURSOR_FILE: ${GPUFL_CURSOR_FILE:-/var/gpufl/monitor/cursor.json}
 
-      # Java agent — publisher (HTTP)
+      # Java agent — publisher (HTTP). Set GPUFL_HTTP_HOST to just the
+      # scheme+host (e.g. https://api.gpuflight.com); the agent builds
+      # the /api/{version}/events/<type> path itself. Override the
+      # version via GPUFL_HTTP_API_VERSION when the backend bumps to v2.
       GPUFL_PUBLISHER_TYPE: ${GPUFL_PUBLISHER_TYPE:-http}
-      GPUFL_HTTP_URL: ${GPUFL_HTTP_URL}
+      GPUFL_HTTP_HOST: ${GPUFL_HTTP_HOST}
+      GPUFL_HTTP_API_VERSION: ${GPUFL_HTTP_API_VERSION:-v1}
       GPUFL_HTTP_TOKEN: ${GPUFL_HTTP_TOKEN:-}
       GPUFL_HTTP_TIMEOUT_SEC: ${GPUFL_HTTP_TIMEOUT_SEC:-10}
 

--- a/docker-compose.monitor.yml
+++ b/docker-compose.monitor.yml
@@ -39,9 +39,13 @@ services:
       GPUFL_SOURCE_FOLDERS: ${GPUFL_SOURCE_FOLDERS:-/var/gpufl/monitor,/var/gpufl/demo}
       GPUFL_CURSOR_FILE: ${GPUFL_CURSOR_FILE:-/var/gpufl/monitor/cursor.json}
 
-      # Java agent — publisher (HTTP)
+      # Java agent — publisher (HTTP). Set GPUFL_HTTP_HOST to just the
+      # scheme+host (e.g. https://api.gpuflight.com); the agent builds
+      # the /api/{version}/events/<type> path itself. Override the
+      # version via GPUFL_HTTP_API_VERSION when the backend bumps to v2.
       GPUFL_PUBLISHER_TYPE: ${GPUFL_PUBLISHER_TYPE:-http}
-      GPUFL_HTTP_URL: ${GPUFL_HTTP_URL}
+      GPUFL_HTTP_HOST: ${GPUFL_HTTP_HOST}
+      GPUFL_HTTP_API_VERSION: ${GPUFL_HTTP_API_VERSION:-v1}
       GPUFL_HTTP_TOKEN: ${GPUFL_HTTP_TOKEN:-}
       GPUFL_HTTP_TIMEOUT_SEC: ${GPUFL_HTTP_TIMEOUT_SEC:-10}
 

--- a/scripts/windows/run-monitor-local.bat
+++ b/scripts/windows/run-monitor-local.bat
@@ -13,7 +13,9 @@ if not defined GPUFL_HTTP_TOKEN (
     echo.
 )
 
-set GPUFL_HTTP_URL=http://host.docker.internal:8080/api/v1/events/
+REM Just the scheme+host — the agent appends /api/{version}/events/<type>.
+REM Override the API version with GPUFL_HTTP_API_VERSION when needed.
+set GPUFL_HTTP_HOST=http://host.docker.internal:8080
 
 pushd %~dp0..\..
 docker compose -f docker-compose.monitor.yml up --build


### PR DESCRIPTION
The gpufl-agent has been updated to split its single endpointUrl field into hostUrl + apiVersion, so this pr applies these changes to Docker and documents. 

## Description
## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update

## Testing
## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas