### PR TITLE
feat(scope): ScopeMeta + GFL_BENCH auto-loop with warmup sub-scope

### DIFF
--- a/example/cuda/sass_divergence_demo.cu
+++ b/example/cuda/sass_divergence_demo.cu
@@ -13,6 +13,7 @@
 
 #include <cuda_runtime.h>
 
+#include <cstdint>
 #include <cstdlib>
 #include <iostream>
 
@@ -208,13 +209,40 @@ int main() {
         CHECK_CUDA(cudaDeviceSynchronize());
     }
 
-    // --- Kernel 1: Baseline (no divergence) ---
-    std::cout << "  [1/5] uniformWork — no divergence" << std::endl;
-    GFL_SCOPE("1_uniform_work") {
+    // --- Kernel 1: Baseline (no divergence) — auto-loop benchmark demo ---
+    //
+    // Demonstrates GFL_BENCH (1.0.3+): the macro runs the body
+    // `warmup` times BEFORE opening the scope and `repeat` times
+    // INSIDE it, all in one place. The scope's BEGIN row carries
+    // both counts so the analyzer / backend can compute per-iter
+    // time. The Python equivalent is:
+    //
+    //   for _ in gpufl.Scope("1_uniform_work", repeat=10, warmup=3):
+    //       uniformWork[...](...)
+    //
+    // The warmup iterations prime L1/L2 and let the PC-sampling
+    // buffer drain its first burst, so the 10 measured iterations
+    // reflect steady-state cost rather than cold-cache overhead.
+    //
+    // The trailing semicolon after `};` is required — the macro
+    // expands to a single expression statement (BenchInvoker
+    // construction + operator+= with the lambda body).
+    //
+    // CUDA error checking sits OUTSIDE the lambda: `return` inside
+    // the body would only exit the lambda, not main, so CHECK_CUDA
+    // wouldn't propagate. cudaGetLastError() afterwards still picks
+    // up any kernel launch / sync failure across the whole loop.
+    std::cout << "  [1/5] uniformWork — 3 warmup + 10 measured" << std::endl;
+    constexpr int kWarmup = 3;
+    constexpr int kRepeat = 10;
+    GFL_BENCH("1_uniform_work",
+              gpufl::ScopeMeta{}
+                  .setRepeat(kRepeat)
+                  .setWarmup(kWarmup)) {
         uniformWork<<<grid, block>>>(d_out, d_in, n);
-        CHECK_CUDA(cudaGetLastError());
-        CHECK_CUDA(cudaDeviceSynchronize());
-    }
+        cudaDeviceSynchronize();
+    };
+    CHECK_CUDA(cudaGetLastError());
 
     // --- Kernel 2: Even/odd split ---
     std::cout << "  [2/5] branchByWarpLane — 50/50 divergence" << std::endl;

--- a/include/gpufl/core/events.hpp
+++ b/include/gpufl/core/events.hpp
@@ -428,6 +428,15 @@ struct ScopeBatchRow {
     uint32_t name_id           = 0;  // scope name dictionary ID
     uint8_t  event_type        = 0;  // 0 = begin, 1 = end
     int      depth             = 0;
+
+    // Optional benchmark metadata set on the BEGIN row only (0 on END).
+    // Populated when the scope was opened with iteration metadata —
+    // e.g. Python's `for _ in gpufl.Scope(name, repeat=N, warmup=K)`.
+    // 0 on either field means "not provided" and the row serializes
+    // the same as before (analyzer / backend simply skip the metric).
+    // Backend joins by scope_instance_id to read the begin-row values.
+    uint32_t repeat            = 0;  // measured iterations bracketed by scope
+    uint32_t warmup            = 0;  // iterations run BEFORE scope opened
 };
 
 struct ProfileSampleBatchRow {

--- a/include/gpufl/core/gpufl.cpp
+++ b/include/gpufl/core/gpufl.cpp
@@ -586,12 +586,30 @@ ScopedMonitor::ScopedMonitor(std::string name, const bool deep_profiling)
     : ScopedMonitor(std::move(name), "", deep_profiling) {}
 
 ScopedMonitor::ScopedMonitor(std::string name, std::string tag,
-                             bool deep_profiling)
+                             bool /*deep_profiling*/)
     : name_(std::move(name)),
       tag_(std::move(tag)),
       pid_(detail::GetPid()),
       start_ns_(detail::GetTimestampNs()),
       scope_id_(nextScopeId_()) {
+    init_(ScopeMeta{});  // no benchmark metadata
+}
+
+// Canonical 1.0.3+ ctor — single options object. Tag now lives
+// inside ScopeMeta (was a separate parameter in the earlier draft)
+// so the call site has a single source of truth and the variadic
+// GFL_SCOPE macro can wrap any combination of fields in one
+// ScopeMeta{...} literal.
+ScopedMonitor::ScopedMonitor(std::string name, ScopeMeta meta)
+    : name_(std::move(name)),
+      tag_(std::move(meta.tag)),
+      pid_(detail::GetPid()),
+      start_ns_(detail::GetTimestampNs()),
+      scope_id_(nextScopeId_()) {
+    init_(meta);  // meta.tag is moved-from; init_ only reads repeat/warmup
+}
+
+void ScopedMonitor::init_(const ScopeMeta& meta) const {
     if (const Runtime* rt = runtime(); !rt || !rt->logger) return;
 
     auto& stack = getThreadScopeStack();
@@ -605,6 +623,11 @@ ScopedMonitor::ScopedMonitor(std::string name, std::string tag,
     row.name_id = name_id;
     row.event_type = 0;  // begin
     row.depth = depth;
+    // Benchmark metadata — 0/0 for the legacy ctors, populated for the
+    // ScopeMeta overload. End row (in dtor) keeps these at 0; backend
+    // joins by scope_instance_id to read the begin-row values.
+    row.repeat = meta.repeat;
+    row.warmup = meta.warmup;
     Monitor::PushScopeRow(row);
 
     // Scope callbacks are useful for both tracing and profiling backends.

--- a/include/gpufl/core/model/batch_models.cpp
+++ b/include/gpufl/core/model/batch_models.cpp
@@ -161,20 +161,25 @@ std::string ScopeEventBatchModel::buildJson() const {
     const int64_t base = rows.front().ts_ns;
 
     std::ostringstream oss;
-    oss << "{\"version\":1,\"type\":\"scope_event_batch\""
+    oss << "{\"version\":2,\"type\":\"scope_event_batch\""
         << ",\"session_id\":\"" << jsonEscape(session_id_) << '"'
         << ",\"batch_id\":" << batch_id_ << ",\"base_time_ns\":" << base
         << ",\"columns\":[\"dt_ns\",\"scope_instance_id\",\"name_id\","
-           "\"event_type\",\"depth\"]"
+           "\"event_type\",\"depth\",\"repeat\",\"warmup\"]"
         << ",\"rows\":[";
 
     bool first = true;
     for (const auto& r : rows) {
         if (!first) oss << ',';
         first = false;
+        // v2 (1.0.3): adds repeat + warmup as the last two columns.
+        // Both are 0 on END rows and on BEGIN rows that didn't carry
+        // benchmark metadata, so older v1 callers keep producing
+        // semantically-identical numeric payloads — only the column
+        // list / version bump changes the wire format.
         oss << '[' << (r.ts_ns - base) << ',' << r.scope_instance_id << ','
             << r.name_id << ',' << static_cast<int>(r.event_type) << ','
-            << r.depth << ']';
+            << r.depth << ',' << r.repeat << ',' << r.warmup << ']';
     }
     oss << "]}";
     return oss.str();

--- a/include/gpufl/gpufl.hpp
+++ b/include/gpufl/gpufl.hpp
@@ -205,18 +205,73 @@ void shutdown();
 // - With output_path: saves the report to a file.
 void generateReport(const std::string& output_path = "");
 
+// Single options object carrying everything you might attach to a
+// scope beyond its name. Used as the canonical 2nd argument of the
+// 1.0.3+ `ScopedMonitor(name, meta)` ctor and the unified
+// `GFL_SCOPE(name, ...)` macro. Designed as an aggregate so callers
+// can use designated initializers:
+//
+//     GFL_SCOPE("hot", .repeat=10, .warmup=3, .tag="ml")
+//
+// Fields are declared in init-list order — designated initializers
+// must list them in the same order (`.tag` before `.repeat` before
+// `.warmup`).  Any field can be omitted; defaults all zero / empty.
+//
+// New fields can be appended without breaking existing callers
+// (designated init only sets named members; aggregate default
+// initializers cover the rest).
+struct ScopeMeta {
+    // Optional category tag (e.g. "math", "ml", "io"). When non-empty,
+    // replaces the legacy `tag` parameter of ScopedMonitor / Python's
+    // `Scope(name, tag)` so the API has a single source of truth.
+    std::string tag = {};
+    // Number of MEASURED iterations bracketed by this scope. Lets the
+    // analyzer divide total scope time by `repeat` to get per-iter avg
+    // without the caller pre-computing it. 0 = not provided.
+    uint32_t repeat = 0;
+    // Iterations the caller ran BEFORE opening this scope, deliberately
+    // excluded from measurement (JIT compile / cold cache warmup). 0 = none.
+    // Stored for audit / reporting; not used in per-iter math.
+    uint32_t warmup = 0;
+
+    // Fluent builders — the portable way to populate ScopeMeta in
+    // pure C++17. Designated initializers (`{.repeat=10}`) require
+    // C++20 (or GCC/Clang in C++17 mode with extensions); MSVC's
+    // /std:c++17 rejects them outright. The builders work on every
+    // compiler.
+    //
+    //     gpufl::ScopeMeta{}.setRepeat(10).setWarmup(3).setTag("ml")
+    //
+    // Each setter returns `*this` so calls chain. Use them with
+    // GFL_BENCH or pass the result directly to ScopedMonitor.
+    ScopeMeta& setTag(std::string t)    { tag    = std::move(t); return *this; }
+    ScopeMeta& setRepeat(uint32_t r)    { repeat = r;            return *this; }
+    ScopeMeta& setWarmup(uint32_t w)    { warmup = w;            return *this; }
+};
+
 class ScopedMonitor {
    public:
     explicit ScopedMonitor(std::string name, std::string tag, bool deep_profiling);
     explicit ScopedMonitor(std::string name, std::string tag);
     explicit ScopedMonitor(std::string name, bool deep_profiling);
     explicit ScopedMonitor(std::string name);
+    // Canonical 1.0.3+ ctor — single options object. `meta.tag`
+    // replaces the legacy separate `tag` parameter; the older
+    // (name, tag, ScopeMeta) overload has been retired in favor of
+    // this one so there's a single source of truth for the tag.
+    explicit ScopedMonitor(std::string name, ScopeMeta meta);
     ~ScopedMonitor();
 
     ScopedMonitor(const ScopedMonitor&) = delete;
     ScopedMonitor& operator=(const ScopedMonitor&) = delete;
 
    private:
+    // Shared ctor body — all constructors funnel through this so the
+    // begin-row push, NVTX push, and profiler-scope hooks live in one
+    // place. `meta` defaults to ScopeMeta{} (zeros) for the legacy
+    // overloads, so their wire output is byte-for-byte unchanged.
+    void init_(const ScopeMeta& meta) const;
+
     std::string name_;
     std::string tag_;
     int pid_{0};
@@ -233,12 +288,105 @@ inline void monitor(const std::string& name, const std::string& tag,
     ScopedMonitor r(name, tag);
     fn();
 }
+
+namespace detail {
+
+// Helper that powers GFL_BENCH. The trailing lambda body is delivered
+// via operator+=, which lets the macro expansion look like a natural
+// `{ block }` after `GFL_BENCH(...)`. The body runs `warmup` times
+// BEFORE the scope opens (excluded from measurement) and `repeat`
+// times INSIDE the scope (bracketed by the BEGIN / END rows).
+//
+// Body is captured by reference via the `[&]` lambda the macro
+// produces, so it sees all enclosing locals — but be aware that
+// `return` inside the body returns from the LAMBDA, not the
+// enclosing function. Use exceptions for fatal errors instead.
+class BenchInvoker {
+   public:
+    BenchInvoker(std::string name, ScopeMeta meta)
+        : name_(std::move(name)), meta_(std::move(meta)) {}
+
+    // Precedence note: `operator+=` was picked over `*` / `<<` because
+    // it has lower precedence than the lambda's `[]` capture syntax,
+    // so the macro doesn't need extra parens around the lambda.
+    template <class Body>
+    void operator+=(Body&& body) {
+        // Warmup phase: open a "<name>_warmup" sub-scope so the kernel
+        // events emitted during warmup are attributed to a separately
+        // identifiable bucket in the log instead of leaking into the
+        // global / outer scope. The warmup scope itself carries
+        // repeat=meta_.warmup so the analyzer's per-iteration math
+        // works for cold-start cost too. Tag inherits from the user's
+        // meta so warmup and measured group together (e.g. both
+        // tagged "ml" if the user passed that).
+        if (meta_.warmup > 0) {
+            ScopeMeta warmup_meta;
+            warmup_meta.tag    = meta_.tag;
+            warmup_meta.repeat = meta_.warmup;
+            ScopedMonitor warmup_scope(name_ + "_warmup",
+                                       std::move(warmup_meta));
+            for (uint32_t i = 0; i < meta_.warmup; ++i) body();
+        }
+        // Measured phase: open the main "<name>" scope.
+        ScopedMonitor scope(name_, meta_);
+        for (uint32_t i = 0; i < meta_.repeat; ++i) body();
+    }
+
+   private:
+    std::string name_;
+    ScopeMeta meta_;
+};
+
+}  // namespace detail
 }  // namespace gpufl
 
+// GFL_SCOPE — single-arg scoped instrumentation, unchanged since
+// pre-1.0.3. Pass ONLY a name. The body runs exactly once and the
+// scope brackets all the work inside it.
+//
+//     GFL_SCOPE("inference") { model_forward(x); }
+//
+// For benchmark loops with automatic warmup + repeat, see GFL_BENCH
+// below. For attaching metadata (tag / repeat / warmup) to a scope
+// without using the auto-loop helper — e.g. you have an irregular
+// loop body with `continue` / `break` / early-return semantics that
+// don't fit in a lambda — construct ScopedMonitor directly:
+//
+//     gpufl::ScopeMeta meta;
+//     meta.repeat = 10;
+//     gpufl::ScopedMonitor scope("hot", meta);
+//     for (int i = 0; i < 10; ++i) { ... }
 #define GFL_SCOPE(name) if (gpufl::ScopedMonitor _gpufl_scope{name}; true)
 
 #define GFL_SCOPE_TAGGED(name, tag, deep_profiling) \
     if (gpufl::ScopedMonitor _gpufl_scope{name, tag}; true)
+
+// GFL_BENCH — automatic benchmark loop. The body block runs
+// `meta.warmup` times BEFORE the scope opens and `meta.repeat` times
+// INSIDE the scope (BEGIN row carries both counts). Saves you from
+// writing two for-loops + a manual ScopedMonitor:
+//
+//     GFL_BENCH("hot", gpufl::ScopeMeta{}.setRepeat(10).setWarmup(3)) {
+//         my_kernel<<<grid, block>>>(...);
+//         cudaDeviceSynchronize();
+//     };   // ← trailing ';' is required
+//
+// The builder form (`ScopeMeta{}.setX(...)`) is recommended because
+// it compiles on every major compiler in /std:c++17. Designated
+// initializers (`{.repeat=10, .warmup=3}`) work on GCC and Clang in
+// C++17 (compiler extension) and on every compiler in C++20, but
+// MSVC's /std:c++17 explicitly rejects them — so projects targeting
+// MSVC pre-C++20 should stick with builders.
+//
+// The body is captured by `[&]` so it sees enclosing locals.
+//
+// IMPORTANT: `return` inside the body returns from the LAMBDA, not
+// the enclosing function. Macros that expand to early-return
+// (e.g. CHECK_CUDA) won't propagate errors out — throw an exception
+// instead, or check status after the macro completes.
+#define GFL_BENCH(name, ...) \
+    ::gpufl::detail::BenchInvoker{name, ::gpufl::ScopeMeta{__VA_ARGS__}} \
+        += [&]()
 
 #define GFL_SYSTEM_START(name) ::gpufl::systemStart(name)
 #define GFL_SYSTEM_STOP(name) ::gpufl::systemStop(name)

--- a/python/bindings.cpp
+++ b/python/bindings.cpp
@@ -9,10 +9,28 @@ namespace py = pybind11;
 
 class PyScope {
 public:
-    PyScope(std::string name, std::string tag) : name_(name), tag_(tag) {}
+    // `repeat` / `warmup` are benchmark metadata stamped onto the BEGIN
+    // row of the underlying scope_event_batch when the scope opens.
+    // Both default to 0 — the legacy `with gpufl.Scope("x"):` call path
+    // produces byte-identical output to pre-1.0.3.
+    PyScope(std::string name, std::string tag, uint32_t repeat, uint32_t warmup)
+        : name_(std::move(name)),
+          tag_(std::move(tag)),
+          repeat_(repeat),
+          warmup_(warmup) {}
 
     void enter() {
-        monitor_ = std::make_unique<gpufl::ScopedMonitor>(name_, tag_);
+        if (repeat_ == 0 && warmup_ == 0) {
+            // Legacy fast path — no ScopeMeta allocation needed.
+            monitor_ = std::make_unique<gpufl::ScopedMonitor>(name_, tag_);
+        } else {
+            // 1.0.3+ canonical ctor: tag now lives inside ScopeMeta.
+            gpufl::ScopeMeta meta;
+            meta.tag    = tag_;
+            meta.repeat = repeat_;
+            meta.warmup = warmup_;
+            monitor_ = std::make_unique<gpufl::ScopedMonitor>(name_, meta);
+        }
     }
 
     void exit(py::object exc_type, py::object exc_value, py::object traceback) {
@@ -22,6 +40,8 @@ public:
 private:
     std::string name_;
     std::string tag_;
+    uint32_t repeat_{0};
+    uint32_t warmup_{0};
     std::unique_ptr<gpufl::ScopedMonitor> monitor_;
 };
 
@@ -180,7 +200,17 @@ PYBIND11_MODULE(_gpufl_client, m) {
     // --------------------------
 
     py::class_<PyScope>(m, "Scope")
-        .def(py::init<std::string, std::string>(), py::arg("name"), py::arg("tag") = "")
+        // `repeat` / `warmup` are keyword-only on purpose — they're
+        // optional benchmark metadata, not positional name/tag args. The
+        // pure-Python `gpufl.Scope` wrapper in __init__.py forwards
+        // these when its iterable (repeat=N, warmup=K) form opens the
+        // C++ scope.
+        .def(py::init<std::string, std::string, uint32_t, uint32_t>(),
+             py::arg("name"),
+             py::arg("tag")    = "",
+             py::kw_only(),
+             py::arg("repeat") = 0u,
+             py::arg("warmup") = 0u)
         .def("__enter__", [](PyScope &self) {
             self.enter();
             return &self;

--- a/python/gpufl/__init__.py
+++ b/python/gpufl/__init__.py
@@ -58,7 +58,7 @@ if os.name == 'nt':
 
 # 2. Import C++ Core Bindings
 try:
-    from ._gpufl_client import Scope, init, shutdown, system_start, system_stop, BackendKind, InitOptions, ProfilingEngine
+    from ._gpufl_client import Scope as _CScope, init, shutdown, system_start, system_stop, BackendKind, InitOptions, ProfilingEngine
 except ImportError as e:
     # We catch ImportError specifically to handle missing libcuda.so.1 or DLLs
     import sys
@@ -115,7 +115,7 @@ except ImportError as e:
             self.config_name = ""
             self.remote_upload = False
 
-    class Scope:
+    class _CScope:
         def __init__(self, *args): pass
         def __enter__(self): return self
         def __exit__(self, *args): pass
@@ -143,6 +143,15 @@ __version__ = "0.1.0.dev"
 # sass_divergence_demo) get the same capability without spawning a
 # Python interpreter, and the behavior is consistent across the two
 # call paths.
+
+# ── Session / log-path bookkeeping ──────────────────────────────────────────
+#
+# Tracked purely so `clean_logs()` can (a) refuse to delete the logs of a
+# session that's still being written in THIS process, and (b) default to the
+# last init()'s log location when called with no arguments.
+_session_active = False
+_last_log_path = None
+_last_app_name = None
 
 # Wrap the C++ init to pass through backend_url / remote_upload kwargs
 # and env vars into the underlying InitOptions.
@@ -206,6 +215,198 @@ def init(*args, backend_url=None, api_key=None, config_name=None,
     if remote_upload and 'remote_upload' not in kwargs:
         kwargs['remote_upload'] = True
 
-    return _original_init(*args, **kwargs)
+    # Remember where this session writes its logs so clean_logs() can
+    # default to it later, and guard against wiping an active session.
+    global _session_active, _last_log_path, _last_app_name
+    _last_app_name = kwargs.get('app_name', args[0] if args else None)
+    _last_log_path = kwargs.get('log_path', args[1] if len(args) > 1 else None)
 
-__all__ = ["Scope", "init", "shutdown", "system_start", "system_stop", "BackendKind", "InitOptions", "ProfilingEngine"]
+    result = _original_init(*args, **kwargs)
+    if result:
+        _session_active = True
+    return result
+
+
+# Wrap shutdown so the active-session guard in clean_logs() clears once the
+# logs are flushed and closed.
+_original_shutdown = shutdown
+
+def shutdown():
+    """Stop the runtime, flush and close all log files."""
+    global _session_active
+    try:
+        return _original_shutdown()
+    finally:
+        _session_active = False
+
+# ── Scope: context manager + benchmark-iteration helper ─────────────────────
+#
+# Thin Python wrapper over the C++ `_CScope`. Backward compatible: used as a
+# `with` block it behaves exactly as before. New in 1.0.3 it is also
+# *iterable* when constructed with `repeat=N`, which removes the
+# `with Scope(...): for _ in range(N):` boilerplate and — via `warmup=K` —
+# lets you exclude cold-start iterations (JIT compile, cold caches) from the
+# measured/profiled window without hand-writing two loops.
+class Scope:
+    """A logical profiling scope.
+
+    Two usage forms:
+
+    1. Context manager (unchanged) — bracket an arbitrary block::
+
+           with gpufl.Scope("inference", "ml"):
+               model(x)
+
+    2. Iterable benchmark loop (requires ``repeat``)::
+
+           for _ in gpufl.Scope("matmul", "math", repeat=10, warmup=3):
+               matmul_kernel[bpg, tpb](A, B, C)
+
+       The scope opens once, brackets all ``repeat`` measured iterations,
+       and closes when the loop ends — even if the body raises.
+
+    Args:
+        name:   Scope name shown in the report / dashboard.
+        tag:    Optional category tag (e.g. "math", "ml").
+        repeat: If set, the scope becomes iterable and yields this many
+                *measured* iterations (indices ``0 .. repeat-1``). Required
+                to iterate; a ``with`` block ignores it.
+        warmup: Iterations run BEFORE the scope opens — their work executes
+                but is excluded from the scope's timing/profiling. They yield
+                negative indices (``-warmup .. -1``) so ``i >= 0`` marks a
+                measured iteration. Only meaningful together with ``repeat``.
+    """
+
+    def __init__(self, name, tag="", *, repeat=None, warmup=0):
+        if repeat is not None and repeat < 0:
+            raise ValueError("Scope(repeat=...) must be >= 0")
+        if warmup < 0:
+            raise ValueError("Scope(warmup=...) must be >= 0")
+        self._name = name
+        self._tag = tag
+        self._repeat = repeat
+        self._warmup = warmup
+        self._inner = None
+
+    # --- context-manager protocol (backward compatible) ---
+    def __enter__(self):
+        self._inner = _CScope(self._name, self._tag)
+        self._inner.__enter__()
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        if self._inner is not None:
+            inner, self._inner = self._inner, None
+            return inner.__exit__(exc_type, exc_value, traceback)
+        return False
+
+    # --- iterator protocol (new in 1.0.3) ---
+    def __iter__(self):
+        # Validate eagerly so `for _ in Scope("x")` (no repeat) raises on
+        # loop entry rather than deferring until the first next().
+        if self._repeat is None:
+            raise TypeError(
+                "Scope is only iterable when constructed with repeat=N. "
+                "Use it as a context manager — `with gpufl.Scope(...):` — "
+                "otherwise."
+            )
+        return self._iterate()
+
+    def _iterate(self):
+        # Warmup: body runs with the scope CLOSED (excluded from timing).
+        for w in range(self._warmup):
+            yield w - self._warmup  # -warmup .. -1
+        # Measured: open the scope once, yield repeat times, always close.
+        self._inner = _CScope(self._name, self._tag)
+        self._inner.__enter__()
+        try:
+            for i in range(self._repeat):
+                yield i  # 0 .. repeat-1
+        finally:
+            inner, self._inner = self._inner, None
+            inner.__exit__(None, None, None)
+
+
+# ── clean_logs: wipe a session's NDJSON logs to start fresh ──────────────────
+def clean_logs(log_path=None, log_prefix=None, *, dry_run=False):
+    """Delete this app's NDJSON log files so the next run starts clean.
+
+    Removes the active and rotated log files for a given prefix —
+    ``<prefix>.<channel>.log`` and ``<prefix>.<channel>.<N>.log[.gz]`` — and
+    nothing else. It never removes a directory and never touches files that
+    don't match that pattern, so an unrelated file in the same folder is safe.
+
+    Target resolution:
+        * No args  → the ``log_path`` (or ``app_name``) of the most recent
+          ``gpufl.init()`` call in this process.
+        * ``log_path`` → a path/prefix like ``"./gfl_logs"``; the directory is
+          its dirname and the prefix its basename.
+        * ``log_prefix`` → override just the filename prefix.
+
+    Safety:
+        * **Refuses while a session is active in THIS process** — if you've
+          called ``init()`` without a matching ``shutdown()`` it raises
+          ``RuntimeError`` rather than delete logs you're still writing.
+        * **Does NOT detect the ``gpufl-monitor`` sidecar / agent running in
+          another process.** On Windows a file the agent has open cannot be
+          deleted, so the OS protects you (the file is skipped with a
+          warning). On Linux an unlink succeeds even while the agent holds the
+          file open, which can confuse a live tail — **stop the agent before
+          calling this, or use ``dry_run=True`` first to preview.**
+
+    Args:
+        log_path:   Path/prefix whose logs to remove. Defaults to the last
+                    ``init()``'s location.
+        log_prefix: Override the filename prefix (basename) only.
+        dry_run:    If True, return the list of matching files WITHOUT
+                    deleting anything.
+
+    Returns:
+        list[str]: The files removed (or, with ``dry_run``, the files that
+        would be removed).
+    """
+    if _session_active:
+        raise RuntimeError(
+            "clean_logs() refused: a gpufl session is active in this process "
+            "(init() was called without a matching shutdown()). Call "
+            "gpufl.shutdown() first, then clean_logs()."
+        )
+
+    if log_path is None:
+        log_path = _last_log_path or _last_app_name
+    if not log_path:
+        raise ValueError(
+            "clean_logs(): no log_path given and no prior init() to infer one "
+            "from. Pass log_path=... explicitly."
+        )
+
+    directory = os.path.dirname(log_path) or "."
+    base = log_prefix if log_prefix is not None else os.path.basename(log_path)
+    if base.endswith(".log"):
+        base = base[:-4]
+
+    import glob
+    import warnings
+    matched = sorted({
+        p
+        for pattern in (f"{base}.*.log", f"{base}.*.log.gz")
+        for p in glob.glob(os.path.join(directory, pattern))
+    })
+
+    if dry_run:
+        return matched
+
+    removed = []
+    for p in matched:
+        try:
+            os.remove(p)
+            removed.append(p)
+        except OSError as e:
+            # On Windows an open file (e.g. the sidecar agent tailing it)
+            # raises PermissionError — skipping it IS the safety net against
+            # deleting a file that's in use. Warn rather than crash.
+            warnings.warn(f"[gpufl] clean_logs: could not remove {p}: {e}")
+    return removed
+
+
+__all__ = ["Scope", "init", "shutdown", "clean_logs", "system_start", "system_stop", "BackendKind", "InitOptions", "ProfilingEngine"]

--- a/python/gpufl/__init__.py
+++ b/python/gpufl/__init__.py
@@ -116,7 +116,9 @@ except ImportError as e:
             self.remote_upload = False
 
     class _CScope:
-        def __init__(self, *args): pass
+        # Accept kwargs (repeat/warmup added in 1.0.3) so the no-GPU
+        # fallback matches the real pybind11 binding's signature.
+        def __init__(self, *args, **kwargs): pass
         def __enter__(self): return self
         def __exit__(self, *args): pass
     # --- FIX END ---
@@ -313,11 +315,27 @@ class Scope:
         return self._iterate()
 
     def _iterate(self):
-        # Warmup: body runs with the scope CLOSED (excluded from timing).
-        for w in range(self._warmup):
-            yield w - self._warmup  # -warmup .. -1
-        # Measured: open the scope once, yield repeat times, always close.
-        self._inner = _CScope(self._name, self._tag)
+        # Warmup: open a "<name>_warmup" sub-scope so the kernel events
+        # emitted during warmup are attributed to a separately
+        # identifiable bucket — same convention as the C++ BenchInvoker,
+        # keeps Python and C++ logs interchangeable. The sub-scope's
+        # BEGIN row carries repeat=warmup so per-iteration cold-start
+        # cost can be computed by the analyzer.
+        if self._warmup > 0:
+            warmup_inner = _CScope(self._name + "_warmup", self._tag,
+                                   repeat=self._warmup, warmup=0)
+            warmup_inner.__enter__()
+            try:
+                for w in range(self._warmup):
+                    yield w - self._warmup  # -warmup .. -1
+            finally:
+                warmup_inner.__exit__(None, None, None)
+        # Measured: open the main scope, yield repeat times, always close.
+        # Pass repeat/warmup through to the C++ scope so they land on the
+        # BEGIN row of scope_event_batch — the analyzer / backend then
+        # derive per-iteration metrics without the caller doing math.
+        self._inner = _CScope(self._name, self._tag,
+                              repeat=self._repeat, warmup=self._warmup)
         self._inner.__enter__()
         try:
             for i in range(self._repeat):

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -14,6 +14,7 @@ set(GPUFL_TEST_SOURCES
     core/test_analyzer.cpp
     core/test_api_path_routing.cpp
     core/test_batch_models.cpp
+    core/test_bench_invoker.cpp
     core/test_wire_contract.cpp
     core/test_monitor.cpp
     core/test_http_log_sink.cpp

--- a/tests/core/test_bench_invoker.cpp
+++ b/tests/core/test_bench_invoker.cpp
@@ -1,0 +1,139 @@
+// BenchInvoker / GFL_BENCH tests (1.0.3+).
+//
+// BenchInvoker is the template-lambda helper behind the GFL_BENCH macro.
+// It runs the lambda body `meta.warmup` times BEFORE opening a
+// ScopedMonitor scope and `meta.repeat` times INSIDE it.
+//
+// These tests run without calling gpufl::init() — the ScopedMonitor ctor
+// short-circuits in init_() when there's no Runtime, so the scope side
+// is a no-op and we can verify pure BenchInvoker logic (body invocation
+// count + ordering) without touching CUDA, file I/O, or the collector
+// thread.
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "gpufl/gpufl.hpp"
+
+using gpufl::ScopeMeta;
+using gpufl::detail::BenchInvoker;
+
+// ── Count-based tests ─────────────────────────────────────────────────────
+
+TEST(BenchInvoker, RunsBodyWarmupPlusRepeatTimes) {
+    int runs = 0;
+    BenchInvoker{"scope", ScopeMeta{}.setRepeat(10).setWarmup(3)} += [&]() {
+        ++runs;
+    };
+    EXPECT_EQ(runs, 13);  // 3 warmup + 10 measured
+}
+
+TEST(BenchInvoker, DefaultMetaRunsBodyZeroTimes) {
+    // With repeat=0 and warmup=0, the body should never execute. The
+    // scope itself still opens/closes (empty BEGIN/END pair).
+    int runs = 0;
+    BenchInvoker{"empty", ScopeMeta{}} += [&]() { ++runs; };
+    EXPECT_EQ(runs, 0);
+}
+
+TEST(BenchInvoker, RepeatOnly) {
+    int runs = 0;
+    BenchInvoker{"repeat_only", ScopeMeta{}.setRepeat(7)} += [&]() {
+        ++runs;
+    };
+    EXPECT_EQ(runs, 7);
+}
+
+TEST(BenchInvoker, WarmupOnly) {
+    // Warmup-only is a legal but unusual configuration — the scope
+    // opens and closes immediately (no measured iterations). Useful
+    // for documenting "I ran N warmup launches outside any timed scope."
+    int runs = 0;
+    BenchInvoker{"warmup_only", ScopeMeta{}.setWarmup(5)} += [&]() {
+        ++runs;
+    };
+    EXPECT_EQ(runs, 5);
+}
+
+// ── Ordering: warmup runs BEFORE scope opens ──────────────────────────────
+//
+// We can't directly observe ScopedMonitor's open/close from here without
+// initializing the full runtime + a logger spy. Instead we use a tracker
+// that snapshots `runs` at every invocation and asserts the sequence is
+// `[1, 2, ..., warmup+repeat]` with no out-of-order calls — which is the
+// only property the macro contract makes.
+//
+// The "warmup happens before the scope" invariant is enforced by
+// inspection of BenchInvoker::operator+= (warmup for-loop, then
+// ScopedMonitor ctor, then repeat for-loop) and end-to-end by the
+// example's NDJSON log when run on real hardware.
+
+TEST(BenchInvoker, BodyInvocationsAreSequential) {
+    std::vector<int> trace;
+    BenchInvoker{"seq", ScopeMeta{}.setRepeat(4).setWarmup(2)} += [&]() {
+        trace.push_back(static_cast<int>(trace.size()) + 1);
+    };
+    ASSERT_EQ(trace.size(), 6u);
+    for (size_t i = 0; i < trace.size(); ++i) {
+        EXPECT_EQ(trace[i], static_cast<int>(i + 1));
+    }
+}
+
+// ── Lambda capture semantics ──────────────────────────────────────────────
+
+TEST(BenchInvoker, LambdaCapturesEnclosingState) {
+    // The macro uses `[&]` capture, so the lambda mutates enclosing
+    // locals. Verify multiple captured variables flow through.
+    int counter = 0;
+    int accumulator = 0;
+    BenchInvoker{"capture", ScopeMeta{}.setRepeat(5)} += [&]() {
+        ++counter;
+        accumulator += counter;  // 1 + 2 + 3 + 4 + 5 = 15
+    };
+    EXPECT_EQ(counter, 5);
+    EXPECT_EQ(accumulator, 15);
+}
+
+// ── Macro expansion test ──────────────────────────────────────────────────
+//
+// Verifies the GFL_BENCH macro itself (not just BenchInvoker) compiles
+// and behaves the same. Catches regressions in the macro definition —
+// e.g. the trailing `+= [&]()` pattern, the `__VA_ARGS__` forwarding,
+// or the ScopeMeta{...} wrapping.
+
+TEST(GflBenchMacro, RunsBodyWarmupPlusRepeatTimes) {
+    int runs = 0;
+    GFL_BENCH("macro_test",
+              gpufl::ScopeMeta{}.setRepeat(8).setWarmup(2)) {
+        ++runs;
+    };
+    EXPECT_EQ(runs, 10);
+}
+
+TEST(GflBenchMacro, EmptyMetaIsNoOpBody) {
+    int runs = 0;
+    GFL_BENCH("macro_empty", gpufl::ScopeMeta{}) { ++runs; };
+    EXPECT_EQ(runs, 0);
+}
+
+// ── Tag field flows through ───────────────────────────────────────────────
+
+TEST(ScopeMeta, BuilderChainSetsAllFields) {
+    auto meta = ScopeMeta{}
+                    .setTag("ml")
+                    .setRepeat(42)
+                    .setWarmup(7);
+    EXPECT_EQ(meta.tag, "ml");
+    EXPECT_EQ(meta.repeat, 42u);
+    EXPECT_EQ(meta.warmup, 7u);
+}
+
+TEST(ScopeMeta, DefaultsAreZeroAndEmpty) {
+    ScopeMeta meta;
+    EXPECT_TRUE(meta.tag.empty());
+    EXPECT_EQ(meta.repeat, 0u);
+    EXPECT_EQ(meta.warmup, 0u);
+}

--- a/tests/core/test_wire_contract.cpp
+++ b/tests/core/test_wire_contract.cpp
@@ -304,6 +304,12 @@ TEST(WireContract, DeviceMetricBatchExtendedColumns) {
 }
 
 // ── scope_event_batch ─────────────────────────────────────────────────────
+//
+// v2 format (1.0.3+): two extra columns `repeat` and `warmup` carry
+// benchmark metadata on BEGIN rows produced by GFL_BENCH / Python's
+// iterable Scope. Rows that don't set them (legacy GFL_SCOPE, END
+// rows) emit 0/0 — semantically a no-op for older readers that
+// project only the first 5 columns.
 TEST(WireContract, ScopeEventBatchColumns) {
     gpufl::BatchBuffer<gpufl::ScopeBatchRow> batch;
     gpufl::ScopeBatchRow begin{};
@@ -325,11 +331,48 @@ TEST(WireContract, ScopeEventBatchColumns) {
         gpufl::model::ScopeEventBatchModel(batch, "sess-1", 1).buildJson();
 
     EXPECT_TRUE(JsonContains(json, "\"type\":\"scope_event_batch\""));
+    EXPECT_TRUE(JsonContains(json, "\"version\":2"));
     EXPECT_TRUE(JsonContains(
         json,
         "\"columns\":[\"dt_ns\",\"scope_instance_id\",\"name_id\","
-        "\"event_type\",\"depth\"]"));
-    EXPECT_TRUE(JsonContains(json, "\"rows\":[[0,1,1,0,0],[5500,1,1,1,0]]"));
+        "\"event_type\",\"depth\",\"repeat\",\"warmup\"]"));
+    // BEGIN/END rows from a non-bench scope carry 0/0 in the trailing
+    // two columns — wire output is otherwise byte-identical to v1.
+    EXPECT_TRUE(JsonContains(json,
+        "\"rows\":[[0,1,1,0,0,0,0],[5500,1,1,1,0,0,0]]"));
+}
+
+// Verifies that when a scope's BEGIN row carries benchmark metadata
+// (set by GFL_BENCH / ScopedMonitor(name, ScopeMeta{...})), the
+// values surface on the wire. END rows always emit 0/0 — the backend
+// joins by scope_instance_id and reads metadata from the BEGIN row.
+TEST(WireContract, ScopeEventBatchCarriesRepeatAndWarmupOnBegin) {
+    gpufl::BatchBuffer<gpufl::ScopeBatchRow> batch;
+    gpufl::ScopeBatchRow begin{};
+    begin.ts_ns = 1000;
+    begin.scope_instance_id = 7;
+    begin.name_id = 3;
+    begin.event_type = 0;
+    begin.depth = 1;
+    begin.repeat = 10;
+    begin.warmup = 3;
+    batch.push(begin);
+    gpufl::ScopeBatchRow end{};
+    end.ts_ns = 2000;
+    end.scope_instance_id = 7;
+    end.name_id = 3;
+    end.event_type = 1;
+    end.depth = 1;
+    // repeat/warmup intentionally left at default 0 on the END row.
+    batch.push(end);
+
+    const std::string json =
+        gpufl::model::ScopeEventBatchModel(batch, "sess-1", 1).buildJson();
+
+    // BEGIN row: dt=0, instance=7, name=3, event=0, depth=1, repeat=10, warmup=3
+    // END   row: dt=1000, instance=7, name=3, event=1, depth=1, repeat=0, warmup=0
+    EXPECT_TRUE(JsonContains(json,
+        "\"rows\":[[0,7,3,0,1,10,3],[1000,7,3,1,1,0,0]]"));
 }
 
 // ── host_metric_batch ─────────────────────────────────────────────────────

--- a/tests/python/test_scope_iterable.py
+++ b/tests/python/test_scope_iterable.py
@@ -1,0 +1,271 @@
+"""
+Tests for the pure-Python wrapper layer in python/gpufl/__init__.py:
+
+  * gpufl.Scope context-manager form (legacy, unchanged)
+  * gpufl.Scope iterable form (repeat + warmup, new in 1.0.3)
+  * The "<name>_warmup" sub-scope opened automatically when warmup > 0
+  * gpufl.clean_logs() — prefix-scoped deletion + active-session guard
+
+These all run without a GPU by monkey-patching the C++ _CScope binding
+with a recording fake. The fake captures every constructor call and every
+__enter__ / __exit__ so we can assert on (a) the kwargs forwarded to C++,
+and (b) the open/close ordering between the warmup sub-scope and the
+main scope.
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+# Mirror test_bindings.py — add the source python/ dir to sys.path so a
+# git-checkout dev environment doesn't need an installed wheel.
+sys.path.insert(0, str(Path(__file__).parent.parent.parent / "python"))
+
+import gpufl
+
+
+# ---------------------------------------------------------------------------
+# Fixture: replace the C++ _CScope with a recording fake
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def fake_cscope(monkeypatch):
+    """Patch gpufl._CScope so we can observe ctor args + open/close order."""
+    events = []      # list of ("enter"|"exit", scope_name)
+    ctor_calls = []  # list of (positional_args, kwargs)
+
+    class FakeCScope:
+        def __init__(self, *args, **kwargs):
+            ctor_calls.append((args, kwargs))
+            self._name = args[0] if args else "?"
+
+        def __enter__(self):
+            events.append(("enter", self._name))
+            return self
+
+        def __exit__(self, *_):
+            events.append(("exit", self._name))
+            return False
+
+    # The Scope wrapper looks up `_CScope` as a module global, resolved at
+    # call time — monkeypatching gpufl._CScope is enough; no reload needed.
+    monkeypatch.setattr(gpufl, "_CScope", FakeCScope)
+    return events, ctor_calls
+
+
+# ---------------------------------------------------------------------------
+# Context-manager form — must be byte-identical to pre-1.0.3 behavior
+# ---------------------------------------------------------------------------
+
+class TestScopeContextManager:
+    def test_plain_with_no_kwargs(self, fake_cscope):
+        events, ctor_calls = fake_cscope
+        with gpufl.Scope("inference"):
+            pass
+        # Legacy fast path: no repeat/warmup kwargs forwarded to C++.
+        assert ctor_calls == [(("inference", ""), {})]
+        assert events == [("enter", "inference"), ("exit", "inference")]
+
+    def test_with_tag_passes_positionally(self, fake_cscope):
+        events, ctor_calls = fake_cscope
+        with gpufl.Scope("forward", "ml"):
+            pass
+        assert ctor_calls == [(("forward", "ml"), {})]
+
+
+# ---------------------------------------------------------------------------
+# Iterable form — repeat without warmup
+# ---------------------------------------------------------------------------
+
+class TestScopeIterableRepeatOnly:
+    def test_repeat_yields_zero_to_n_minus_one(self, fake_cscope):
+        seen = list(gpufl.Scope("hot", repeat=5))
+        assert seen == [0, 1, 2, 3, 4]
+
+    def test_repeat_forwards_kwargs_to_cscope(self, fake_cscope):
+        events, ctor_calls = fake_cscope
+        list(gpufl.Scope("hot", repeat=5))
+        # Exactly one scope is constructed (no warmup sub-scope when warmup=0)
+        assert len(ctor_calls) == 1
+        args, kwargs = ctor_calls[0]
+        assert args == ("hot", "")
+        assert kwargs == {"repeat": 5, "warmup": 0}
+
+    def test_repeat_zero_runs_no_body_but_opens_scope(self, fake_cscope):
+        events, ctor_calls = fake_cscope
+        seen = list(gpufl.Scope("empty", repeat=0))
+        assert seen == []
+        # Main scope still opens and closes (empty BEGIN/END pair in the log).
+        assert events == [("enter", "empty"), ("exit", "empty")]
+
+
+# ---------------------------------------------------------------------------
+# Iterable form — warmup>0 opens the "<name>_warmup" sub-scope
+# ---------------------------------------------------------------------------
+
+class TestScopeIterableWarmup:
+    def test_warmup_yields_negative_indices_then_measured(self, fake_cscope):
+        seen = list(gpufl.Scope("matmul", repeat=10, warmup=3))
+        # Warmup: -3, -2, -1 (so `i >= 0` marks a measured iteration)
+        # Measured: 0..9
+        assert seen == [-3, -2, -1, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+
+    def test_warmup_opens_sub_scope_before_main_scope(self, fake_cscope):
+        """The key 1.0.3+ invariant — warmup events get their own bucket."""
+        events, ctor_calls = fake_cscope
+        list(gpufl.Scope("matmul", repeat=10, warmup=3))
+
+        # Two scopes constructed in order: warmup sub-scope, then main.
+        assert len(ctor_calls) == 2
+
+        warmup_args, warmup_kwargs = ctor_calls[0]
+        assert warmup_args == ("matmul_warmup", "")
+        # Sub-scope carries repeat=warmup_count so the analyzer's
+        # per-iter math works for the cold-start cost. warmup=0 because
+        # the sub-scope IS the warmup phase (not a nested benchmark).
+        assert warmup_kwargs == {"repeat": 3, "warmup": 0}
+
+        main_args, main_kwargs = ctor_calls[1]
+        assert main_args == ("matmul", "")
+        # Main scope keeps the original metadata — warmup count records
+        # for audit ("3 warmup launches were excluded from this scope").
+        assert main_kwargs == {"repeat": 10, "warmup": 3}
+
+        # Ordering: warmup scope is fully opened AND closed before the
+        # main scope opens. This is the contract that lets the analyzer
+        # cleanly partition kernel events into cold-start vs steady-state.
+        assert events == [
+            ("enter", "matmul_warmup"),
+            ("exit",  "matmul_warmup"),
+            ("enter", "matmul"),
+            ("exit",  "matmul"),
+        ]
+
+    def test_warmup_only_no_repeat_still_opens_both(self, fake_cscope):
+        """warmup=K with repeat=0 still produces sub-scope + empty main."""
+        events, ctor_calls = fake_cscope
+        seen = list(gpufl.Scope("name", repeat=0, warmup=2))
+        assert seen == [-2, -1]
+        assert len(ctor_calls) == 2  # sub-scope + main (empty)
+        assert events == [
+            ("enter", "name_warmup"),
+            ("exit",  "name_warmup"),
+            ("enter", "name"),
+            ("exit",  "name"),
+        ]
+
+    def test_tag_inherits_into_warmup_subscope(self, fake_cscope):
+        """User-provided tag flows to both warmup and main scopes."""
+        events, ctor_calls = fake_cscope
+        list(gpufl.Scope("op", "ml", repeat=2, warmup=1))
+        assert ctor_calls[0][0] == ("op_warmup", "ml")
+        assert ctor_calls[1][0] == ("op", "ml")
+
+
+# ---------------------------------------------------------------------------
+# Iterable form — error paths
+# ---------------------------------------------------------------------------
+
+class TestScopeIterableErrors:
+    def test_iter_without_repeat_raises_eagerly(self, fake_cscope):
+        events, _ = fake_cscope
+        # Validation happens in __iter__, BEFORE the generator starts,
+        # so the for-loop raises on entry rather than swallowing into
+        # a later StopIteration.
+        with pytest.raises(TypeError, match=r"repeat"):
+            for _ in gpufl.Scope("no_repeat"):
+                pass  # pragma: no cover — should not execute
+        # No scopes were constructed.
+        assert events == []
+
+    def test_exception_in_body_closes_main_scope(self, fake_cscope):
+        events, _ = fake_cscope
+        with pytest.raises(ValueError, match="kaboom"):
+            for i in gpufl.Scope("crash", repeat=5):
+                if i == 1:
+                    raise ValueError("kaboom")
+        # The main scope's finally-block ran the exit even on exception.
+        assert events[-1] == ("exit", "crash")
+
+    def test_negative_repeat_rejected(self):
+        with pytest.raises(ValueError, match=r">= 0"):
+            gpufl.Scope("x", repeat=-1)
+
+    def test_negative_warmup_rejected(self):
+        with pytest.raises(ValueError, match=r">= 0"):
+            gpufl.Scope("x", warmup=-1)
+
+
+# ---------------------------------------------------------------------------
+# clean_logs
+# ---------------------------------------------------------------------------
+
+class TestCleanLogs:
+    def test_refuses_during_active_session(self):
+        """Calling clean_logs between init() and shutdown() raises."""
+        # Manually set the guard the init() wrapper would set on success.
+        gpufl._session_active = True
+        try:
+            with pytest.raises(RuntimeError, match=r"session is active"):
+                gpufl.clean_logs("./irrelevant")
+        finally:
+            gpufl._session_active = False
+
+    def test_dry_run_lists_matches_without_deleting(self, tmp_path):
+        # Mix of matching + unrelated files; only the prefix-scoped ones
+        # should be returned.
+        for name in [
+            "gfl_logs.device.log",
+            "gfl_logs.scope.1.log.gz",
+            "gfl_logs.kernel.log",
+            "notes.txt",          # unrelated — must NOT be touched
+            "other.device.log",   # different prefix — must NOT be touched
+        ]:
+            (tmp_path / name).touch()
+
+        base = tmp_path / "gfl_logs"
+        preview = gpufl.clean_logs(str(base), dry_run=True)
+
+        # Three matching files, prefix-scoped.
+        names = sorted(Path(p).name for p in preview)
+        assert names == [
+            "gfl_logs.device.log",
+            "gfl_logs.kernel.log",
+            "gfl_logs.scope.1.log.gz",
+        ]
+        # Dry-run must NOT delete anything.
+        assert (tmp_path / "gfl_logs.device.log").exists()
+        assert (tmp_path / "notes.txt").exists()
+
+    def test_actual_delete_keeps_unrelated_files(self, tmp_path):
+        for name in [
+            "gfl_logs.device.log",
+            "gfl_logs.scope.1.log.gz",
+            "notes.txt",
+            "other.device.log",
+        ]:
+            (tmp_path / name).touch()
+
+        base = tmp_path / "gfl_logs"
+        removed = gpufl.clean_logs(str(base))
+
+        assert len(removed) == 2
+        survivors = sorted(p.name for p in tmp_path.iterdir())
+        # Only the unrelated files survive.
+        assert survivors == ["notes.txt", "other.device.log"]
+
+    def test_defaults_to_last_init_path(self, tmp_path, monkeypatch):
+        """No args → uses the path stashed by the most recent init()."""
+        (tmp_path / "my_app.device.log").touch()
+        monkeypatch.setattr(gpufl, "_last_log_path", str(tmp_path / "my_app"))
+        monkeypatch.setattr(gpufl, "_last_app_name", "my_app")
+
+        removed = gpufl.clean_logs()
+        assert len(removed) == 1
+        assert Path(removed[0]).name == "my_app.device.log"
+
+    def test_no_path_and_no_prior_init_raises(self, monkeypatch):
+        monkeypatch.setattr(gpufl, "_last_log_path", None)
+        monkeypatch.setattr(gpufl, "_last_app_name", None)
+        with pytest.raises(ValueError, match=r"log_path"):
+            gpufl.clean_logs()


### PR DESCRIPTION
## Description
- Adds `gpufl::ScopeMeta` (tag/repeat/warmup) carried on the BEGIN row of `scope_event_batch` (wire format v1 → v2; new columns default to 0 so old readers keep working).
- New `GFL_BENCH(name, ScopeMeta{}.setRepeat(N).setWarmup(K)) { body };` macro runs the body warmup+repeat times automatically via a template-lambda `BenchInvoker`.
- Warmup iterations get their own `<name>_warmup` sub-scope so cold-start kernels show up as a distinct bucket in the report instead of being attributed to the global scope.
- Python `for _ in gpufl.Scope(name, repeat=N, warmup=K)` mirrors the C++ behavior; new `gpufl.clean_logs()` helper for resetting log dirs between runs.
- Existing `GFL_SCOPE("name") { ... }` call sites are unchanged.
## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update

## Testing
## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas