### PR TITLE
fix: fix numba function name readable. fix for getting kernel event d…

### DIFF
--- a/example/python/02_numba_cuda.py
+++ b/example/python/02_numba_cuda.py
@@ -22,13 +22,32 @@ def matmul_kernel(A, B, C):
 
 def run_benchmark():
     # --- 2. Initialize GPUFL ---
-    # We enable the background sampler (16ms) to catch VRAM/Power usage during the heavy compute.
     # LOG_PATH is the file prefix the FileLogSink writes to — it produces
     # <LOG_PATH>.device.log / .scope.log / .system.log. We reuse it below
     # to point generate_report() at the same files.
     LOG_PATH = "./gfl_logs"
+
+    BACKEND_URL = os.environ.get("GPUFL_BACKEND_URL", "api.gpuflight.com")
+    API_KEY = os.environ.get("GPUFL_API_KEY", "")
+    REMOTE_UPLOAD = bool(API_KEY)
+
     print("[GPUFL] Initializing...")
-    gfl.init("Numba_App", LOG_PATH, 100)
+    if REMOTE_UPLOAD:
+        print(f"[GPUFL] Live upload ON -> {BACKEND_URL}")
+    else:
+        print("[GPUFL] Live upload OFF (set GPUFL_API_KEY to enable). Local files only.")
+
+    gfl.init(
+        app_name="Numba_App",
+        log_path=LOG_PATH,
+        sampling_auto_start=True,
+        system_sample_rate_ms=100,
+        enable_debug_output=True,
+        profiling_engine=gfl.ProfilingEngine.PcSamplingWithSass,
+        backend_url=BACKEND_URL,
+        api_key=API_KEY,
+        remote_upload=REMOTE_UPLOAD,
+    )
 
     try:
         # --- 3. Setup Data (Heavy Load) ---

--- a/include/gpufl/backends/nvidia/cuda_feature_guards.hpp
+++ b/include/gpufl/backends/nvidia/cuda_feature_guards.hpp
@@ -1,0 +1,39 @@
+#pragma once
+
+// Centralized CUDA-toolkit feature gates.
+//
+// CUPTI's callback-id enumerators and the `*_params` structs we cast to only
+// exist when the CUDA headers we compile against are new enough. Code that
+// references them therefore has to be wrapped in a preprocessor guard — a
+// runtime check is impossible because the symbol simply isn't declared on
+// older toolkits.
+//
+// Rather than scatter `#if defined(CUDART_VERSION) && CUDART_VERSION >= NNNNN`
+// (which encodes a magic version number but not *why*) across every call
+// site, we resolve each toolkit threshold to a named feature macro here, once.
+// Call sites then read as intent: `#if GPUFL_HAS_EXTENSIBLE_LAUNCH`. If NVIDIA
+// ever shifts a threshold, there's a single line to change.
+//
+// CUDART_VERSION is defined by <cuda_runtime_api.h>; include it so this header
+// is self-contained no matter the include order at the call site.
+#include <cuda_runtime_api.h>
+
+// Cooperative-group launches: cuLaunchCooperativeKernel /
+// cudaLaunchCooperativeKernel (+ MultiDevice, + _ptsz). Used by NCCL
+// collectives and any kernel that grid-syncs via cooperative_groups.
+// Public since CUDA 9.0.
+#if defined(CUDART_VERSION) && CUDART_VERSION >= 9000
+#  define GPUFL_HAS_COOPERATIVE_LAUNCH 1
+#else
+#  define GPUFL_HAS_COOPERATIVE_LAUNCH 0
+#endif
+
+// Extensible launch: cuLaunchKernelEx / cudaLaunchKernelExC (+ _ptsz). This is
+// the path cuda.core takes — and therefore modern numba-cuda (cuda.core >=
+// 1.0), CUTLASS, and any thread-block-cluster kernel — because it carries a
+// LaunchConfig with launch attributes. Public since CUDA 11.6.
+#if defined(CUDART_VERSION) && CUDART_VERSION >= 11060
+#  define GPUFL_HAS_EXTENSIBLE_LAUNCH 1
+#else
+#  define GPUFL_HAS_EXTENSIBLE_LAUNCH 0
+#endif

--- a/include/gpufl/backends/nvidia/kernel_launch_handler.cpp
+++ b/include/gpufl/backends/nvidia/kernel_launch_handler.cpp
@@ -1,7 +1,9 @@
 #include "gpufl/backends/nvidia/kernel_launch_handler.hpp"
 
 #include <cstdio>
+#include <set>
 
+#include "gpufl/backends/nvidia/cuda_feature_guards.hpp"
 #include "gpufl/backends/nvidia/cupti_utils.hpp"
 #include "gpufl/core/activity_record.hpp"
 #include "gpufl/core/common.hpp"
@@ -38,11 +40,12 @@ KernelLaunchHandler::requiredCallbacks() const {
     // backend stores 0 for the API timestamps, the frontend can't
     // compute cpu_overhead / queue_latency, and the kernel detail
     // page falls back to "—" for those metrics. Add new launch CBIDs
-    // here as CUPTI exposes them.
+    // here as CUPTI exposes them — shouldHandle() derives its filter from
+    // this list, so there's only one place to update.
     //
-    // CUDART_VERSION guards keep the agent buildable against older
-    // CUDA toolkits — the enum value isn't defined if CUPTI predates
-    // the API.
+    // The GPUFL_HAS_* feature gates (see cuda_feature_guards.hpp) keep the
+    // agent buildable against older CUDA toolkits — the CBID enumerator
+    // isn't declared if CUPTI predates the API.
     std::vector<std::pair<CUpti_CallbackDomain, CUpti_CallbackId>> cbs = {
         // ── Runtime API ───────────────────────────────────────────
         {CUPTI_CB_DOMAIN_RUNTIME_API,
@@ -69,7 +72,7 @@ KernelLaunchHandler::requiredCallbacks() const {
     // Cooperative kernel launches (CUDA 9.0+) — used by NCCL
     // collectives and any kernel that needs grid-wide
     // synchronization via cooperative_groups.
-#if defined(CUDART_VERSION) && CUDART_VERSION >= 9000
+#if GPUFL_HAS_COOPERATIVE_LAUNCH
     cbs.push_back({CUPTI_CB_DOMAIN_RUNTIME_API,
                    CUPTI_RUNTIME_TRACE_CBID_cudaLaunchCooperativeKernel_v9000});
     cbs.push_back({CUPTI_CB_DOMAIN_RUNTIME_API,
@@ -88,7 +91,7 @@ KernelLaunchHandler::requiredCallbacks() const {
     // CUTLASS ≥ 2.10, and most new CUDA samples emit. Was the
     // primary cause of api_start_ns / api_exit_ns showing up as 0
     // for users on recent toolkits before this CBID was wired up.
-#if defined(CUDART_VERSION) && CUDART_VERSION >= 11060
+#if GPUFL_HAS_EXTENSIBLE_LAUNCH
     cbs.push_back({CUPTI_CB_DOMAIN_RUNTIME_API,
                    CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernelExC_v11060});
     cbs.push_back({CUPTI_CB_DOMAIN_RUNTIME_API,
@@ -109,55 +112,20 @@ std::vector<CUpti_ActivityKind> KernelLaunchHandler::requiredActivityKinds()
 
 bool KernelLaunchHandler::shouldHandle(const CUpti_CallbackDomain domain,
                                        const CUpti_CallbackId cbid) const {
-    // Mirror the CBIDs registered in requiredCallbacks() — anything
-    // missing here gets filtered out before handle() runs and the
-    // corresponding kernel records arrive without API timestamps.
-    if (domain == CUPTI_CB_DOMAIN_RUNTIME_API) {
-        switch (cbid) {
-            case CUPTI_RUNTIME_TRACE_CBID_cudaLaunch_v3020:
-            case CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernel_v7000:
-            case CUPTI_RUNTIME_TRACE_CBID_cudaLaunch_ptsz_v7000:
-            case CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernel_ptsz_v7000:
-                return true;
-#if defined(CUDART_VERSION) && CUDART_VERSION >= 9000
-            case CUPTI_RUNTIME_TRACE_CBID_cudaLaunchCooperativeKernel_v9000:
-            case CUPTI_RUNTIME_TRACE_CBID_cudaLaunchCooperativeKernel_ptsz_v9000:
-            case CUPTI_RUNTIME_TRACE_CBID_cudaLaunchCooperativeKernelMultiDevice_v9000:
-                return true;
-#endif
-#if defined(CUDART_VERSION) && CUDART_VERSION >= 11060
-            case CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernelExC_v11060:
-            case CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernelExC_ptsz_v11060:
-                return true;
-#endif
-            default:
-                return false;
-        }
-    }
-    if (domain == CUPTI_CB_DOMAIN_DRIVER_API) {
-        switch (cbid) {
-            case CUPTI_DRIVER_TRACE_CBID_cuLaunch:
-            case CUPTI_DRIVER_TRACE_CBID_cuLaunchGrid:
-            case CUPTI_DRIVER_TRACE_CBID_cuLaunchGridAsync:
-            case CUPTI_DRIVER_TRACE_CBID_cuLaunchKernel:
-            case CUPTI_DRIVER_TRACE_CBID_cuLaunchKernel_ptsz:
-                return true;
-#if defined(CUDART_VERSION) && CUDART_VERSION >= 9000
-            case CUPTI_DRIVER_TRACE_CBID_cuLaunchCooperativeKernel:
-            case CUPTI_DRIVER_TRACE_CBID_cuLaunchCooperativeKernel_ptsz:
-            case CUPTI_DRIVER_TRACE_CBID_cuLaunchCooperativeKernelMultiDevice:
-                return true;
-#endif
-#if defined(CUDART_VERSION) && CUDART_VERSION >= 11060
-            case CUPTI_DRIVER_TRACE_CBID_cuLaunchKernelEx:
-            case CUPTI_DRIVER_TRACE_CBID_cuLaunchKernelEx_ptsz:
-                return true;
-#endif
-            default:
-                return false;
-        }
-    }
-    return false;
+    // Single source of truth: a callback is handled iff we registered it in
+    // requiredCallbacks(). Deriving the filter from that list (rather than
+    // re-typing every CBID and its version guard here) means the two can
+    // never drift — a CBID added to one but forgotten in the other used to
+    // silently drop that launch API's telemetry. The set is identical for
+    // every instance, so build it once on first call (thread-safe since
+    // C++11) and reuse it; this stays on the per-callback hot path.
+    static const std::set<std::pair<CUpti_CallbackDomain, CUpti_CallbackId>>
+        kHandled = [this] {
+            const auto cbs = requiredCallbacks();
+            return std::set<std::pair<CUpti_CallbackDomain, CUpti_CallbackId>>(
+                cbs.begin(), cbs.end());
+        }();
+    return kHandled.count({domain, cbid}) != 0;
 }
 
 void KernelLaunchHandler::handle(CUpti_CallbackDomain domain,
@@ -208,32 +176,73 @@ void KernelLaunchHandler::handle(CUpti_CallbackDomain domain,
             meta.scope_depth = 0;
         }
 
+        auto setLaunchDims = [&meta](const unsigned int gx,
+                                     const unsigned int gy,
+                    const unsigned int gz, const unsigned int bx,
+                    const unsigned int by, const unsigned int bz,
+                                     size_t dyn_smem) {
+            meta.has_details = true;
+            meta.grid_x = static_cast<int>(gx);
+            meta.grid_y = static_cast<int>(gy);
+            meta.grid_z = static_cast<int>(gz);
+            meta.block_x = static_cast<int>(bx);
+            meta.block_y = static_cast<int>(by);
+            meta.block_z = static_cast<int>(bz);
+            meta.dyn_shared = static_cast<int>(dyn_smem);
+        };
+
         if (cbInfo->functionParams != nullptr) {
             if (domain == CUPTI_CB_DOMAIN_RUNTIME_API &&
                 cbid == CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernel_v7000) {
-                meta.has_details = true;
-                const auto* params =
+                const auto* p =
                     (cudaLaunchKernel_v7000_params*)(cbInfo->functionParams);
-                meta.grid_x = params->gridDim.x;
-                meta.grid_y = params->gridDim.y;
-                meta.grid_z = params->gridDim.z;
-                meta.block_x = params->blockDim.x;
-                meta.block_y = params->blockDim.y;
-                meta.block_z = params->blockDim.z;
-                meta.dyn_shared = static_cast<int>(params->sharedMem);
+                setLaunchDims(p->gridDim.x, p->gridDim.y, p->gridDim.z,
+                              p->blockDim.x, p->blockDim.y, p->blockDim.z,
+                              p->sharedMem);
             } else if (domain == CUPTI_CB_DOMAIN_DRIVER_API &&
                        cbid == CUPTI_DRIVER_TRACE_CBID_cuLaunchKernel) {
-                meta.has_details = true;
-                const auto* params =
-                    (cuLaunchKernel_params*)cbInfo->functionParams;
-                meta.grid_x = params->gridDimX;
-                meta.grid_y = params->gridDimY;
-                meta.grid_z = params->gridDimZ;
-                meta.block_x = params->blockDimX;
-                meta.block_y = params->blockDimY;
-                meta.block_z = params->blockDimZ;
-                meta.dyn_shared = static_cast<int>(params->sharedMemBytes);
+                const auto* p = (cuLaunchKernel_params*)cbInfo->functionParams;
+                setLaunchDims(p->gridDimX, p->gridDimY, p->gridDimZ,
+                              p->blockDimX, p->blockDimY, p->blockDimZ,
+                              p->sharedMemBytes);
             }
+#if GPUFL_HAS_EXTENSIBLE_LAUNCH
+            // Extensible launch (CUDA 11.6+). cuda.core's launch() routes
+            // through cuLaunchKernelEx — NOT the plain cuLaunchKernel handled
+            // above — because LaunchConfig carries launch attributes (thread-
+            // block clusters, cooperative, etc.). numba-cuda's modern
+            // dispatcher (when cuda.core >= 1.0 is present) launches every
+            // kernel this way, as do CUTLASS and recent CUDA samples. Without
+            // these branches such kernels arrive with timing but has_details
+            // stays false, so grid/block/occupancy are dropped from the report
+            // ("kernel details missing" for Numba). The launch config is a
+            // pointer captured at API_ENTER and is valid for the callback's
+            // lifetime, so read it here while we're still inside the callback.
+            else if (domain == CUPTI_CB_DOMAIN_DRIVER_API &&
+                     (cbid == CUPTI_DRIVER_TRACE_CBID_cuLaunchKernelEx ||
+                      cbid == CUPTI_DRIVER_TRACE_CBID_cuLaunchKernelEx_ptsz)) {
+                const auto* p = (cuLaunchKernelEx_params*)cbInfo->functionParams;
+                if (p->config != nullptr) {
+                    const CUlaunchConfig* c = p->config;
+                    setLaunchDims(c->gridDimX, c->gridDimY, c->gridDimZ,
+                                  c->blockDimX, c->blockDimY, c->blockDimZ,
+                                  c->sharedMemBytes);
+                }
+            } else if (domain == CUPTI_CB_DOMAIN_RUNTIME_API &&
+                       (cbid ==
+                            CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernelExC_v11060 ||
+                        cbid ==
+                            CUPTI_RUNTIME_TRACE_CBID_cudaLaunchKernelExC_ptsz_v11060)) {
+                const auto* p =
+                    (cudaLaunchKernelExC_v11060_params*)cbInfo->functionParams;
+                if (p->config != nullptr) {
+                    const cudaLaunchConfig_t* c = p->config;
+                    setLaunchDims(c->gridDim.x, c->gridDim.y, c->gridDim.z,
+                                  c->blockDim.x, c->blockDim.y, c->blockDim.z,
+                                  c->dynamicSmemBytes);
+                }
+            }
+#endif
         }
 
         // Store metadata — emit later from scope stop (PC Sampling path)

--- a/include/gpufl/core/itanium_demangle.cpp
+++ b/include/gpufl/core/itanium_demangle.cpp
@@ -57,6 +57,11 @@ private:
     // depends on it).
     bool lastNameWasTemplate_ = false;
 
+    // Set when skipAbiTags() runs off the end of the input on a truncated
+    // abi-tag. Tells parseNestedName() to accept the implicit end instead
+    // of demanding the closing 'E' that the clip removed.
+    bool truncated_ = false;
+
     // ── Byte-level helpers ────────────────────────────────────────
     bool eof() const { return p_ >= end_; }
     char peek() const { return eof() ? '\0' : *p_; }
@@ -151,8 +156,9 @@ private:
             lastNameWasTemplate_ = false;
             return sub;
         }
-        // Unscoped name: source_name [template_args]
+        // Unscoped name: source_name [abi-tags] [template_args]
         std::string n = parseUnqualifiedName();
+        skipAbiTags();
         if (peek() == 'I') {
             std::string targs = parseTemplateArgs();
             lastNameWasTemplate_ = true;
@@ -205,13 +211,18 @@ private:
                 std::string tp = parseTemplateParam();
                 parts.push_back(tp);
             } else {
-                // Source name (length-prefixed identifier).
+                // Source name (length-prefixed identifier), optionally
+                // followed by abi-tags (consumed + discarded).
                 std::string n = parseUnqualifiedName();
+                skipAbiTags();
                 parts.push_back(n);
                 subs_.push_back(joinScope(parts));
             }
         }
-        if (!consume('E')) throw ParseError();
+        // Normally the nested name must close with 'E'. If a truncated
+        // abi-tag ate the rest of the buffer (incl. the 'E'), accept the
+        // implicit end — we already have all the real name components.
+        if (!consume('E') && !truncated_) throw ParseError();
 
         std::string joined = joinScope(parts);
         // Was the LAST component templated? Detect by its trailing '>'.
@@ -246,6 +257,47 @@ private:
         std::string s(p_, p_ + len);
         p_ += len;
         return s;
+    }
+
+    // <abi-tags> ::= <abi-tag>*
+    // <abi-tag>  ::= "B" <source-name>
+    //
+    // Abi-tags decorate an unqualified-name. The case that brought us
+    // here: Numba/NVVM CUDA kernels encode the lowered type signature as
+    // a long hashed abi-tag —
+    //   _ZN8__main__13matmul_kernel B2v1 B102<102-char hash> E
+    // The standard demangler renders these as `name[abi:tag]`, but for
+    // our purpose (readable kernel names + the frontend's regex
+    // op-categorization) the tag is pure noise, and Numba's 100+ char
+    // hash would overflow the name buffer anyway. So we CONSUME and
+    // DISCARD them — a tagged name demangles to the bare name. Without
+    // this the loop hit the 'B', tried to read it as a source-name
+    // (which must start with a digit), threw ParseError, and the whole
+    // demangle fell back to the raw mangled string.
+    //
+    // Guarded on a following digit so we only treat 'B' as an abi-tag
+    // when it's actually `B<length>…`; a stray uppercase 'B' elsewhere
+    // won't be misconsumed (lowercase 'b' is the bool builtin, distinct).
+    void skipAbiTags() {
+        while (peek() == 'B' && p_ + 1 < end_ && p_[1] >= '0' && p_[1] <= '9') {
+            ++p_;                       // consume 'B'
+            const int len = parseNumber();
+            if (len <= 0) return;
+            if (p_ + len > end_) {
+                // Truncated abi-tag: the symbol was clipped by a fixed-size
+                // buffer before it reached us (CUDA tooling stores kernel
+                // names in bounded char arrays, and Numba's hashed tag is
+                // 100+ chars). The tag is discardable and we've already
+                // captured the real name, so consume what's left and flag
+                // truncation — the nested-name parser then finishes
+                // gracefully instead of failing the whole demangle and
+                // falling back to the raw mangled string.
+                p_ = end_;
+                truncated_ = true;
+                return;
+            }
+            p_ += len;                  // discard the tag identifier
+        }
     }
 
     // <template_args> ::= "I" <template_arg>+ "E"
@@ -382,8 +434,10 @@ private:
         }
 
         if (c >= '0' && c <= '9') {
-            // Source name as a class type, e.g. "5MyClass".
+            // Source name as a class type, e.g. "5MyClass", optionally
+            // abi-tagged.
             std::string n = parseSourceName();
+            skipAbiTags();
             subs_.push_back(n);
             return n;
         }

--- a/include/gpufl/core/itanium_demangle.hpp
+++ b/include/gpufl/core/itanium_demangle.hpp
@@ -26,6 +26,11 @@ namespace gpufl::core {
  *   - template params      T_, T0_, T1_, …
  *   - substitutions        S_, S0_, S1_, … (used for repeated types)
  *   - bare function types  return type + parameter list
+ *   - abi-tags             B<source-name> (consumed + DISCARDED, not
+ *                          rendered) — Numba/NVVM CUDA kernels encode the
+ *                          lowered signature as a long hashed abi-tag, e.g.
+ *                          `_ZN8__main__13matmul_kernelB2v1B102<hash>` →
+ *                          `__main__::matmul_kernel`
  *
  * Constructs deliberately not handled (and the parser falls back to
  * returning the input unchanged when it hits them): operator names,

--- a/include/gpufl/core/stack_trace.cpp
+++ b/include/gpufl/core/stack_trace.cpp
@@ -85,6 +85,22 @@ std::string GetCallStack(int skipFrames) {
 
 namespace gpufl {
 namespace core {
+// Strip Itanium "[abi:...]" decorations that __cxa_demangle renders.
+// Numba/NVVM CUDA kernels encode their lowered signature as a long hashed
+// abi-tag (e.g. `__main__::matmul_kernel[abi:v1][abi:cw51cX…]`); for
+// readable names + the frontend's regex op-categorization we drop them.
+// This keeps the Linux output consistent with the Windows portable
+// demangler (DemangleItaniumName), which discards abi-tags while parsing.
+static std::string StripAbiTags(std::string s) {
+    std::string::size_type pos;
+    while ((pos = s.find("[abi:")) != std::string::npos) {
+        const std::string::size_type close = s.find(']', pos);
+        if (close == std::string::npos) break;
+        s.erase(pos, close - pos + 1);
+    }
+    return s;
+}
+
 std::string DemangleName(const char* mangled) {
     if (!mangled || mangled[0] == '\0') return mangled ? mangled : "";
     int status = 0;
@@ -92,7 +108,7 @@ std::string DemangleName(const char* mangled) {
     if (status == 0 && demangled) {
         std::string result(demangled);
         free(demangled);
-        return result;
+        return StripAbiTags(std::move(result));
     }
     return mangled;
 }


### PR DESCRIPTION
Fixed Numba CUDA kernel names showing as raw mangled strings by adding Itanium abi-tag parsing (consume-and-discard, with tolerance for buffer-truncated tags) to the portable demangler and stripping [abi:…] from the Linux __cxa_demangle output — so _ZN8__main__13matmul_kernelB2v1B102… now renders as __main__::matmul_kernel. Verified via a standalone MSVC compile of the demangler against your exact (truncated) name plus full/ordinary-kernel regression cases.

## Description
## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Documentation update

## Testing
## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas