### PR TITLE
fix: it should conditionally generate SASS instructions.

### DIFF
--- a/include/gpufl/backends/nvidia/cupti_backend.hpp
+++ b/include/gpufl/backends/nvidia/cupti_backend.hpp
@@ -45,6 +45,23 @@ class CuptiBackend : public IMonitorBackend {
     bool IsMonitoringMode() override { return true; }
     bool IsProfilingMode()  override { return engine_ != nullptr; }
 
+    // Whether the active engine consumes cubin binaries. Cubin capture
+    // feeds two consumers, and both want the binary for the SAME three
+    // instruction-level engines:
+    //   1. disassembly (nvdisasm → cubin_disassembly events for the
+    //      Source/SASS dashboard view), and
+    //   2. the engine's own per-PC cubin lookups (PcSampling and
+    //      SassMetrics read cubin_by_crc_ to correlate samples).
+    // None (monitoring only) and RangeProfiler (scope-level HW counters)
+    // need neither, so we skip cubin capture/disassembly entirely for
+    // them — there's no per-instruction data to attach it to. This is
+    // what makes profiling_engine=None truly "monitoring only".
+    bool NeedsCubinCapture() const {
+        return opts_.profiling_engine == ProfilingEngine::PcSampling ||
+               opts_.profiling_engine == ProfilingEngine::SassMetrics ||
+               opts_.profiling_engine == ProfilingEngine::PcSamplingWithSass;
+    }
+
     void RegisterHandler(const std::shared_ptr<ICuptiHandler>& handler);
 
     bool IsActive() const { return active_.load(); }

--- a/include/gpufl/backends/nvidia/resource_handler.cpp
+++ b/include/gpufl/backends/nvidia/resource_handler.cpp
@@ -44,6 +44,15 @@ void ResourceHandler::handle(CUpti_CallbackDomain domain, CUpti_CallbackId cbid,
 
     if (cbid == CUPTI_CBID_RESOURCE_MODULE_LOADED ||
         cbid == CUPTI_CBID_RESOURCE_MODULE_PROFILED) {
+        // Only capture cubins when the active engine actually consumes
+        // them. For profiling_engine=None (monitoring only) and
+        // RangeProfiler (scope-level HW counters) there is no per-PC data
+        // to overlay disassembly on, so capturing + disassembling +
+        // uploading cubins would be pure waste. Gating here keeps
+        // "monitoring only" truly monitoring-only and stops the
+        // cubin_disassembly bloat seen with PyTorch under None.
+        if (!backend_->NeedsCubinCapture()) return;
+
         auto *modData = static_cast<CUpti_ModuleResourceData *>(
             resourceData->resourceDescriptor);
         if (modData && modData->pCubin && modData->cubinSize > 0) {


### PR DESCRIPTION
## Description
SASS instructions are generated even with profiling engine = None. Should not be generated for the Range Profile and None

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

## Testing
## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas