### PR TITLE
Rephrase profiling-engine taxonomy + stabilize SASS / Deep / PerfWorks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,17 +107,23 @@ suggesting `--force`; `--all-sessions` mode silently skips completed
 sessions and uploads the rest. Survives across runs to skip
 already-uploaded rotated files.
 
-#### `ProfilingEngine` friendly aliases
+#### `ProfilingEngine` — clarified names
 
-| Alias | Underlying enum value |
+The engine enum was reworked into a single, plainly-named ladder
+(no aliases). New default is `Monitor` (telemetry only, no CUPTI).
+
+| Name | What it captures |
 |---|---|
-| `Continuous` | `PcSampling` |
-| `Deep` | `PcSamplingWithSass` |
-| `Range` | `RangeProfiler` |
+| `Monitor` | GPU/host health metrics only — no CUPTI. The default. |
+| `Trace` | + activity trace: kernels, memcpy, sync (no sampling) |
+| `PcSampling` | + PC stall-reason sampling |
+| `SassMetrics` | + per-instruction SASS counters |
+| `RangeProfiler` | + hardware throughput counters |
+| `Deep` | `PcSampling` + `SassMetrics` in one run |
 
-Both names are accepted as wire-format values, kwarg values, and
-env-var values. Old names stay as the canonical enum members; new
-names are class attributes pointing at the same values.
+Replaces the earlier `None` / `KernelTrace` / `Continuous` / `Range` /
+`PcSamplingWithSass` names. Pre-1.0, no deprecation shim — the old
+names are gone.
 
 #### Ref-counted system-metric sampler
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -242,6 +242,7 @@ if(GPUFL_ENABLE_NVIDIA)
                 include/gpufl/backends/nvidia/sampler/cupti_sass.hpp
                 include/gpufl/backends/nvidia/cuda_collector.cpp
                 include/gpufl/backends/nvidia/cupti_utils.cpp
+                include/gpufl/backends/nvidia/cuda_cleanup_handler.cpp
                 include/gpufl/backends/nvidia/resource_handler.cpp
                 include/gpufl/backends/nvidia/kernel_launch_handler.cpp
                 include/gpufl/backends/nvidia/mem_transfer_handler.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ project(gpufl_client
 # `project(... VERSION ...)`, so we layer them on top here. To promote
 # 1.1.0rc1 → 1.1.0 final, set this to the empty string. To bump rc1 →
 # rc2 mid-validation, change just this line.
-set(GPUFL_VERSION_SUFFIX "rc1")
+set(GPUFL_VERSION_SUFFIX "rc2")
 
 # -----------------------
 # CUDA Architectures (CI Friendly)

--- a/benchmark/README.md
+++ b/benchmark/README.md
@@ -26,10 +26,10 @@ python run_benchmark.py
 | Mode | Engine | What it measures |
 |------|--------|-----------------|
 | Baseline | — | Pure CUDA/PyTorch, no GPUFlight |
-| Monitoring only | `None_` | System metrics (GPU util, temp, mem) only |
+| Monitoring only | `Monitor` | System metrics (GPU util, temp, mem) only, no CUPTI |
 | PC Sampling | `PcSampling` | Stall reason sampling |
 | SASS Metrics | `SassMetrics` | Instruction-level counters |
-| PcSampling + SASS | `PcSamplingWithSass` | Full profiling (default) |
+| PcSampling + SASS | `Deep` | Full profiling (PC sampling + SASS) |
 
 ## Workloads
 
@@ -66,6 +66,6 @@ Tested on NVIDIA GeForce RTX 5060 Laptop GPU (8.0 GiB), GPUFlight v0.1.0.dev.
 - **PC Sampling: high overhead on many-small-kernel workloads** (PyTorch launches thousands of micro-kernels). Use for targeted profiling sessions, not always-on. Set via environment variable:
   ```bash
   GPUFL_PROFILING_ENGINE=SassMetrics python train.py  # low-overhead
-  GPUFL_PROFILING_ENGINE=PcSamplingWithSass python train.py  # full (default)
+  GPUFL_PROFILING_ENGINE=Deep python train.py          # full (PC sampling + SASS)
   ```
 - **GEMM (large kernels):** overhead is moderate even with full profiling, because per-kernel CUPTI cost is amortized over longer kernel execution

--- a/benchmark/profile_pytorch_via_gpufl.py
+++ b/benchmark/profile_pytorch_via_gpufl.py
@@ -51,18 +51,19 @@ def run_minigpt_under_gpufl(steps: int, warmup_steps: int, batch_size: int,
                   # error if gpufl isn't installed
     log_dir.mkdir(parents=True, exist_ok=True)
 
-    # Monitoring-only mode — engine=None_ means CUPTI is enabled for
-    # kernel activity records (which is what gives us duration_ns) but
-    # PC sampling is OFF, so we're not measuring the +657% overhead
-    # case — just the kernel timing ground truth. PC sampling on or
-    # off, the kernel duration_ns values are the same because they
-    # come from CUPTI's KIND_KERNEL records either way.
+    # Trace mode — kernel activity records are on (that's what gives us
+    # duration_ns) but PC sampling is OFF, so we're not measuring the
+    # +657% overhead case, just the kernel-timing ground truth. (Note:
+    # NOT Monitor — that disables CUPTI entirely and would yield zero
+    # kernel records. We need the activity trace.) PC sampling on or off,
+    # the duration_ns values are identical — they come from CUPTI's
+    # KIND_KERNEL records either way.
     ok = gpufl.init(
         "minigpt_kernel_profile",
         str(log_dir),
         True,  # continuous_system_sampling — unused but historically positional
         0,     # system_sample_rate_ms — off
-        profiling_engine=gpufl.ProfilingEngine.None_,
+        profiling_engine=gpufl.ProfilingEngine.Trace,
         enable_debug_output=False,  # debug stderr spam dominated overhead
                                     # in earlier runs — keep off for clean
                                     # kernel timing

--- a/benchmark/run_benchmark.py
+++ b/benchmark/run_benchmark.py
@@ -32,7 +32,7 @@ CONFIGS = [
     {
         'name': 'Monitoring only',
         'use_gpufl': True,
-        'engine': 'None_',
+        'engine': 'Monitor',
         'desc': 'System metrics sampling, no CUPTI',
     },
     {
@@ -50,8 +50,8 @@ CONFIGS = [
     {
         'name': 'PcSampling + SASS',
         'use_gpufl': True,
-        'engine': 'PcSamplingWithSass',
-        'desc': 'Full profiling (default)',
+        'engine': 'Deep',
+        'desc': 'Full profiling (PC sampling + SASS)',
     },
 ]
 
@@ -65,10 +65,7 @@ def setup_gpufl(config: dict, log_dir: str) -> bool:
     try:
         import gpufl
         engine_name = config['engine']
-        # C++ binding uses 'None', Python stub uses 'None_'
-        engine = getattr(gpufl.ProfilingEngine, engine_name, None)
-        if engine is None and engine_name == 'None_':
-            engine = getattr(gpufl.ProfilingEngine, 'None')
+        engine = getattr(gpufl.ProfilingEngine, engine_name)
         log_path = os.path.join(log_dir, 'bench')
         result = gpufl.init(
             app_name='benchmark',

--- a/daemon/monitor/main.cpp
+++ b/daemon/monitor/main.cpp
@@ -84,7 +84,11 @@ int main() {
     gpufl::InitOptions opts;
     opts.app_name = appName;
     opts.log_path = logPath;
-    opts.profiling_engine = gpufl::ProfilingEngine::None;
+    // Telemetry-only daemon: Monitor means no CUPTI at all, just the
+    // NVML/host metrics sampler driven by continuous_system_sampling
+    // below. (This used to pass `None`, which despite the name still
+    // subscribed CUPTI and captured kernel events the daemon never wanted.)
+    opts.profiling_engine = gpufl::ProfilingEngine::Monitor;
     opts.continuous_system_sampling = true;
     opts.system_sample_rate_ms = intervalMs;
     opts.enable_debug_output = true;

--- a/example/cuda/block_style_example.cu
+++ b/example/cuda/block_style_example.cu
@@ -41,7 +41,7 @@ int main() {
     opts.continuous_system_sampling = true;
     opts.enable_debug_output = true;
     opts.enable_source_collection = true;
-    opts.profiling_engine = gpufl::ProfilingEngine::PcSamplingWithSass;
+    opts.profiling_engine = gpufl::ProfilingEngine::Deep;
 
     if (!gpufl::init(opts)) {
         std::cerr << "Failed to initialize gpufl" << std::endl;

--- a/example/cuda/manykernel_benchmark.cu
+++ b/example/cuda/manykernel_benchmark.cu
@@ -304,16 +304,20 @@ static bool gpufl_init_for(Mode m) {
             opts.profiling_engine = gpufl::ProfilingEngine::PcSampling;
             break;
         case Mode::PcSamplingWithSass:
-            // "Deep" — PC sampling + SASS metrics. SASS metrics use
+            // gpufl Deep = PC sampling + SASS metrics. SASS metrics use
             // cuptiProfilerInitialize which has reportedly returned
             // CUPTI_ERROR_UNKNOWN (999) on Blackwell in earlier runs;
             // if init fails the mode is skipped cleanly via the
             // !gpufl_init_for(m) branch in run_mode().
-            opts.profiling_engine = gpufl::ProfilingEngine::PcSamplingWithSass;
+            opts.profiling_engine = gpufl::ProfilingEngine::Deep;
             break;
         case Mode::Monitoring:
         default:
-            opts.profiling_engine = gpufl::ProfilingEngine::None;
+            // The benchmark's "Monitoring" mode measures kernel-event
+            // capture overhead, so it maps to gpufl Trace (activity
+            // records, no sampling) — NOT gpufl Monitor, which disables
+            // CUPTI entirely and would capture no kernels to measure.
+            opts.profiling_engine = gpufl::ProfilingEngine::Trace;
             break;
     }
     return gpufl::init(opts);

--- a/example/cuda/memory_coalescing_demo.cu
+++ b/example/cuda/memory_coalescing_demo.cu
@@ -63,7 +63,7 @@ int main() {
     opts.kernel_sample_rate_ms = 10;
     opts.continuous_system_sampling = true;
     opts.enable_debug_output = true;
-    opts.profiling_engine = gpufl::ProfilingEngine::PcSamplingWithSass;
+    opts.profiling_engine = gpufl::ProfilingEngine::Deep;
     gpufl::init(opts);
 
     constexpr int M = 512, K = 256, N = 512;

--- a/example/cuda/sass_divergence_demo.cu
+++ b/example/cuda/sass_divergence_demo.cu
@@ -150,7 +150,7 @@ int main() {
     opts.enable_debug_output = true;
     opts.continuous_system_sampling = true;
     opts.enable_stack_trace = true;
-    opts.profiling_engine = gpufl::ProfilingEngine::PcSamplingWithSass;
+    opts.profiling_engine = gpufl::ProfilingEngine::Deep;
 
     if (!gpufl::init(opts)) {
         std::cerr << "Failed to initialize gpufl" << std::endl;

--- a/example/cuda/vector_add_benchmark.cu
+++ b/example/cuda/vector_add_benchmark.cu
@@ -30,7 +30,7 @@ int main() {
     opts.continuous_system_sampling = true;
     opts.enable_debug_output = true;
     opts.enable_source_collection = true;
-    opts.profiling_engine = gpufl::ProfilingEngine::None;
+    opts.profiling_engine = gpufl::ProfilingEngine::Trace;
 
     if (!gpufl::init(opts)) {
         std::cerr << "Failed to initialize gpufl" << std::endl;

--- a/example/python/02_numba_cuda.py
+++ b/example/python/02_numba_cuda.py
@@ -48,7 +48,7 @@ def run_benchmark():
         continuous_system_sampling=True,
         system_sample_rate_ms=100,
         enable_debug_output=True,
-        profiling_engine=gfl.ProfilingEngine.PcSamplingWithSass,
+        profiling_engine=gfl.ProfilingEngine.Deep,
         backend_url=BACKEND_URL,
         api_key=API_KEY,
     )

--- a/example/python/03_pytorch_benchmark.py
+++ b/example/python/03_pytorch_benchmark.py
@@ -47,7 +47,7 @@ def run_stress_test():
                enable_cuda_graphs_tracking=True,
                api_key=api_key,
                backend_url=backend_url,
-               profiling_engine=gpufl.ProfilingEngine.None_)
+               profiling_engine=gpufl.ProfilingEngine.Deep)
 
     try:
         # 2. Allocate (Uses approx 3GB VRAM)

--- a/include/gpufl/backends/amd/rocprofiler_backend.cpp
+++ b/include/gpufl/backends/amd/rocprofiler_backend.cpp
@@ -262,14 +262,20 @@ int RocprofilerBackend::toolInitialize() {
     // Create profiling engine based on user configuration.
     // On AMD, PC sampling and counter collection cannot coexist in the same
     // context, so PcSamplingWithSass falls back to dispatch counters.
-    if (opts_.profiling_engine != ProfilingEngine::None && primary_gpu_agent_.handle != 0) {
+    // Trace (activity records only) creates no engine — the switch
+    // default covers it. ProfilingEngine::Monitor never reaches this
+    // backend (CreateMonitorAdapter returns nullptr for it), but guard
+    // anyway so a directly-constructed Monitor backend stays engine-free.
+    if (opts_.profiling_engine != ProfilingEngine::Trace &&
+        opts_.profiling_engine != ProfilingEngine::Monitor &&
+        primary_gpu_agent_.handle != 0) {
         switch (opts_.profiling_engine) {
             case ProfilingEngine::PcSampling:
                 // TODO: engine_ = std::make_unique<AmdPcSamplingEngine>();
                 GFL_LOG_DEBUG("[ROCProfilerBackend] PC sampling engine requested (not yet implemented)");
                 break;
             case ProfilingEngine::SassMetrics:
-            case ProfilingEngine::PcSamplingWithSass:
+            case ProfilingEngine::Deep:
             case ProfilingEngine::RangeProfiler:
                 engine_ = std::make_unique<DispatchCounterEngine>();
                 break;

--- a/include/gpufl/backends/nvidia/cuda_cleanup_handler.cpp
+++ b/include/gpufl/backends/nvidia/cuda_cleanup_handler.cpp
@@ -1,0 +1,93 @@
+#include "gpufl/backends/nvidia/cuda_cleanup_handler.hpp"
+
+#include "gpufl/core/scope_registry.hpp"
+
+namespace gpufl {
+
+std::vector<std::pair<CUpti_CallbackDomain, CUpti_CallbackId>>
+CudaCleanupHandler::requiredCallbacks() const {
+    return {
+        {CUPTI_CB_DOMAIN_RUNTIME_API, CUPTI_RUNTIME_TRACE_CBID_cudaFree_v3020},
+        {CUPTI_CB_DOMAIN_RUNTIME_API, CUPTI_RUNTIME_TRACE_CBID_cudaFreeArray_v3020},
+        {CUPTI_CB_DOMAIN_RUNTIME_API, CUPTI_RUNTIME_TRACE_CBID_cudaFreeHost_v3020},
+        {CUPTI_CB_DOMAIN_RUNTIME_API, CUPTI_RUNTIME_TRACE_CBID_cudaFreeMipmappedArray_v5000},
+        {CUPTI_CB_DOMAIN_RUNTIME_API, CUPTI_RUNTIME_TRACE_CBID_cudaDeviceReset_v3020},
+#if defined(CUPTI_RUNTIME_TRACE_CBID_cudaFreeAsync_v11020)
+        {CUPTI_CB_DOMAIN_RUNTIME_API, CUPTI_RUNTIME_TRACE_CBID_cudaFreeAsync_v11020},
+#endif
+#if defined(CUPTI_RUNTIME_TRACE_CBID_cudaFreeAsync_ptsz_v11020)
+        {CUPTI_CB_DOMAIN_RUNTIME_API, CUPTI_RUNTIME_TRACE_CBID_cudaFreeAsync_ptsz_v11020},
+#endif
+        {CUPTI_CB_DOMAIN_DRIVER_API, CUPTI_DRIVER_TRACE_CBID_cuMemFree},
+        {CUPTI_CB_DOMAIN_DRIVER_API, CUPTI_DRIVER_TRACE_CBID_cuMemFree_v2},
+        {CUPTI_CB_DOMAIN_DRIVER_API, CUPTI_DRIVER_TRACE_CBID_cuMemFreeHost},
+        {CUPTI_CB_DOMAIN_DRIVER_API, CUPTI_DRIVER_TRACE_CBID_cuCtxDestroy},
+        {CUPTI_CB_DOMAIN_DRIVER_API, CUPTI_DRIVER_TRACE_CBID_cuCtxDestroy_v2},
+#if defined(CUPTI_DRIVER_TRACE_CBID_cuMemFreeAsync)
+        {CUPTI_CB_DOMAIN_DRIVER_API, CUPTI_DRIVER_TRACE_CBID_cuMemFreeAsync},
+#endif
+#if defined(CUPTI_DRIVER_TRACE_CBID_cuMemFreeAsync_ptsz)
+        {CUPTI_CB_DOMAIN_DRIVER_API, CUPTI_DRIVER_TRACE_CBID_cuMemFreeAsync_ptsz},
+#endif
+    };
+}
+
+bool CudaCleanupHandler::shouldHandle(CUpti_CallbackDomain domain,
+                                      CUpti_CallbackId cbid) const {
+    for (const auto& cb : requiredCallbacks()) {
+        if (cb.first == domain && cb.second == cbid) return true;
+    }
+    return false;
+}
+
+const char* CudaCleanupHandler::CleanupReason(CUpti_CallbackDomain domain,
+                                              CUpti_CallbackId cbid) {
+    if (domain == CUPTI_CB_DOMAIN_RUNTIME_API) {
+        switch (cbid) {
+            case CUPTI_RUNTIME_TRACE_CBID_cudaFree_v3020: return "cudaFree";
+            case CUPTI_RUNTIME_TRACE_CBID_cudaFreeArray_v3020: return "cudaFreeArray";
+            case CUPTI_RUNTIME_TRACE_CBID_cudaFreeHost_v3020: return "cudaFreeHost";
+            case CUPTI_RUNTIME_TRACE_CBID_cudaFreeMipmappedArray_v5000: return "cudaFreeMipmappedArray";
+            case CUPTI_RUNTIME_TRACE_CBID_cudaDeviceReset_v3020: return "cudaDeviceReset";
+#if defined(CUPTI_RUNTIME_TRACE_CBID_cudaFreeAsync_v11020)
+            case CUPTI_RUNTIME_TRACE_CBID_cudaFreeAsync_v11020: return "cudaFreeAsync";
+#endif
+#if defined(CUPTI_RUNTIME_TRACE_CBID_cudaFreeAsync_ptsz_v11020)
+            case CUPTI_RUNTIME_TRACE_CBID_cudaFreeAsync_ptsz_v11020: return "cudaFreeAsync_ptsz";
+#endif
+            default: return "runtime_cleanup";
+        }
+    }
+
+    switch (cbid) {
+        case CUPTI_DRIVER_TRACE_CBID_cuMemFree: return "cuMemFree";
+        case CUPTI_DRIVER_TRACE_CBID_cuMemFree_v2: return "cuMemFree_v2";
+        case CUPTI_DRIVER_TRACE_CBID_cuMemFreeHost: return "cuMemFreeHost";
+        case CUPTI_DRIVER_TRACE_CBID_cuCtxDestroy: return "cuCtxDestroy";
+        case CUPTI_DRIVER_TRACE_CBID_cuCtxDestroy_v2: return "cuCtxDestroy_v2";
+#if defined(CUPTI_DRIVER_TRACE_CBID_cuMemFreeAsync)
+        case CUPTI_DRIVER_TRACE_CBID_cuMemFreeAsync: return "cuMemFreeAsync";
+#endif
+#if defined(CUPTI_DRIVER_TRACE_CBID_cuMemFreeAsync_ptsz)
+        case CUPTI_DRIVER_TRACE_CBID_cuMemFreeAsync_ptsz: return "cuMemFreeAsync_ptsz";
+#endif
+        default: return "driver_cleanup";
+    }
+}
+
+void CudaCleanupHandler::handle(CUpti_CallbackDomain domain,
+                                CUpti_CallbackId cbid, const void* cbdata) {
+    if (!backend_) return;
+
+    auto* cbInfo = static_cast<const CUpti_CallbackData*>(cbdata);
+    if (!cbInfo || cbInfo->callbackSite != CUPTI_API_ENTER) return;
+
+    // Only use cleanup APIs as an automatic final-flush boundary outside a
+    // measured scope. Frees inside an active scope are part of user work and
+    // should not trigger the mid-run SASS flush path we avoid for PyTorch.
+    if (!getThreadScopeStack().empty()) return;
+
+    backend_->FlushProfilingDataBeforeCudaTeardown(CleanupReason(domain, cbid));
+}
+
+}  // namespace gpufl

--- a/include/gpufl/backends/nvidia/cuda_cleanup_handler.hpp
+++ b/include/gpufl/backends/nvidia/cuda_cleanup_handler.hpp
@@ -1,0 +1,27 @@
+#pragma once
+
+#include "gpufl/backends/nvidia/cupti_backend.hpp"
+#include "gpufl/backends/nvidia/cupti_common.hpp"
+
+namespace gpufl {
+
+class CudaCleanupHandler : public ICuptiHandler {
+   public:
+    explicit CudaCleanupHandler(CuptiBackend* backend) : backend_(backend) {}
+
+    const char* getName() const override { return "CudaCleanupHandler"; }
+    bool shouldHandle(CUpti_CallbackDomain domain,
+                      CUpti_CallbackId cbid) const override;
+    void handle(CUpti_CallbackDomain domain, CUpti_CallbackId cbid,
+                const void* cbdata) override;
+    std::vector<std::pair<CUpti_CallbackDomain, CUpti_CallbackId>>
+    requiredCallbacks() const override;
+
+   private:
+    static const char* CleanupReason(CUpti_CallbackDomain domain,
+                                     CUpti_CallbackId cbid);
+
+    CuptiBackend* backend_ = nullptr;
+};
+
+}  // namespace gpufl

--- a/include/gpufl/backends/nvidia/cupti_backend.cpp
+++ b/include/gpufl/backends/nvidia/cupti_backend.cpp
@@ -402,7 +402,6 @@ void CuptiBackend::shutdown() {
     if (engine_) {
         engine_->stop();
         engine_->shutdown();
-        engine_.reset();
     }
 
     // Belt-and-suspenders final drain. stop() already disabled all
@@ -421,6 +420,8 @@ void CuptiBackend::shutdown() {
     cudaDeviceSynchronize();
     LogCuptiIfUnexpected("shutdown", "cuptiActivityFlushAll(final)",
                          cuptiActivityFlushAll(1));
+    EmitCaptureCapabilities_();
+    if (engine_) engine_.reset();
 
     cuptiUnsubscribe(subscriber_);
     g_activeBackend.store(nullptr, std::memory_order_release);
@@ -436,6 +437,11 @@ void CuptiBackend::start() {
     kernel_activity_seen_.store(0, std::memory_order_relaxed);
     kernel_activity_emitted_.store(0, std::memory_order_relaxed);
     kernel_activity_throttled_.store(0, std::memory_order_relaxed);
+    memory_activity_emitted_.store(0, std::memory_order_relaxed);
+    external_correlation_seen_.store(0, std::memory_order_relaxed);
+    source_locator_seen_.store(0, std::memory_order_relaxed);
+    function_record_seen_.store(0, std::memory_order_relaxed);
+    capture_capabilities_emitted_.store(false, std::memory_order_relaxed);
 
     // Resolve CUDA context/device before asking handlers for activity kinds.
     // SASS safe-mode policy is device dependent, and the policy log should
@@ -833,8 +839,6 @@ void CuptiBackend::start() {
             " (CUptiResult=", static_cast<int>(g_res), ")");
     }
 
-    EmitCaptureCapabilities_();
-
     active_.store(true);
     GFL_LOG_DEBUG("Backend started.");
 }
@@ -843,26 +847,51 @@ void CuptiBackend::start() {
 void CuptiBackend::EmitCaptureCapabilities_() const {
     const Runtime* rt = runtime();
     if (!(rt && rt->logger)) return;
+    if (capture_capabilities_emitted_.exchange(true, std::memory_order_acq_rel)) {
+        return;
+    }
 
     const bool sassMode = IsSassProfilerMode();
     const bool kernelActivity = !sassMode || AllowSassKernelActivity();
     const bool syntheticKernels = sassMode && !kernelActivity;
     const bool cubinCapture = NeedsCubinCapture();
 
-    bool sassActive = opts_.profiling_engine == ProfilingEngine::SassMetrics &&
-                      engine_ && engine_->isOperational();
-    bool pcActive = opts_.profiling_engine == ProfilingEngine::PcSampling &&
-                    engine_ && engine_->isOperational();
-    if (opts_.profiling_engine == ProfilingEngine::Deep) {
-        if (const auto* deep = dynamic_cast<const PcSamplingWithSassEngine*>(engine_.get())) {
-            sassActive = deep->sassActive();
-            pcActive = deep->pcSamplingActive();
+    bool sassActive = false;
+    bool pcActive = false;
+
+    // Capability emission happens after final engine shutdown so the report can
+    // see late-flushed samples. Some engines drop their operational flag during
+    // shutdown, so keep a path active if it was requested and produced data.
+    if (opts_.profiling_engine == ProfilingEngine::SassMetrics && engine_) {
+        sassActive = engine_->isOperational() || engine_->producedData();
+    } else if (opts_.profiling_engine == ProfilingEngine::PcSampling && engine_) {
+        pcActive = engine_->isOperational() || engine_->producedData();
+    } else if (opts_.profiling_engine == ProfilingEngine::Deep) {
+        if (const auto* deep =
+                dynamic_cast<const PcSamplingWithSassEngine*>(engine_.get())) {
+            sassActive = deep->sassActive() || deep->sassProducedData();
+            pcActive = deep->pcSamplingActive() || deep->pcProducedData();
         }
     }
 
     // Did each path actually emit rows (vs merely arm)? Drives the
     // "enabled_no_data" status so a capability that was turned ON but produced
     // zero records is reported honestly instead of as "collected".
+    const uint64_t kernelRows =
+        kernel_activity_emitted_.load(std::memory_order_relaxed);
+    const uint64_t memoryRows =
+        memory_activity_emitted_.load(std::memory_order_relaxed);
+    const uint64_t externalRows =
+        external_correlation_seen_.load(std::memory_order_relaxed);
+    const uint64_t sourceRows =
+        source_locator_seen_.load(std::memory_order_relaxed);
+    const uint64_t functionRows =
+        function_record_seen_.load(std::memory_order_relaxed);
+    const bool kernelHasData = kernelRows > 0;
+    const bool memoryHasData = memoryRows > 0;
+    const bool externalHasData = externalRows > 0;
+    const bool sourceHasData = sourceRows > 0 || functionRows > 0;
+
     bool sassHasData = false;
     bool pcHasData = false;
     if (engine_) {
@@ -890,27 +919,61 @@ void CuptiBackend::EmitCaptureCapabilities_() const {
     evt.requested_engine = ProfilingEngineWireName(opts_.profiling_engine);
     evt.selected_engine = selected;
 
+    const bool metricsOnly = SassMetricsOnlyMode();
     AddCapability(evt, "kernel_events", true,
-                  syntheticKernels ? "fallback" : "collected",
-                  syntheticKernels ? "launch_callbacks_synthetic" : "cupti_activity",
-                  syntheticKernels ? "cupti_kernel_activity_deadlock_risk" : "",
-                  syntheticKernels
-                      ? "Kernel rows were collected from launch callbacks; durations are estimated because CUPTI kernel activity is disabled in SASS safe mode."
-                      : "Kernel rows were collected from CUPTI kernel activity records.");
+                  kernelHasData
+                      ? (syntheticKernels ? "fallback" : "collected")
+                      : (metricsOnly ? "skipped" : "enabled_no_data"),
+                  metricsOnly
+                      ? "sass_metrics_only"
+                      : (syntheticKernels ? "launch_callbacks_synthetic" : "cupti_activity"),
+                  kernelHasData
+                      ? (syntheticKernels ? "cupti_kernel_activity_deadlock_risk" : "")
+                      : (metricsOnly ? "disabled_to_preserve_sass_counters"
+                                     : "enabled_but_no_records"),
+                  kernelHasData
+                      ? (syntheticKernels
+                            ? "Kernel rows were collected from launch callbacks; durations are estimated because CUPTI kernel activity is disabled in SASS safe mode."
+                            : "Kernel rows were collected from CUPTI kernel activity records.")
+                      : (metricsOnly
+                            ? "Kernel activity was intentionally disabled because CUPTI SASS Metrics requires metrics-only mode on this GPU/driver to produce non-zero counters."
+                            : "Kernel tracing was enabled but emitted no kernel rows this session."));
     AddCapability(evt, "kernel_names", true,
-                  syntheticKernels ? "partial" : "collected",
-                  syntheticKernels ? "callback_symbol_probe" : "cupti_activity_name",
-                  syntheticKernels ? "symbol_name_may_be_unavailable" : "",
-                  syntheticKernels
-                      ? "Kernel names use CUPTI callback symbolName when safely readable, otherwise the CUDA launch API name."
-                      : "Kernel names came from CUPTI activity records.");
+                  kernelHasData
+                      ? (syntheticKernels ? "partial" : "collected")
+                      : (metricsOnly ? "skipped" : "enabled_no_data"),
+                  metricsOnly
+                      ? "sass_metrics_only"
+                      : (syntheticKernels ? "callback_symbol_probe" : "cupti_activity_name"),
+                  kernelHasData
+                      ? (syntheticKernels ? "symbol_name_may_be_unavailable" : "")
+                      : (metricsOnly ? "disabled_to_preserve_sass_counters"
+                                     : "enabled_but_no_records"),
+                  kernelHasData
+                      ? (syntheticKernels
+                            ? "Kernel names use CUPTI callback symbolName when safely readable, otherwise the CUDA launch API name."
+                            : "Kernel names came from CUPTI activity records.")
+                      : (metricsOnly
+                            ? "Kernel name tracing was intentionally disabled to keep SASS metric counters valid."
+                            : "Kernel name capture was enabled but no kernel rows were emitted."));
     AddCapability(evt, "kernel_details", true,
-                  syntheticKernels ? "partial" : "collected",
-                  syntheticKernels ? "launch_callback_params" : "cupti_activity_details",
-                  syntheticKernels ? "activity_details_unavailable" : "",
-                  syntheticKernels
-                      ? "Grid/block parameters are captured from launch callbacks; register and occupancy details may be unavailable."
-                      : "Kernel details came from CUPTI activity records and launch metadata.");
+                  kernelHasData
+                      ? (syntheticKernels ? "partial" : "collected")
+                      : (metricsOnly ? "skipped" : "enabled_no_data"),
+                  metricsOnly
+                      ? "sass_metrics_only"
+                      : (syntheticKernels ? "launch_callback_params" : "cupti_activity_details"),
+                  kernelHasData
+                      ? (syntheticKernels ? "activity_details_unavailable" : "")
+                      : (metricsOnly ? "disabled_to_preserve_sass_counters"
+                                     : "enabled_but_no_records"),
+                  kernelHasData
+                      ? (syntheticKernels
+                            ? "Grid/block parameters are captured from launch callbacks; register and occupancy details may be unavailable."
+                            : "Kernel details came from CUPTI activity records and launch metadata.")
+                      : (metricsOnly
+                            ? "Kernel detail tracing was intentionally disabled to keep SASS metric counters valid."
+                            : "Kernel detail capture was enabled but no kernel rows were emitted."));
     AddCapability(evt, "cubin_disassembly", cubinCapture,
                   cubinCapture ? "collected" : "not_requested",
                   cubinCapture ? "module_resource_callbacks" : "disabled",
@@ -950,29 +1013,47 @@ void CuptiBackend::EmitCaptureCapabilities_() const {
                             : "PC sampling was enabled but produced no stall samples this session (e.g. kernels too short for the sampling period).")
                                   : "PC sampling was not collected for this session."));
     AddCapability(evt, "source_correlation", pcActive,
-                  pcActive ? "collected" : (sassActive ? "skipped" : "not_requested"),
+                  pcActive ? (sourceHasData ? "collected" : "enabled_no_data")
+                           : (sassActive ? "skipped" : "not_requested"),
                   pcActive ? "pc_sampling_source_locator" : "disabled",
-                  pcActive ? "" : (sassActive ? "sass_metrics_have_no_source_lines" : "not_requested"),
+                  pcActive ? (sourceHasData ? "" : "enabled_but_no_records")
+                           : (sassActive ? "sass_metrics_have_no_source_lines" : "not_requested"),
                   pcActive
-                      ? "PC sampling source locator records can provide CUDA source correlation when available."
+                      ? (sourceHasData
+                            ? "PC sampling source locator/function records were collected for CUDA source correlation."
+                            : "PC sampling source correlation was enabled but emitted no source locator/function records.")
                       : "CUDA source-line correlation was not collected in this session.");
+    const bool memoryRequestedAndAllowed =
+        opts_.enable_memory_tracking && AllowSassMemory2Activity();
     AddCapability(evt, "memory_activity", opts_.enable_memory_tracking,
-                  opts_.enable_memory_tracking && AllowSassMemory2Activity() ? "collected" :
-                      (opts_.enable_memory_tracking ? "skipped" : "not_requested"),
-                  opts_.enable_memory_tracking && AllowSassMemory2Activity() ? "cupti_memory2" : "disabled",
-                  opts_.enable_memory_tracking && !AllowSassMemory2Activity()
-                      ? "sass_safe_mode_memory_activity_disabled" : "",
-                  opts_.enable_memory_tracking && AllowSassMemory2Activity()
-                      ? "CUPTI MEMORY2 activity was enabled."
+                  memoryRequestedAndAllowed
+                      ? (memoryHasData ? "collected" : "enabled_no_data")
+                      : (opts_.enable_memory_tracking ? "skipped" : "not_requested"),
+                  memoryRequestedAndAllowed ? "cupti_memory" : "disabled",
+                  memoryRequestedAndAllowed
+                      ? (memoryHasData ? "" : "enabled_but_no_records")
+                      : (opts_.enable_memory_tracking && !AllowSassMemory2Activity()
+                            ? "sass_safe_mode_memory_activity_disabled" : ""),
+                  memoryRequestedAndAllowed
+                      ? (memoryHasData
+                            ? "CUPTI memory activity records were collected."
+                            : "CUPTI memory activity was enabled but emitted no memory rows this session.")
                       : "CUPTI memory activity was not collected.");
+    const bool externalRequestedAndAllowed =
+        opts_.enable_external_correlation && AllowSassExternalCorrelation();
     AddCapability(evt, "external_correlation", opts_.enable_external_correlation,
-                  opts_.enable_external_correlation && AllowSassExternalCorrelation() ? "collected" :
-                      (opts_.enable_external_correlation ? "skipped" : "not_requested"),
-                  opts_.enable_external_correlation && AllowSassExternalCorrelation() ? "cupti_external_correlation" : "disabled",
-                  opts_.enable_external_correlation && !AllowSassExternalCorrelation()
-                      ? "sass_safe_mode_external_correlation_disabled" : "",
-                  opts_.enable_external_correlation && AllowSassExternalCorrelation()
-                      ? "Framework external correlation was enabled."
+                  externalRequestedAndAllowed
+                      ? (externalHasData ? "collected" : "enabled_no_data")
+                      : (opts_.enable_external_correlation ? "skipped" : "not_requested"),
+                  externalRequestedAndAllowed ? "cupti_external_correlation" : "disabled",
+                  externalRequestedAndAllowed
+                      ? (externalHasData ? "" : "enabled_but_no_records")
+                      : (opts_.enable_external_correlation && !AllowSassExternalCorrelation()
+                            ? "sass_safe_mode_external_correlation_disabled" : ""),
+                  externalRequestedAndAllowed
+                      ? (externalHasData
+                            ? "Framework external correlation records were collected."
+                            : "Framework external correlation was enabled but emitted no records this session.")
                       : "Framework external correlation was not collected.");
 
     rt->logger->write(model::CaptureCapabilitiesModel(evt));
@@ -1254,6 +1335,8 @@ void CUPTIAPI CuptiBackend::BufferCompleted(CUcontext context,
                         ec->externalId,
                     };
                 }
+                backend->external_correlation_seen_.fetch_add(
+                    1, std::memory_order_relaxed);
                 static std::atomic g_ec_count{0};
                 const int n = g_ec_count.fetch_add(
                     1, std::memory_order_relaxed) + 1;
@@ -1295,6 +1378,8 @@ void CUPTIAPI CuptiBackend::BufferCompleted(CUcontext context,
                             std::lock_guard lk(g_sourceLocatorMu);
                             g_sourceLocatorMap[sl->id] = {sl->fileName,
                                                           sl->lineNumber};
+                            backend->source_locator_seen_.fetch_add(
+                                1, std::memory_order_relaxed);
                         }
                     } else if (record->kind == CUPTI_ACTIVITY_KIND_FUNCTION) {
                         auto* fn = reinterpret_cast<
@@ -1302,6 +1387,8 @@ void CUPTIAPI CuptiBackend::BufferCompleted(CUcontext context,
                         if (fn->name) {
                             std::lock_guard lk(g_sourceLocatorMu);
                             g_functionNameMap[fn->id] = fn->name;
+                            backend->function_record_seen_.fetch_add(
+                                1, std::memory_order_relaxed);
                         }
                     } else if (record->kind ==
                                CUPTI_ACTIVITY_KIND_PC_SAMPLING) {
@@ -1464,6 +1551,8 @@ void CUPTIAPI CuptiBackend::BufferCompleted(CUcontext context,
                         out.stream       = m->streamId;
                         out.corr_id      = m->correlationId;
                         g_monitorBuffer.Push(out);
+                        backend->memory_activity_emitted_.fetch_add(
+                            1, std::memory_order_relaxed);
                     } else if (record->kind ==
                                CUPTI_ACTIVITY_KIND_SYNCHRONIZATION) {
                         // F2: cudaStreamSynchronize / cudaDeviceSynchronize

--- a/include/gpufl/backends/nvidia/cupti_backend.cpp
+++ b/include/gpufl/backends/nvidia/cupti_backend.cpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <cstdlib>
 #include <exception>
+#include <filesystem>
 #include <mutex>
 #include <set>
 #include <string>
@@ -178,6 +179,101 @@ void LogCuptiIfUnexpected(const char* scope, const char* op, CUptiResult res) {
     }
     LogCuptiErrorIfFailed(scope, op, res);
 }
+
+#if defined(__linux__)
+// CUPTI loads PerfWorks by soname the first time a profiling feature
+// runs — cuptiPCSamplingEnable (PC sampling) and cuptiProfilerInitialize
+// (SASS / Range / Deep) both do. PerfWorks is NOT one library: the host
+// API (libnvperf_host.so) pulls in companions — libnvperf_target.so (the
+// driver-side counterpart that NVPW_CUDA_LoadDriver initializes) and, for
+// PC sampling, libpcsamplingutil.so. ALL of them must come from the SAME
+// CUDA install as the libcupti we're bound to. If the dynamic loader
+// resolves ANY of them from a DIFFERENT install (classic case: a pip
+// `nvidia-cu13` CUPTI inside a venv + the system /usr/local/cuda nvperf),
+// NVPW_CUDA_LoadDriver SEGFAULTs on the version mismatch — the crash that
+// killed BOTH Deep and PcSampling in PyTorch venvs.
+//
+// Putting the matching directory on LD_LIBRARY_PATH fixes it because that
+// redirects the WHOLE set. An earlier version of this preloaded ONLY
+// libnvperf_host.so, which was NOT enough: host resolved to the venv copy
+// but its companion libnvperf_target.so still resolved to the mismatched
+// system copy, so NVPW_CUDA_LoadDriver kept crashing. So we preload the
+// ENTIRE PerfWorks set sitting next to our libcupti, RTLD_GLOBAL, in
+// dependency order (target before host). The loader tracks shared objects
+// by SONAME, so once these are resident CUPTI's later internal dlopen()s
+// return THESE regardless of LD_LIBRARY_PATH ordering. Best-effort:
+// anything missing is logged and skipped — CUPTI falls back to the
+// loader's choice (prior behavior).
+void PreloadMatchingPerfWorks() {
+    Dl_info info{};
+    // &cuptiSubscribe resolves into whichever libcupti this binary is
+    // bound to; dladdr hands back that library's on-disk path.
+    if (!dladdr(reinterpret_cast<void*>(&cuptiSubscribe), &info) ||
+        !info.dli_fname || !info.dli_fname[0]) {
+        GFL_LOG_DEBUG("[CuptiBackend] PerfWorks preload: couldn't locate our "
+                      "libcupti via dladdr; skipping (CUPTI will use the "
+                      "loader's PerfWorks libs).");
+        return;
+    }
+    namespace fs = std::filesystem;
+    std::error_code ec;
+    const fs::path dir = fs::path(info.dli_fname).parent_path();
+    if (dir.empty() || !fs::is_directory(dir, ec)) {
+        GFL_LOG_DEBUG("[CuptiBackend] PerfWorks preload: our libcupti's "
+                      "directory is not accessible; skipping.");
+        return;
+    }
+
+    auto tryLoad = [](const fs::path& p) {
+        if (dlopen(p.string().c_str(), RTLD_LAZY | RTLD_GLOBAL)) {
+            GFL_LOG_DEBUG("[CuptiBackend] Preloaded PerfWorks lib: ",
+                          p.string());
+        } else {
+            const char* err = dlerror();
+            GFL_LOG_DEBUG("[CuptiBackend] PerfWorks preload skipped ",
+                          p.string(), " (", err ? err : "n/a", ")");
+        }
+    };
+
+    // Bucket the companion libs in our CUPTI's directory. Load order
+    // matters: dependencies before dependents. libnvperf_target.so (driver
+    // side) and other helpers go first, libnvperf_host.so last — otherwise
+    // host's DT_NEEDED on the target soname resolves to the system copy
+    // BEFORE we make the matching one resident, and soname-dedup then locks
+    // in the wrong target.
+    std::vector<fs::path> targets, hosts, others;
+    for (const auto& entry : fs::directory_iterator(dir, ec)) {
+        if (ec) break;
+        const std::string name = entry.path().filename().string();
+        if (name.find(".so") == std::string::npos) continue;
+        if (name.rfind("libnvperf_target", 0) == 0) {
+            targets.push_back(entry.path());
+        } else if (name.rfind("libnvperf_host", 0) == 0) {
+            hosts.push_back(entry.path());
+        } else if (name.rfind("libnvperf", 0) == 0 ||
+                   name.rfind("libpcsamplingutil", 0) == 0) {
+            others.push_back(entry.path());
+        }
+    }
+
+    if (targets.empty() && hosts.empty() && others.empty()) {
+        GFL_LOG_DEBUG("[CuptiBackend] No PerfWorks libs found next to our "
+                      "CUPTI in ", dir.string(), " — CUPTI will use the "
+                      "loader's choice, which may mismatch and crash in "
+                      "NVPW_CUDA_LoadDriver on split CUDA installs.");
+        return;
+    }
+
+    for (const auto& p : targets) tryLoad(p);  // driver-side first
+    for (const auto& p : others) tryLoad(p);   // pcsamplingutil, etc.
+    for (const auto& p : hosts) tryLoad(p);     // host API last
+}
+#else
+// Non-Linux: the same split-install hazard exists on Windows
+// (cupti64_*.dll loading a mismatched nvperf_host.dll) but isn't wired
+// up yet — Windows users typically run a single consistent CUDA toolkit.
+inline void PreloadMatchingPerfWorks() {}
+#endif
 }  // namespace
 
 void CuptiBackend::initialize(const MonitorOptions& opts) {
@@ -202,17 +298,38 @@ void CuptiBackend::initialize(const MonitorOptions& opts) {
 #else
             GFL_LOG_ERROR(
                 "[CuptiBackend] RangeProfiler engine requires "
-                "GPUFL_HAS_PERFWORKS; falling back to None");
+                "GPUFL_HAS_PERFWORKS; falling back to kernel-trace only");
 #endif
             break;
-        case ProfilingEngine::PcSamplingWithSass:
+        case ProfilingEngine::Deep:
+            // Deep = the deepest analysis the GPU supports. SASS (Profiler
+            // API) and PC sampling are mutually exclusive on current drivers,
+            // so the composite collects one or the other: SASS metrics on
+            // Blackwell+ (where lazy patching is safe), PC sampling on older
+            // GPUs (SASS lazy patching deadlocks against concurrent kernel
+            // launches there — observed on Ampere sm_86). The engine logs
+            // which path it selected in initialize().
             engine_ = std::make_unique<PcSamplingWithSassEngine>();
-            GFL_LOG_DEBUG("[CuptiBackend] Engine: PcSamplingWithSass");
+            GFL_LOG_DEBUG("[CuptiBackend] Engine: Deep");
             break;
-        case ProfilingEngine::None:
+        case ProfilingEngine::Trace:
         default:
-            GFL_LOG_DEBUG("[CuptiBackend] Engine: None (monitoring only)");
+            // No sampling engine — activity records only (kernels, memcpy,
+            // sync). ProfilingEngine::Monitor never reaches here:
+            // CreateMonitorAdapter returns nullptr for it, so no
+            // CuptiBackend is created at all.
+            GFL_LOG_DEBUG("[CuptiBackend] Engine: none (activity trace only)");
             break;
+    }
+
+    // Any engine that touches PerfWorks (PcSampling via cuptiPCSamplingEnable;
+    // SassMetrics / RangeProfiler / Deep via cuptiProfilerInitialize) must use
+    // the libnvperf_host.so that MATCHES our libcupti, or NVPW_CUDA_LoadDriver
+    // segfaults on a split CUDA install. Preload it now, before any of those
+    // CUPTI calls run. `engine_` is null only for Trace, which needs no
+    // PerfWorks, so we skip the preload there.
+    if (engine_) {
+        PreloadMatchingPerfWorks();
     }
 
     g_activeBackend.store(this, std::memory_order_release);
@@ -509,7 +626,7 @@ void CuptiBackend::start() {
             }
             if (chosen[0]) {
                 _putenv_s("NVTX_INJECTION64_PATH", chosen);
-                GFL_LOG_DEBUG("[CuptiBackend] NVTX injection path: {}", chosen);
+                GFL_LOG_DEBUG("[CuptiBackend] NVTX injection path: ", chosen);
             }
         }
 #elif defined(__linux__)
@@ -532,7 +649,7 @@ void CuptiBackend::start() {
                     Dl_info info{};
                     if (dladdr(sym, &info) && info.dli_fname && info.dli_fname[0]) {
                         setenv("NVTX_INJECTION64_PATH", info.dli_fname, 0);
-                        GFL_LOG_DEBUG("[CuptiBackend] NVTX injection path: {}",
+                        GFL_LOG_DEBUG("[CuptiBackend] NVTX injection path: ",
                                       info.dli_fname);
                     }
                 }
@@ -546,7 +663,7 @@ void CuptiBackend::start() {
                 Dl_info info{};
                 if (dladdr(sym, &info) && info.dli_fname && info.dli_fname[0]) {
                     setenv("NVTX_INJECTION64_PATH", info.dli_fname, 0);
-                    GFL_LOG_DEBUG("[CuptiBackend] NVTX injection path: {}",
+                    GFL_LOG_DEBUG("[CuptiBackend] NVTX injection path: ",
                                   info.dli_fname);
                 }
             }

--- a/include/gpufl/backends/nvidia/cupti_backend.cpp
+++ b/include/gpufl/backends/nvidia/cupti_backend.cpp
@@ -394,14 +394,16 @@ void CuptiBackend::shutdown() {
     // Belt-and-suspenders final drain. stop() already disabled all
     // activity kinds and flushed, but engine teardown above can emit a
     // last burst (e.g. PcSamplingEngine::shutdown's StopAndCollectPcSampling_
-    // collection). Disabling SOURCE_LOCATOR explicitly here matches
-    // what start() enables for the SamplingAPI path. The final flush
+    // collection). Disabling SOURCE_LOCATOR + FUNCTION here matches what
+    // PcSamplingEngine enables on the PC-sampling paths (no-op for engines
+    // that never enabled them). The final flush
     // guarantees every BufferCompleted callback has returned before
     // we null g_activeBackend below — without this, late deliveries
     // raced the pointer-clear and surfaced as "No active backend!"
     // noise on benchmarks that init/shutdown gpufl repeatedly in a
     // single process (run_benchmark.py).
     cuptiActivityDisable(CUPTI_ACTIVITY_KIND_SOURCE_LOCATOR);
+    cuptiActivityDisable(CUPTI_ACTIVITY_KIND_FUNCTION);
     cudaDeviceSynchronize();
     LogCuptiIfUnexpected("shutdown", "cuptiActivityFlushAll(final)",
                          cuptiActivityFlushAll(1));
@@ -421,10 +423,15 @@ void CuptiBackend::start() {
     kernel_activity_emitted_.store(0, std::memory_order_relaxed);
     kernel_activity_throttled_.store(0, std::memory_order_relaxed);
 
-    CUPTI_CHECK(cuptiActivityEnable(CUPTI_ACTIVITY_KIND_SOURCE_LOCATOR));
-    // FUNCTION records carry the function name indexed by functionId in
-    // CUpti_ActivityPCSampling3; needed for source correlation on ActivityAPI.
-    CUPTI_CHECK(cuptiActivityEnable(CUPTI_ACTIVITY_KIND_FUNCTION));
+    // SOURCE_LOCATOR + FUNCTION activity records feed only the Activity-API
+    // PC-sampling source-correlation maps (g_sourceLocatorMap /
+    // g_functionNameMap, read solely by the CUPTI_ACTIVITY_KIND_PC_SAMPLING
+    // handler). PcSamplingEngine now enables them on the path that consumes
+    // them (both on the ActivityAPI branch; SOURCE_LOCATOR also on the
+    // SamplingAPI branch), so engines that don't PC-sample — SassMetrics,
+    // RangeProfiler, Trace — no longer emit records nothing reads, and
+    // PcSampling stops enabling them when it falls back to the new SamplingAPI
+    // on CUDA 13.x.
     // MARKER records capture NVTX push/pop ranges. We enable this
     // unconditionally because:
     //   - GFL_SCOPE itself now emits NVTX ranges (see gpufl.cpp)
@@ -711,7 +718,7 @@ void CuptiBackend::start() {
     {
         std::set<CUpti_ActivityKind> kinds;
         {
-            std::lock_guard<std::mutex> lk(handler_mu_);
+            std::lock_guard lk(handler_mu_);
             for (const auto& h : handlers_)
                 for (auto k : h->requiredActivityKinds()) kinds.insert(k);
         }
@@ -815,7 +822,7 @@ void CuptiBackend::stop() {
     {
         std::set<CUpti_ActivityKind> kinds;
         {
-            std::lock_guard<std::mutex> lk(handler_mu_);
+            std::lock_guard lk(handler_mu_);
             for (const auto& h : handlers_)
                 for (auto k : h->requiredActivityKinds()) kinds.insert(k);
         }
@@ -849,7 +856,7 @@ void CuptiBackend::stop() {
                          cuptiActivityFlushAll(1));
     FlushPendingKernels();
     {
-        std::lock_guard<std::mutex> lk(g_extCorrMu);
+        std::lock_guard lk(g_extCorrMu);
         g_extCorrMap.clear();
     }
 

--- a/include/gpufl/backends/nvidia/cupti_backend.cpp
+++ b/include/gpufl/backends/nvidia/cupti_backend.cpp
@@ -423,6 +423,16 @@ void CuptiBackend::start() {
     kernel_activity_emitted_.store(0, std::memory_order_relaxed);
     kernel_activity_throttled_.store(0, std::memory_order_relaxed);
 
+    if (IsSassProfilerMode()) {
+        const ComputeCapability cc =
+            GetComputeCapability(static_cast<int>(device_id_));
+        const uint32_t cuptiVersion = GetCuptiVersion();
+        GFL_LOG_DEBUG("[CuptiBackend] SASS activity policy: ",
+                      UseSafeSassActivityDefaults() ? "safe" : "full",
+                      " (sm=", cc.major, cc.minor,
+                      ", cupti_version=", cuptiVersion, ")");
+    }
+
     // SOURCE_LOCATOR + FUNCTION activity records feed only the Activity-API
     // PC-sampling source-correlation maps (g_sourceLocatorMap /
     // g_functionNameMap, read solely by the CUPTI_ACTIVITY_KIND_PC_SAMPLING
@@ -439,7 +449,13 @@ void CuptiBackend::start() {
     //   - The cost is ~zero when no NVTX traffic exists
     // Paired START/END records are merged into NvtxMarkerEvent below
     // in BufferCompleted.
-    CUPTI_CHECK(cuptiActivityEnable(CUPTI_ACTIVITY_KIND_MARKER));
+    if (AllowSassMarkerActivity()) {
+        CUPTI_CHECK(cuptiActivityEnable(CUPTI_ACTIVITY_KIND_MARKER));
+    } else {
+        GFL_LOG_DEBUG(
+            "[CuptiBackend] MARKER activity disabled in SASS profiler mode. "
+            "Set GPUFL_SASS_ALLOW_MARKER_ACTIVITY=1 to test it.");
+    }
 
     // SYNCHRONIZATION records capture every cudaStreamSynchronize /
     // cudaDeviceSynchronize / cudaEventSynchronize / cuStreamWaitEvent
@@ -447,7 +463,7 @@ void CuptiBackend::start() {
     // activity kind required (CUPTI emits these regardless of which
     // API kinds are enabled). Soft-fail on enable so a CUPTI build that
     // doesn't support the kind still lets the rest of collection work.
-    if (opts_.enable_synchronization) {
+    if (opts_.enable_synchronization && AllowSassSyncActivity()) {
         const CUptiResult res_sync =
             cuptiActivityEnable(CUPTI_ACTIVITY_KIND_SYNCHRONIZATION);
         if (res_sync != CUPTI_SUCCESS) {
@@ -468,7 +484,7 @@ void CuptiBackend::start() {
     // without MEMORY2 — they had MEMORY (deprecated) which has a
     // different record shape. We don't try to fall back; if MEMORY2
     // isn't available we log and continue without F3 attribution.
-    if (opts_.enable_memory_tracking) {
+    if (opts_.enable_memory_tracking && AllowSassMemory2Activity()) {
         const CUptiResult res_mem =
             cuptiActivityEnable(CUPTI_ACTIVITY_KIND_MEMORY2);
         if (res_mem != CUPTI_SUCCESS) {
@@ -483,7 +499,7 @@ void CuptiBackend::start() {
     // because some Blackwell driver builds reset PC sampling on first
     // graph launch — the planning doc has the full risk note. Soft-
     // fail on enable so older CUPTI without the kind keeps working.
-    if (opts_.enable_cuda_graphs_tracking) {
+    if (opts_.enable_cuda_graphs_tracking && AllowSassGraphActivity()) {
         const CUptiResult res_g =
             cuptiActivityEnable(CUPTI_ACTIVITY_KIND_GRAPH_TRACE);
         if (res_g != CUPTI_SUCCESS) {
@@ -515,7 +531,15 @@ void CuptiBackend::start() {
     // API, not the driver API directly. If a workload only uses cuLaunch
     // we may need DRIVER too — defer until we see a session that needs
     // it.)
-    if (opts_.enable_external_correlation) {
+    const bool enableExternalCorrelation =
+        opts_.enable_external_correlation && AllowSassExternalCorrelation();
+    if (opts_.enable_external_correlation && IsSassProfilerMode() &&
+        !AllowSassExternalCorrelation()) {
+        GFL_LOG_DEBUG(
+            "[CuptiBackend] EXTERNAL_CORRELATION disabled in SASS profiler "
+            "mode. Set GPUFL_SASS_ALLOW_EXTERNAL_CORRELATION=1 to test it.");
+    }
+    if (enableExternalCorrelation) {
         const CUptiResult res_ec =
             cuptiActivityEnable(CUPTI_ACTIVITY_KIND_EXTERNAL_CORRELATION);
         if (res_ec != CUPTI_SUCCESS) {
@@ -733,7 +757,7 @@ void CuptiBackend::start() {
     //
     // RUNTIME is the anchor that makes EXTERNAL_CORRELATION actually
     // emit records (see the start-of-start() block for the rationale).
-    if (opts_.enable_external_correlation) {
+    if (enableExternalCorrelation) {
         const CUptiResult ec_res =
             cuptiActivityEnable(CUPTI_ACTIVITY_KIND_EXTERNAL_CORRELATION);
         const CUptiResult rt_res =
@@ -761,7 +785,7 @@ void CuptiBackend::start() {
     // initialize() phase. Idempotent; CUPTI ignores the second enable
     // when the kind is already on. SYNCHRONIZATION isn't tied to any
     // handler so it would otherwise be silently dropped.
-    if (opts_.enable_synchronization) {
+    if (opts_.enable_synchronization && AllowSassSyncActivity()) {
         const CUptiResult sync_res =
             cuptiActivityEnable(CUPTI_ACTIVITY_KIND_SYNCHRONIZATION);
         GFL_LOG_DEBUG(
@@ -771,7 +795,7 @@ void CuptiBackend::start() {
     }
 
     // F3: matching post-engine re-enable for MEMORY2.
-    if (opts_.enable_memory_tracking) {
+    if (opts_.enable_memory_tracking && AllowSassMemory2Activity()) {
         const CUptiResult mem_res =
             cuptiActivityEnable(CUPTI_ACTIVITY_KIND_MEMORY2);
         GFL_LOG_DEBUG(
@@ -781,7 +805,7 @@ void CuptiBackend::start() {
     }
 
     // F4: matching post-engine re-enable for GRAPH_TRACE.
-    if (opts_.enable_cuda_graphs_tracking) {
+    if (opts_.enable_cuda_graphs_tracking && AllowSassGraphActivity()) {
         const CUptiResult g_res =
             cuptiActivityEnable(CUPTI_ACTIVITY_KIND_GRAPH_TRACE);
         GFL_LOG_DEBUG(

--- a/include/gpufl/backends/nvidia/cupti_backend.cpp
+++ b/include/gpufl/backends/nvidia/cupti_backend.cpp
@@ -1,4 +1,5 @@
 #include "gpufl/backends/nvidia/cupti_backend.hpp"
+#include "gpufl/backends/nvidia/cuda_cleanup_handler.hpp"
 
 #include <cupti_pcsampling.h>
 
@@ -38,6 +39,9 @@
 #include "gpufl/core/activity_record.hpp"
 #include "gpufl/core/common.hpp"
 #include "gpufl/core/debug_logger.hpp"
+#include "gpufl/core/logger/logger.hpp"
+#include "gpufl/core/model/lifecycle_model.hpp"
+#include "gpufl/core/runtime.hpp"
 #include "gpufl/core/ring_buffer.hpp"
 #include "gpufl/core/stack_registry.hpp"
 #include "gpufl/core/trace_type.hpp"
@@ -46,6 +50,15 @@ namespace gpufl {
 std::atomic<CuptiBackend*> g_activeBackend{nullptr};
 
 namespace {
+
+void AddCapability(CaptureCapabilitiesEvent& evt, std::string feature,
+                   bool requested, std::string status, std::string mode,
+                   std::string reason, std::string message) {
+    evt.capabilities.push_back(CaptureCapability{
+        std::move(feature), requested, std::move(status), std::move(mode),
+        std::move(reason), std::move(message)});
+}
+
 // Persistent maps for ActivityAPI PC sampling companion records.
 // SOURCE_LOCATOR records map sourceLocatorId → (fileName, lineNumber).
 // FUNCTION records map functionId → functionName.
@@ -336,6 +349,7 @@ void CuptiBackend::initialize(const MonitorOptions& opts) {
 
     // Internal handler registration
     RegisterHandler(std::make_shared<ResourceHandler>(this));
+    RegisterHandler(std::make_shared<CudaCleanupHandler>(this));
     RegisterHandler(std::make_shared<KernelLaunchHandler>(this));
     RegisterHandler(std::make_shared<MemTransferHandler>(this));
     RegisterHandler(std::make_shared<SynchronizationHandler>(this));
@@ -819,8 +833,142 @@ void CuptiBackend::start() {
             " (CUptiResult=", static_cast<int>(g_res), ")");
     }
 
+    EmitCaptureCapabilities_();
+
     active_.store(true);
     GFL_LOG_DEBUG("Backend started.");
+}
+
+
+void CuptiBackend::EmitCaptureCapabilities_() const {
+    const Runtime* rt = runtime();
+    if (!(rt && rt->logger)) return;
+
+    const bool sassMode = IsSassProfilerMode();
+    const bool kernelActivity = !sassMode || AllowSassKernelActivity();
+    const bool syntheticKernels = sassMode && !kernelActivity;
+    const bool cubinCapture = NeedsCubinCapture();
+
+    bool sassActive = opts_.profiling_engine == ProfilingEngine::SassMetrics &&
+                      engine_ && engine_->isOperational();
+    bool pcActive = opts_.profiling_engine == ProfilingEngine::PcSampling &&
+                    engine_ && engine_->isOperational();
+    if (opts_.profiling_engine == ProfilingEngine::Deep) {
+        if (const auto* deep = dynamic_cast<const PcSamplingWithSassEngine*>(engine_.get())) {
+            sassActive = deep->sassActive();
+            pcActive = deep->pcSamplingActive();
+        }
+    }
+
+    std::string selected = ProfilingEngineWireName(opts_.profiling_engine);
+    if (opts_.profiling_engine == ProfilingEngine::Deep) {
+        if (sassActive) selected = "nvidia.sass_metrics";
+        else if (pcActive) selected = "nvidia.pc_sampling";
+        else selected = "nvidia.none";
+    }
+
+    CaptureCapabilitiesEvent evt;
+    evt.session_id = rt->session_id;
+    evt.ts_ns = detail::GetTimestampNs();
+    evt.requested_engine = ProfilingEngineWireName(opts_.profiling_engine);
+    evt.selected_engine = selected;
+
+    AddCapability(evt, "kernel_events", true,
+                  syntheticKernels ? "fallback" : "collected",
+                  syntheticKernels ? "launch_callbacks_synthetic" : "cupti_activity",
+                  syntheticKernels ? "cupti_kernel_activity_deadlock_risk" : "",
+                  syntheticKernels
+                      ? "Kernel rows were collected from launch callbacks; durations are estimated because CUPTI kernel activity is disabled in SASS safe mode."
+                      : "Kernel rows were collected from CUPTI kernel activity records.");
+    AddCapability(evt, "kernel_names", true,
+                  syntheticKernels ? "partial" : "collected",
+                  syntheticKernels ? "callback_symbol_probe" : "cupti_activity_name",
+                  syntheticKernels ? "symbol_name_may_be_unavailable" : "",
+                  syntheticKernels
+                      ? "Kernel names use CUPTI callback symbolName when safely readable, otherwise the CUDA launch API name."
+                      : "Kernel names came from CUPTI activity records.");
+    AddCapability(evt, "kernel_details", true,
+                  syntheticKernels ? "partial" : "collected",
+                  syntheticKernels ? "launch_callback_params" : "cupti_activity_details",
+                  syntheticKernels ? "activity_details_unavailable" : "",
+                  syntheticKernels
+                      ? "Grid/block parameters are captured from launch callbacks; register and occupancy details may be unavailable."
+                      : "Kernel details came from CUPTI activity records and launch metadata.");
+    AddCapability(evt, "cubin_disassembly", cubinCapture,
+                  cubinCapture ? "collected" : "not_requested",
+                  cubinCapture ? "module_resource_callbacks" : "disabled",
+                  "",
+                  cubinCapture
+                      ? "CUBINs were captured for offline SASS disassembly."
+                      : "This profiling engine does not request CUBIN capture.");
+    AddCapability(evt, "sass_metrics",
+                  opts_.profiling_engine == ProfilingEngine::SassMetrics ||
+                      opts_.profiling_engine == ProfilingEngine::Deep,
+                  sassActive ? "collected" :
+                      ((opts_.profiling_engine == ProfilingEngine::SassMetrics ||
+                        opts_.profiling_engine == ProfilingEngine::Deep) ? "skipped" : "not_requested"),
+                  sassActive ? "cupti_sass_metrics" : "disabled",
+                  sassActive ? "" : "not_selected_or_not_operational",
+                  sassActive
+                      ? "SASS metrics were collected for this session."
+                      : "SASS metrics were not collected for this session.");
+    AddCapability(evt, "pc_sampling",
+                  opts_.profiling_engine == ProfilingEngine::PcSampling ||
+                      opts_.profiling_engine == ProfilingEngine::Deep,
+                  pcActive ? "collected" :
+                      (opts_.profiling_engine == ProfilingEngine::Deep && sassActive ? "skipped" :
+                       (opts_.profiling_engine == ProfilingEngine::PcSampling ? "skipped" : "not_requested")),
+                  pcActive ? "cupti_pc_sampling" : "disabled",
+                  opts_.profiling_engine == ProfilingEngine::Deep && sassActive
+                      ? "mutually_exclusive_with_sass_metrics" :
+                    (pcActive ? "" : "not_selected_or_not_operational"),
+                  opts_.profiling_engine == ProfilingEngine::Deep && sassActive
+                      ? "Deep selected SASS metrics; PC sampling was skipped because SASS metrics and PC sampling are mutually exclusive in one run."
+                      : (pcActive ? "PC sampling was collected for this session."
+                                  : "PC sampling was not collected for this session."));
+    AddCapability(evt, "source_correlation", pcActive,
+                  pcActive ? "collected" : (sassActive ? "skipped" : "not_requested"),
+                  pcActive ? "pc_sampling_source_locator" : "disabled",
+                  pcActive ? "" : (sassActive ? "sass_metrics_have_no_source_lines" : "not_requested"),
+                  pcActive
+                      ? "PC sampling source locator records can provide CUDA source correlation when available."
+                      : "CUDA source-line correlation was not collected in this session.");
+    AddCapability(evt, "memory_activity", opts_.enable_memory_tracking,
+                  opts_.enable_memory_tracking && AllowSassMemory2Activity() ? "collected" :
+                      (opts_.enable_memory_tracking ? "skipped" : "not_requested"),
+                  opts_.enable_memory_tracking && AllowSassMemory2Activity() ? "cupti_memory2" : "disabled",
+                  opts_.enable_memory_tracking && !AllowSassMemory2Activity()
+                      ? "sass_safe_mode_memory_activity_disabled" : "",
+                  opts_.enable_memory_tracking && AllowSassMemory2Activity()
+                      ? "CUPTI MEMORY2 activity was enabled."
+                      : "CUPTI memory activity was not collected.");
+    AddCapability(evt, "external_correlation", opts_.enable_external_correlation,
+                  opts_.enable_external_correlation && AllowSassExternalCorrelation() ? "collected" :
+                      (opts_.enable_external_correlation ? "skipped" : "not_requested"),
+                  opts_.enable_external_correlation && AllowSassExternalCorrelation() ? "cupti_external_correlation" : "disabled",
+                  opts_.enable_external_correlation && !AllowSassExternalCorrelation()
+                      ? "sass_safe_mode_external_correlation_disabled" : "",
+                  opts_.enable_external_correlation && AllowSassExternalCorrelation()
+                      ? "Framework external correlation was enabled."
+                      : "Framework external correlation was not collected.");
+
+    rt->logger->write(model::CaptureCapabilitiesModel(evt));
+}
+
+void CuptiBackend::FlushProfilingDataBeforeCudaTeardown(const char* reason) {
+    if (!initialized_ || !active_.load(std::memory_order_relaxed) || !engine_) {
+        return;
+    }
+    if (!IsSassProfilerMode()) return;
+
+    const int64_t now = detail::GetTimestampNs();
+    int64_t expected = 0;
+    if (!last_cleanup_flush_ns_.compare_exchange_strong(
+            expected, now, std::memory_order_acq_rel, std::memory_order_relaxed)) {
+        return;
+    }
+
+    engine_->flushBeforeCudaTeardown(reason);
 }
 
 void CuptiBackend::stop() {

--- a/include/gpufl/backends/nvidia/cupti_backend.cpp
+++ b/include/gpufl/backends/nvidia/cupti_backend.cpp
@@ -852,8 +852,11 @@ void CuptiBackend::EmitCaptureCapabilities_() const {
     }
 
     const bool sassMode = IsSassProfilerMode();
-    const bool kernelActivity = !sassMode || AllowSassKernelActivity();
-    const bool syntheticKernels = sassMode && !kernelActivity;
+    const bool pcSamplingMode =
+        opts_.profiling_engine == ProfilingEngine::PcSampling;
+    const bool kernelActivity =
+        pcSamplingMode ? false : (!sassMode || AllowSassKernelActivity());
+    const bool syntheticKernels = !kernelActivity && (sassMode || pcSamplingMode);
     const bool cubinCapture = NeedsCubinCapture();
 
     bool sassActive = false;
@@ -928,12 +931,17 @@ void CuptiBackend::EmitCaptureCapabilities_() const {
                       ? "sass_metrics_only"
                       : (syntheticKernels ? "launch_callbacks_synthetic" : "cupti_activity"),
                   kernelHasData
-                      ? (syntheticKernels ? "cupti_kernel_activity_deadlock_risk" : "")
+                      ? (syntheticKernels
+                            ? (pcSamplingMode ? "cupti_kernel_activity_conflicts_with_pc_sampling"
+                                              : "cupti_kernel_activity_deadlock_risk")
+                            : "")
                       : (metricsOnly ? "disabled_to_preserve_sass_counters"
                                      : "enabled_but_no_records"),
                   kernelHasData
                       ? (syntheticKernels
-                            ? "Kernel rows were collected from launch callbacks; durations are estimated because CUPTI kernel activity is disabled in SASS safe mode."
+                            ? (pcSamplingMode
+                                  ? "Kernel rows were collected from launch callbacks; durations are estimated because CUPTI kernel activity is disabled while PC Sampling API is active."
+                                  : "Kernel rows were collected from launch callbacks; durations are estimated because CUPTI kernel activity is disabled in SASS safe mode.")
                             : "Kernel rows were collected from CUPTI kernel activity records.")
                       : (metricsOnly
                             ? "Kernel activity was intentionally disabled because CUPTI SASS Metrics requires metrics-only mode on this GPU/driver to produce non-zero counters."

--- a/include/gpufl/backends/nvidia/cupti_backend.cpp
+++ b/include/gpufl/backends/nvidia/cupti_backend.cpp
@@ -423,6 +423,22 @@ void CuptiBackend::start() {
     kernel_activity_emitted_.store(0, std::memory_order_relaxed);
     kernel_activity_throttled_.store(0, std::memory_order_relaxed);
 
+    // Resolve CUDA context/device before asking handlers for activity kinds.
+    // SASS safe-mode policy is device dependent, and the policy log should
+    // report the real SM version. Querying requiredActivityKinds() before this
+    // point used device_id_=0 and could choose the wrong activity policy.
+    const bool haveCudaContext = EnsureCudaContext(&ctx_);
+    if (haveCudaContext) {
+        cuptiGetDeviceId(ctx_, &device_id_);
+        GetSMProps(device_id_);
+        chip_name_ = getChipName(device_id_);
+        cached_device_name_ = GetCurrentDeviceName();
+    } else if (engine_) {
+        GFL_LOG_ERROR(
+            "[CuptiBackend] Failed to get CUDA context; "
+            "engine will not start.");
+    }
+
     if (IsSassProfilerMode()) {
         const ComputeCapability cc =
             GetComputeCapability(static_cast<int>(device_id_));
@@ -715,22 +731,11 @@ void CuptiBackend::start() {
     }
 
     // Initialize and start the engine (requires CUDA context)
-    if (engine_) {
-        if (EnsureCudaContext(&ctx_)) {
-            cuptiGetDeviceId(ctx_, &device_id_);
-            GetSMProps(device_id_);
-            chip_name_ = getChipName(device_id_);
-            cached_device_name_ = GetCurrentDeviceName();
-
-            EngineContext ectx{ctx_, device_id_, chip_name_, &cubin_mu_,
-                               &cubin_by_crc_};
-            engine_->initialize(opts_, ectx);
-            engine_->start();
-        } else {
-            GFL_LOG_ERROR(
-                "[CuptiBackend] Failed to get CUDA context; "
-                "engine will not start.");
-        }
+    if (engine_ && haveCudaContext) {
+        EngineContext ectx{ctx_, device_id_, chip_name_, &cubin_mu_,
+                           &cubin_by_crc_};
+        engine_->initialize(opts_, ectx);
+        engine_->start();
     }
 
     // Re-enable activity kinds after engine start. Some engines call

--- a/include/gpufl/backends/nvidia/cupti_backend.cpp
+++ b/include/gpufl/backends/nvidia/cupti_backend.cpp
@@ -860,6 +860,23 @@ void CuptiBackend::EmitCaptureCapabilities_() const {
         }
     }
 
+    // Did each path actually emit rows (vs merely arm)? Drives the
+    // "enabled_no_data" status so a capability that was turned ON but produced
+    // zero records is reported honestly instead of as "collected".
+    bool sassHasData = false;
+    bool pcHasData = false;
+    if (engine_) {
+        if (const auto* deep =
+                dynamic_cast<const PcSamplingWithSassEngine*>(engine_.get())) {
+            sassHasData = deep->sassProducedData();
+            pcHasData = deep->pcProducedData();
+        } else if (opts_.profiling_engine == ProfilingEngine::SassMetrics) {
+            sassHasData = engine_->producedData();
+        } else if (opts_.profiling_engine == ProfilingEngine::PcSampling) {
+            pcHasData = engine_->producedData();
+        }
+    }
+
     std::string selected = ProfilingEngineWireName(opts_.profiling_engine);
     if (opts_.profiling_engine == ProfilingEngine::Deep) {
         if (sassActive) selected = "nvidia.sass_metrics";
@@ -904,27 +921,33 @@ void CuptiBackend::EmitCaptureCapabilities_() const {
     AddCapability(evt, "sass_metrics",
                   opts_.profiling_engine == ProfilingEngine::SassMetrics ||
                       opts_.profiling_engine == ProfilingEngine::Deep,
-                  sassActive ? "collected" :
+                  sassActive ? (sassHasData ? "collected" : "enabled_no_data") :
                       ((opts_.profiling_engine == ProfilingEngine::SassMetrics ||
                         opts_.profiling_engine == ProfilingEngine::Deep) ? "skipped" : "not_requested"),
                   sassActive ? "cupti_sass_metrics" : "disabled",
-                  sassActive ? "" : "not_selected_or_not_operational",
+                  sassActive ? (sassHasData ? "" : "enabled_but_no_samples")
+                             : "not_selected_or_not_operational",
                   sassActive
-                      ? "SASS metrics were collected for this session."
+                      ? (sassHasData
+                            ? "SASS metrics were collected for this session."
+                            : "SASS metrics were enabled but produced no instruction-level samples this session (e.g. kernels too short, or CUPTI replay returned no data).")
                       : "SASS metrics were not collected for this session.");
     AddCapability(evt, "pc_sampling",
                   opts_.profiling_engine == ProfilingEngine::PcSampling ||
                       opts_.profiling_engine == ProfilingEngine::Deep,
-                  pcActive ? "collected" :
+                  pcActive ? (pcHasData ? "collected" : "enabled_no_data") :
                       (opts_.profiling_engine == ProfilingEngine::Deep && sassActive ? "skipped" :
                        (opts_.profiling_engine == ProfilingEngine::PcSampling ? "skipped" : "not_requested")),
                   pcActive ? "cupti_pc_sampling" : "disabled",
                   opts_.profiling_engine == ProfilingEngine::Deep && sassActive
                       ? "mutually_exclusive_with_sass_metrics" :
-                    (pcActive ? "" : "not_selected_or_not_operational"),
+                    (pcActive ? (pcHasData ? "" : "enabled_but_no_samples")
+                              : "not_selected_or_not_operational"),
                   opts_.profiling_engine == ProfilingEngine::Deep && sassActive
                       ? "Deep selected SASS metrics; PC sampling was skipped because SASS metrics and PC sampling are mutually exclusive in one run."
-                      : (pcActive ? "PC sampling was collected for this session."
+                      : (pcActive ? (pcHasData
+                            ? "PC sampling was collected for this session."
+                            : "PC sampling was enabled but produced no stall samples this session (e.g. kernels too short for the sampling period).")
                                   : "PC sampling was not collected for this session."));
     AddCapability(evt, "source_correlation", pcActive,
                   pcActive ? "collected" : (sassActive ? "skipped" : "not_requested"),

--- a/include/gpufl/backends/nvidia/cupti_backend.hpp
+++ b/include/gpufl/backends/nvidia/cupti_backend.hpp
@@ -52,8 +52,18 @@ class CuptiBackend : public IMonitorBackend {
         return opts_.profiling_engine == ProfilingEngine::SassMetrics ||
                opts_.profiling_engine == ProfilingEngine::Deep;
     }
+    bool SassMetricsOnlyMode() const {
+        if (!IsSassProfilerMode()) return false;
+        // CUPTI SASS Metrics can return patched instruction rows with all-zero
+        // counter values when normal CUPTI activity/callback tracing is active
+        // at the same time (confirmed on RTX 3090 + CUDA/CUPTI 13.1). Default
+        // to the official-sample-like path: SASS Metrics only. The opt-out is
+        // for experiments on driver/GPU combinations that prove coexistence.
+        return !EnvFlagEnabled_("GPUFL_SASS_ALLOW_ACTIVITY_WITH_METRICS");
+    }
     bool UseSafeSassActivityDefaults() const {
         if (!IsSassProfilerMode()) return false;
+        if (SassMetricsOnlyMode()) return true;
         if (EnvFlagEnabled_("GPUFL_SASS_FORCE_SAFE_ACTIVITY")) return true;
         if (EnvFlagEnabled_("GPUFL_SASS_FORCE_FULL_ACTIVITY")) return false;
 
@@ -64,18 +74,22 @@ class CuptiBackend : public IMonitorBackend {
         return true;
     }
     bool AllowSassKernelActivity() const {
+        if (SassMetricsOnlyMode()) return false;
         return !UseSafeSassActivityDefaults() ||
                EnvFlagEnabled_("GPUFL_SASS_ALLOW_KERNEL_ACTIVITY");
     }
     bool AllowSassMarkerActivity() const {
+        if (SassMetricsOnlyMode()) return false;
         return !UseSafeSassActivityDefaults() ||
                EnvFlagEnabled_("GPUFL_SASS_ALLOW_MARKER_ACTIVITY");
     }
     bool AllowSassMemTransferActivity() const {
+        if (SassMetricsOnlyMode()) return false;
         if (!UseSafeSassActivityDefaults()) return true;
         return EnvFlagEnabled_("GPUFL_SASS_ALLOW_MEM_TRANSFER_ACTIVITY");
     }
     bool AllowSassMemory2Activity() const {
+        if (SassMetricsOnlyMode()) return false;
         if (!UseSafeSassActivityDefaults()) return true;
         const bool memTransferRequested =
             EnvFlagEnabled_("GPUFL_SASS_ALLOW_MEM_TRANSFER_ACTIVITY");
@@ -90,20 +104,26 @@ class CuptiBackend : public IMonitorBackend {
         return memory2Requested || !memTransferRequested;
     }
     bool AllowSassSyncActivity() const {
+        if (SassMetricsOnlyMode()) return false;
         return !UseSafeSassActivityDefaults() ||
                EnvFlagEnabled_("GPUFL_SASS_ALLOW_SYNC_ACTIVITY");
     }
     bool AllowSassGraphActivity() const {
+        if (SassMetricsOnlyMode()) return false;
         return !UseSafeSassActivityDefaults() ||
                EnvFlagEnabled_("GPUFL_SASS_ALLOW_GRAPH_ACTIVITY");
     }
     bool AllowSassExternalCorrelation() const {
+        if (SassMetricsOnlyMode()) return false;
         return !UseSafeSassActivityDefaults() ||
                EnvFlagEnabled_("GPUFL_SASS_ALLOW_EXTERNAL_CORRELATION");
     }
     void FlushProfilingDataBeforeCudaTeardown(const char* reason);
     void NoteKernelLaunchForCleanupFlush() {
         last_cleanup_flush_ns_.store(0, std::memory_order_release);
+    }
+    void NoteMemoryActivityEmitted() {
+        memory_activity_emitted_.fetch_add(1, std::memory_order_relaxed);
     }
 
     // Whether the active engine consumes cubin binaries. Cubin capture
@@ -228,7 +248,12 @@ class CuptiBackend : public IMonitorBackend {
     std::atomic<uint64_t> kernel_activity_seen_{0};
     std::atomic<uint64_t> kernel_activity_emitted_{0};
     std::atomic<uint64_t> kernel_activity_throttled_{0};
+    std::atomic<uint64_t> memory_activity_emitted_{0};
+    std::atomic<uint64_t> external_correlation_seen_{0};
+    std::atomic<uint64_t> source_locator_seen_{0};
+    std::atomic<uint64_t> function_record_seen_{0};
     std::atomic<int64_t> last_cleanup_flush_ns_{0};
+    mutable std::atomic<bool> capture_capabilities_emitted_{false};
     uint32_t device_id_ = 0;
     std::string chip_name_;
 

--- a/include/gpufl/backends/nvidia/cupti_backend.hpp
+++ b/include/gpufl/backends/nvidia/cupti_backend.hpp
@@ -54,24 +54,15 @@ class CuptiBackend : public IMonitorBackend {
     }
     bool SassMetricsOnlyMode() const {
         if (!IsSassProfilerMode()) return false;
-        // CUPTI SASS Metrics can return patched instruction rows with all-zero
-        // counter values when normal CUPTI activity/callback tracing is active
-        // at the same time (confirmed on RTX 3090 + CUDA/CUPTI 13.1). Default
-        // to the official-sample-like path: SASS Metrics only. The opt-out is
-        // for experiments on driver/GPU combinations that prove coexistence.
-        return !EnvFlagEnabled_("GPUFL_SASS_ALLOW_ACTIVITY_WITH_METRICS");
+        // Isolation mode only. By default match main: allow normal CUPTI
+        // activity/callback tracing to coexist with SASS metrics.
+        return EnvFlagEnabled_("GPUFL_SASS_METRICS_ONLY");
     }
     bool UseSafeSassActivityDefaults() const {
         if (!IsSassProfilerMode()) return false;
         if (SassMetricsOnlyMode()) return true;
         if (EnvFlagEnabled_("GPUFL_SASS_FORCE_SAFE_ACTIVITY")) return true;
-        if (EnvFlagEnabled_("GPUFL_SASS_FORCE_FULL_ACTIVITY")) return false;
-
-        const ComputeCapability cc = GetComputeCapability(static_cast<int>(device_id_));
-        const uint32_t cuptiVersion = GetCuptiVersion();
-        if (cc.valid() && cc.atLeast(12, 0)) return false;
-        if (cuptiVersion >= 130200) return false;
-        return true;
+        return false;
     }
     bool AllowSassKernelActivity() const {
         if (SassMetricsOnlyMode()) return false;

--- a/include/gpufl/backends/nvidia/cupti_backend.hpp
+++ b/include/gpufl/backends/nvidia/cupti_backend.hpp
@@ -4,6 +4,8 @@
 #include <cupti.h>
 
 #include <atomic>
+#include <cstdlib>
+#include <cstring>
 #include <memory>
 #include <mutex>
 #include <optional>
@@ -13,6 +15,7 @@
 #include <vector>
 
 #include "gpufl/backends/nvidia/cupti_common.hpp"
+#include "gpufl/backends/nvidia/cupti_utils.hpp"
 #include "gpufl/backends/nvidia/engine/profiling_engine.hpp"
 #include "gpufl/core/debug_logger.hpp"
 #include "gpufl/core/monitor.hpp"
@@ -44,6 +47,60 @@ class CuptiBackend : public IMonitorBackend {
 
     bool IsMonitoringMode() override { return true; }
     bool IsProfilingMode()  override { return engine_ != nullptr; }
+
+    bool IsSassProfilerMode() const {
+        return opts_.profiling_engine == ProfilingEngine::SassMetrics ||
+               opts_.profiling_engine == ProfilingEngine::Deep;
+    }
+    bool UseSafeSassActivityDefaults() const {
+        if (!IsSassProfilerMode()) return false;
+        if (EnvFlagEnabled_("GPUFL_SASS_FORCE_SAFE_ACTIVITY")) return true;
+        if (EnvFlagEnabled_("GPUFL_SASS_FORCE_FULL_ACTIVITY")) return false;
+
+        const ComputeCapability cc = GetComputeCapability(static_cast<int>(device_id_));
+        const uint32_t cuptiVersion = GetCuptiVersion();
+        if (cc.valid() && cc.atLeast(12, 0)) return false;
+        if (cuptiVersion >= 130200) return false;
+        return true;
+    }
+    bool AllowSassKernelActivity() const {
+        return !UseSafeSassActivityDefaults() ||
+               EnvFlagEnabled_("GPUFL_SASS_ALLOW_KERNEL_ACTIVITY");
+    }
+    bool AllowSassMarkerActivity() const {
+        return !UseSafeSassActivityDefaults() ||
+               EnvFlagEnabled_("GPUFL_SASS_ALLOW_MARKER_ACTIVITY");
+    }
+    bool AllowSassMemTransferActivity() const {
+        if (!UseSafeSassActivityDefaults()) return true;
+        return EnvFlagEnabled_("GPUFL_SASS_ALLOW_MEM_TRANSFER_ACTIVITY");
+    }
+    bool AllowSassMemory2Activity() const {
+        if (!UseSafeSassActivityDefaults()) return true;
+        const bool memTransferRequested =
+            EnvFlagEnabled_("GPUFL_SASS_ALLOW_MEM_TRANSFER_ACTIVITY");
+        const bool memory2Requested =
+            EnvFlagEnabled_("GPUFL_SASS_ALLOW_MEMORY2_ACTIVITY") ||
+            EnvFlagEnabled_("GPUFL_SASS_ALLOW_MEMORY_ACTIVITY");
+        // Safe-mode default keeps MEMORY2 because it is tied to the explicit
+        // enable_memory_tracking option.  If the user asks to test mem-transfer
+        // activity, keep MEMORY2 off unless it is explicitly requested too;
+        // enabling both is the confirmed deadlocking combination on sm_86 +
+        // CUPTI 13.1.
+        return memory2Requested || !memTransferRequested;
+    }
+    bool AllowSassSyncActivity() const {
+        return !UseSafeSassActivityDefaults() ||
+               EnvFlagEnabled_("GPUFL_SASS_ALLOW_SYNC_ACTIVITY");
+    }
+    bool AllowSassGraphActivity() const {
+        return !UseSafeSassActivityDefaults() ||
+               EnvFlagEnabled_("GPUFL_SASS_ALLOW_GRAPH_ACTIVITY");
+    }
+    bool AllowSassExternalCorrelation() const {
+        return !UseSafeSassActivityDefaults() ||
+               EnvFlagEnabled_("GPUFL_SASS_ALLOW_EXTERNAL_CORRELATION");
+    }
 
     // Whether the active engine consumes cubin binaries. Cubin capture
     // feeds two consumers, and both want the binary for the SAME three
@@ -110,6 +167,13 @@ class CuptiBackend : public IMonitorBackend {
     friend class KernelLaunchHandler;
     friend class MemTransferHandler;
     friend class SynchronizationHandler;
+
+    static bool EnvFlagEnabled_(const char* name) {
+        const char* v = std::getenv(name);
+        return v && v[0] != '\0' && v[0] != '0' && std::strcmp(v, "false") != 0 &&
+               std::strcmp(v, "FALSE") != 0 && std::strcmp(v, "off") != 0 &&
+               std::strcmp(v, "OFF") != 0;
+    }
 
     // CUPTI callback functions
     static void CUPTIAPI BufferRequested(uint8_t** buffer, size_t* size,

--- a/include/gpufl/backends/nvidia/cupti_backend.hpp
+++ b/include/gpufl/backends/nvidia/cupti_backend.hpp
@@ -101,6 +101,10 @@ class CuptiBackend : public IMonitorBackend {
         return !UseSafeSassActivityDefaults() ||
                EnvFlagEnabled_("GPUFL_SASS_ALLOW_EXTERNAL_CORRELATION");
     }
+    void FlushProfilingDataBeforeCudaTeardown(const char* reason);
+    void NoteKernelLaunchForCleanupFlush() {
+        last_cleanup_flush_ns_.store(0, std::memory_order_release);
+    }
 
     // Whether the active engine consumes cubin binaries. Cubin capture
     // feeds two consumers, and both want the binary for the SAME three
@@ -130,6 +134,8 @@ class CuptiBackend : public IMonitorBackend {
     // reflect actual GPU execution time.
     void FlushPendingKernels();
     CUpti_SubscriberHandle GetSubscriber() const { return subscriber_; }
+
+    void EmitCaptureCapabilities_() const;
 
     void OnScopeStart(const char* name) override {
         GFL_LOG_DEBUG("OnScopeStart");
@@ -222,6 +228,7 @@ class CuptiBackend : public IMonitorBackend {
     std::atomic<uint64_t> kernel_activity_seen_{0};
     std::atomic<uint64_t> kernel_activity_emitted_{0};
     std::atomic<uint64_t> kernel_activity_throttled_{0};
+    std::atomic<int64_t> last_cleanup_flush_ns_{0};
     uint32_t device_id_ = 0;
     std::string chip_name_;
 

--- a/include/gpufl/backends/nvidia/cupti_backend.hpp
+++ b/include/gpufl/backends/nvidia/cupti_backend.hpp
@@ -52,14 +52,15 @@ class CuptiBackend : public IMonitorBackend {
     //      Source/SASS dashboard view), and
     //   2. the engine's own per-PC cubin lookups (PcSampling and
     //      SassMetrics read cubin_by_crc_ to correlate samples).
-    // None (monitoring only) and RangeProfiler (scope-level HW counters)
-    // need neither, so we skip cubin capture/disassembly entirely for
-    // them — there's no per-instruction data to attach it to. This is
-    // what makes profiling_engine=None truly "monitoring only".
+    // Trace (activity records only) and RangeProfiler (scope-level HW
+    // counters) need neither, so we skip cubin capture/disassembly
+    // entirely for them — there's no per-instruction data to attach it
+    // to. (ProfilingEngine::Monitor never constructs a CuptiBackend at
+    // all, so it doesn't reach this method.)
     bool NeedsCubinCapture() const {
         return opts_.profiling_engine == ProfilingEngine::PcSampling ||
                opts_.profiling_engine == ProfilingEngine::SassMetrics ||
-               opts_.profiling_engine == ProfilingEngine::PcSamplingWithSass;
+               opts_.profiling_engine == ProfilingEngine::Deep;
     }
 
     void RegisterHandler(const std::shared_ptr<ICuptiHandler>& handler);
@@ -89,7 +90,7 @@ class CuptiBackend : public IMonitorBackend {
         // and are flushed at session stop() instead.  cudaDeviceSynchronize
         // ensures GPU work completes before the scope exits.
         if (opts_.profiling_engine == ProfilingEngine::PcSampling ||
-            opts_.profiling_engine == ProfilingEngine::PcSamplingWithSass) {
+            opts_.profiling_engine == ProfilingEngine::Deep) {
             cudaDeviceSynchronize();
         }
     }

--- a/include/gpufl/backends/nvidia/cupti_common.hpp
+++ b/include/gpufl/backends/nvidia/cupti_common.hpp
@@ -5,20 +5,53 @@
 #include <utility>
 #include <vector>
 
-#define CUPTI_CHECK(call)                                            \
-    do {                                                             \
-        CUptiResult res = (call);                                    \
-        if (res != CUPTI_SUCCESS) {                                  \
-            const char* errStr;                                      \
-            cuptiGetResultString(res, &errStr);                      \
-            ::gpufl::DebugLogger::error("[GPUFL Monitor] ", errStr); \
-        }                                                            \
+#include "gpufl/core/debug_logger.hpp"
+
+namespace gpufl {
+
+/**
+ * CUPTI result codes that are EXPECTED on healthy modern systems and
+ * should not be surfaced as errors. The legacy activity-based PC
+ * sampling path isn't supported on Volta+ GPUs, which return
+ * LEGACY_PROFILER_NOT_SUPPORTED / NOT_COMPATIBLE when probed — gpufl
+ * handles that by falling back to the modern PC Sampling API, so these
+ * are routine fallback signals, not failures. CUPTI_CHECK logs them at
+ * debug level (visible with enable_debug_output) instead of as errors,
+ * so a healthy session doesn't spew scary `[GPUFL Monitor]` lines.
+ * Genuinely-unexpected codes still print as errors.
+ */
+inline bool IsBenignCuptiResult(CUptiResult res) {
+    switch (res) {
+        case CUPTI_ERROR_LEGACY_PROFILER_NOT_SUPPORTED:
+        case CUPTI_ERROR_NOT_COMPATIBLE:
+            return true;
+        default:
+            return false;
+    }
+}
+
+}  // namespace gpufl
+
+#define CUPTI_CHECK(call)                                                  \
+    do {                                                                   \
+        CUptiResult _cupti_res = (call);                                   \
+        if (_cupti_res != CUPTI_SUCCESS) {                                 \
+            const char* _cupti_err = nullptr;                              \
+            cuptiGetResultString(_cupti_res, &_cupti_err);                 \
+            if (::gpufl::IsBenignCuptiResult(_cupti_res)) {                \
+                GFL_LOG_DEBUG("[Monitor] expected CUPTI fallback: ",       \
+                              _cupti_err ? _cupti_err : "");               \
+            } else {                                                       \
+                ::gpufl::DebugLogger::error("[GPUFL Monitor] ",            \
+                                            _cupti_err ? _cupti_err : ""); \
+            }                                                              \
+        }                                                                  \
     } while (0)
 
 #define CUPTI_CHECK_RETURN(call, failMsg)                               \
     do {                                                                \
-        CUptiResult res = (call);                                       \
-        if (res != CUPTI_SUCCESS) {                                     \
+        CUptiResult _cupti_res = (call);                                \
+        if (_cupti_res != CUPTI_SUCCESS) {                              \
             ::gpufl::DebugLogger::error("[GPUFL Monitor] ", (failMsg)); \
             return;                                                     \
         }                                                               \

--- a/include/gpufl/backends/nvidia/cupti_utils.cpp
+++ b/include/gpufl/backends/nvidia/cupti_utils.cpp
@@ -61,6 +61,16 @@ ComputeCapability GetComputeCapability(int deviceId) {
     return cc;
 }
 
+uint32_t GetCuptiVersion() {
+    static std::once_flag once;
+    static uint32_t version = 0;
+    std::call_once(once, [] {
+        uint32_t v = 0;
+        if (cuptiGetVersion(&v) == CUPTI_SUCCESS) version = v;
+    });
+    return version;
+}
+
 void CalculateOccupancy(LaunchMeta& meta, const void* funcPtr) {
     if (!funcPtr) return;
 

--- a/include/gpufl/backends/nvidia/cupti_utils.hpp
+++ b/include/gpufl/backends/nvidia/cupti_utils.hpp
@@ -42,6 +42,12 @@ struct ComputeCapability {
 ComputeCapability GetComputeCapability(int deviceId);
 
 /**
+ * @brief Returns the CUPTI runtime version encoded as CUDA_VERSION style
+ * integer (e.g. 130100 for 13.1, 130200 for 13.2). Returns 0 if unavailable.
+ */
+uint32_t GetCuptiVersion();
+
+/**
  * @brief Gets the maximum number of threads per SM for a given device.
  */
 int GetMaxThreadsPerSM(int deviceId);

--- a/include/gpufl/backends/nvidia/engine/pc_sampling_engine.cpp
+++ b/include/gpufl/backends/nvidia/engine/pc_sampling_engine.cpp
@@ -157,6 +157,14 @@ void PcSamplingEngine::start() {
 
     if (pcRes == CUPTI_SUCCESS) {
         pc_sampling_method_ = Method::ActivityAPI;
+        // CUpti_ActivityPCSampling3 carries only sourceLocatorId + functionId,
+        // so the ActivityAPI sampler needs the SOURCE_LOCATOR and FUNCTION
+        // companion records to resolve file/line/function. These used to be
+        // enabled unconditionally in CuptiBackend::start(); they live here now
+        // so only the engine that consumes them turns them on
+        // (CuptiBackend::shutdown() disables both).
+        cuptiActivityEnable(CUPTI_ACTIVITY_KIND_SOURCE_LOCATOR);
+        cuptiActivityEnable(CUPTI_ACTIVITY_KIND_FUNCTION);
         GFL_LOG_DEBUG(
             "[PC Sampling] Using Activity API "
             "(CUPTI_ACTIVITY_KIND_PC_SAMPLING)");

--- a/include/gpufl/backends/nvidia/engine/pc_sampling_engine.cpp
+++ b/include/gpufl/backends/nvidia/engine/pc_sampling_engine.cpp
@@ -46,15 +46,14 @@ BuildPcSamplingConfig(const uint32_t samplingPeriod,
         configInfo[configCount++] = info;
     };
 
-    // CONTINUOUS mode: avoids deadlock between KERNEL_SERIALIZED and
-    // cudaDeviceSynchronize().  Kernel activity records are re-enabled
-    // explicitly after PC sampling configuration.
+    // Kernel-serialized collection plus explicit start/stop lets GPUFL own
+    // the PC sampling lifetime while avoiding mid-session GetData drains.
     {
         CUpti_PCSamplingConfigurationInfo info = {};
         info.attributeType =
             CUPTI_PC_SAMPLING_CONFIGURATION_ATTR_TYPE_COLLECTION_MODE;
         info.attributeData.collectionModeData.collectionMode =
-            CUPTI_PC_SAMPLING_COLLECTION_MODE_CONTINUOUS;
+            CUPTI_PC_SAMPLING_COLLECTION_MODE_KERNEL_SERIALIZED;
         addConfig(info);
     }
     {
@@ -81,17 +80,15 @@ BuildPcSamplingConfig(const uint32_t samplingPeriod,
         addConfig(info);
     }
 
-    // CUPTI auto-managed start/stop.  With enableStartStopControl=0, CUPTI
-    // samples automatically per kernel.  We reset the session between scopes
-    // (disable + re-enable) to ensure each scope gets fresh stall data.
-    // Note: enableStartStopControl=1 (explicit Start/Stop) returns zero data
-    // on Blackwell/WDDM — a CUPTI platform limitation.
+    // Explicit start/stop is required before cuptiPCSamplingStart/Stop.
+    // Do not call cuptiPCSamplingGetData while sampling is active; on CUDA
+    // 13.x this can drain the buffer and leave the final collection empty.
     {
         CUpti_PCSamplingConfigurationInfo info = {};
         info.attributeType =
             CUPTI_PC_SAMPLING_CONFIGURATION_ATTR_TYPE_ENABLE_START_STOP_CONTROL;
         info.attributeData.enableStartStopControlData.enableStartStopControl =
-            0;
+            1;
         addConfig(info);
     }
     {
@@ -208,6 +205,7 @@ void PcSamplingEngine::stop() {
     if (pc_sampling_method_ == Method::SamplingAPI &&
         sampling_api_ready_.load() && ctx_.cuda_ctx) {
         if (sampling_api_started_.load()) {
+            pc_sampling_ref_count_.store(1);
             StopAndCollectPcSampling_();
         }
         CUpti_PCSamplingDisableParams dp = {};
@@ -219,90 +217,17 @@ void PcSamplingEngine::stop() {
 }
 
 void PcSamplingEngine::drainData() {
-    if (pc_sampling_method_ != Method::SamplingAPI) return;
-    if (!sampling_api_started_.load()) return;
-    if (!pc_sampling_buffers_ || !pc_sampling_buffers_->data) return;
-    if (!ctx_.cuda_ctx) return;
-
-    // Non-blocking getData call — CUPTI docs say this never does device
-    // synchronization, so it's safe to call from the collector thread.
-    CUpti_PCSamplingGetDataParams getDataParams = {};
-    getDataParams.size = sizeof(CUpti_PCSamplingGetDataParams);
-    getDataParams.ctx = ctx_.cuda_ctx;
-    getDataParams.pcSamplingData = pc_sampling_buffers_->data;
-
-    // stallReasonCount is both input (available slots) and output (slots
-    // written) in CUpti_PCSamplingPCData.  Reset to original capacity so CUPTI
-    // can write into each entry again.
-    if (num_stall_reasons_ > 0) {
-        const size_t cap = pc_sampling_buffers_->data->collectNumPcs;
-        for (size_t i = 0; i < cap; ++i)
-            pc_sampling_buffers_->pcRecords[i].stallReasonCount =
-                num_stall_reasons_;
-    }
-
-    pc_sampling_buffers_->data->totalNumPcs = 0;
-    if (const CUptiResult getRes = cuptiPCSamplingGetData(&getDataParams);
-        getRes != CUPTI_SUCCESS && getRes != CUPTI_ERROR_OUT_OF_MEMORY)
-        return;
-
-    auto numPcs = pc_sampling_buffers_->data->totalNumPcs;
-    if (numPcs == 0) return;
-    produced_data_.store(true, std::memory_order_relaxed);
-
-    GFL_LOG_DEBUG("[PC Sampling] drainData: ", numPcs, " PC records");
-
-    for (size_t i = 0; i < numPcs; ++i) {
-        const CUpti_PCSamplingPCData& pc =
-            pc_sampling_buffers_->data->pPcData[i];
-        if (pc.stallReasonCount > 0 && pc.stallReason) {
-            for (uint32_t j = 0; j < pc.stallReasonCount; ++j) {
-                if (pc.stallReason[j].samples > 0) {
-                    ActivityRecord out{};
-                    out.type = TraceType::PC_SAMPLE;
-                    cuptiGetDeviceId(ctx_.cuda_ctx, &out.device_id);
-                    out.corr_id = pc.correlationId;
-                    std::snprintf(out.sample_kind, sizeof(out.sample_kind),
-                                  "%s", "pc_sampling");
-                    out.samples_count = pc.stallReason[j].samples;
-                    out.stall_reason =
-                        pc.stallReason[j].pcSamplingStallReasonIndex;
-                    out.cpu_start_ns = detail::GetTimestampNs();
-
-                    if (pc.functionName) {
-                        std::snprintf(out.function_name,
-                                      sizeof(out.function_name), "%s",
-                                      pc.functionName);
-                    } else {
-                        std::snprintf(out.function_name,
-                                      sizeof(out.function_name), "unknown");
-                    }
-
-                    {
-                        std::lock_guard lk(stall_reason_mu_);
-                        if (auto it = stall_reason_map_.find(out.stall_reason);
-                            it != stall_reason_map_.end()) {
-                            out.reason_name = it->second;
-                        } else {
-                            out.reason_name =
-                                "Stall_" + std::to_string(out.stall_reason);
-                        }
-                    }
-
-                    g_monitorBuffer.Push(out);
-                }
-            }
-        }
-    }
+    // SamplingAPI data is collected only after cuptiPCSamplingStop().  Calling
+    // cuptiPCSamplingGetData() from the periodic collector while kernels are
+    // still inside a scope can drain CUPTI's PC buffer and make the final
+    // stop-side collection report zero records.
 }
 
 void PcSamplingEngine::shutdown() {
-    // Collect any deferred SamplingAPI data before teardown.
-    // For SamplingAPI with enableStartStopControl=0, onScopeStop is a no-op
-    // (to avoid killing CUPTI callbacks), so the accumulated samples are
-    // collected here where callback corruption no longer matters.
+    // Collect a still-active SamplingAPI session before teardown.
     if (sampling_api_started_.load() &&
         pc_sampling_method_ == Method::SamplingAPI) {
+        pc_sampling_ref_count_.store(1);
         StopAndCollectPcSampling_();
     }
 
@@ -331,10 +256,7 @@ void PcSamplingEngine::onScopeStart(const char* /*name*/) {
 }
 
 void PcSamplingEngine::onScopeStop(const char* /*name*/) {
-    // Intentionally a no-op: per-scope stop/collect is disabled.
-    // SamplingAPI collection is deferred to stop()/shutdown() to avoid callback
-    // corruption on some driver versions, and non-SamplingAPI paths do not use
-    // StopAndCollectPcSampling_().
+    // Keep SamplingAPI armed across scopes; collect once at session stop.
 }
 
 // ---- Private helpers -------------------------------------------------------
@@ -475,31 +397,6 @@ bool PcSamplingEngine::EnableSamplingFeatures_() {
         return false;
     }
 
-    // Privilege probe: call getData with empty buffers to detect privilege
-    // errors early.  Only on first initialization — on re-init (after
-    // session reset between scopes), calling getData resets CUPTI's
-    // auto-sampling state on Blackwell and causes zero data collection.
-    if (!privilege_probed_) {
-        privilege_probed_ = true;
-        pc_sampling_buffers_->data->totalNumPcs = 0;
-        CUpti_PCSamplingGetDataParams probeParams = {};
-        probeParams.size = sizeof(CUpti_PCSamplingGetDataParams);
-        probeParams.ctx = ctx_.cuda_ctx;
-        probeParams.pcSamplingData = pc_sampling_buffers_->data;
-        CUptiResult probeRes = cuptiPCSamplingGetData(&probeParams);
-        if (IsInsufficientPrivilege(probeRes) ||
-            probeRes == CUPTI_ERROR_NOT_INITIALIZED) {
-            GFL_LOG_DEBUG(
-                "[PC Sampling] Probe failed (", probeRes,
-                ") — "
-                "PC sampling unavailable on this GPU/driver combination "
-                "(may conflict with Profiler API); disabling.");
-            sampling_api_blocked_.store(true);
-            pc_sampling_method_ = Method::None;
-            return false;
-        }
-    }
-
     sampling_api_ready_.store(true);
 
     // cuptiPCSamplingEnable / SetConfigurationAttribute can internally
@@ -532,6 +429,25 @@ void PcSamplingEngine::StartPcSampling_() {
         return;
     }
 
+    if (!ctx_.cuda_ctx || !IsContextValid(ctx_.cuda_ctx)) {
+        pc_sampling_ref_count_.store(0);
+        GFL_LOG_ERROR("[GPUFL] Cannot start PC Sampling: Context invalid.");
+        return;
+    }
+
+    CUpti_PCSamplingStartParams startParams = {};
+    startParams.size = sizeof(CUpti_PCSamplingStartParams);
+    startParams.ctx = ctx_.cuda_ctx;
+    const CUptiResult startRes = cuptiPCSamplingStart(&startParams);
+    if (startRes != CUPTI_SUCCESS) {
+        pc_sampling_ref_count_.store(0);
+        if (IsInsufficientPrivilege(startRes)) {
+            sampling_api_blocked_.store(true);
+        }
+        LogCuptiErrorIfFailed(this->name(), "cuptiPCSamplingStart", startRes);
+        return;
+    }
+
     sampling_api_started_.store(true);
     GFL_LOG_DEBUG("[PC Sampling] >>> STARTED (Scope Begin) <<<");
 }
@@ -546,21 +462,22 @@ void PcSamplingEngine::StopAndCollectPcSampling_() {
         return;
     }
 
-    // Terminal drain. Both callers — stop() and shutdown() — run at session
-    // teardown, and onScopeStop is a deliberate no-op, so pc_sampling_ref_count_
-    // is NOT a "still inside a scope" signal here: it only ever increments (once
-    // per scope start) and is never decremented per-scope. A refcount-gated
-    // collect therefore never reaches the drain for a multi-scope session — that
-    // was the "Deep on Blackwell armed PC sampling but drained ZERO rows" bug
-    // (refcount climbed to 7, the two terminal calls only walked it 7→6→5, never
-    // hit the refs==1 collect path). sampling_api_started_ (set by start() once
-    // CUPTI sampling actually armed) is the correct once-only guard here.
-    if (!sampling_api_started_.exchange(false)) {
-        GFL_LOG_DEBUG(
-            "[PC Sampling] StopAndCollect: exit — already collected / not started");
+    const int refs = pc_sampling_ref_count_.load();
+    if (refs <= 0) {
+        GFL_LOG_DEBUG("[PC Sampling] StopAndCollect: exit — no active scope");
+        return;
+    }
+    if (refs > 1) {
+        const int remaining = pc_sampling_ref_count_.fetch_sub(1) - 1;
+        GFL_LOG_DEBUG("[PC Sampling] still active (RefCount=", remaining, ")");
         return;
     }
     pc_sampling_ref_count_.store(0);
+
+    if (!sampling_api_started_.exchange(false)) {
+        GFL_LOG_DEBUG("[PC Sampling] StopAndCollect: exit — already collected / not started");
+        return;
+    }
 
     if (!ctx_.cuda_ctx || !IsContextValid(ctx_.cuda_ctx)) {
         GFL_LOG_ERROR("[GPUFL] Aborting PC Sampling: Context invalid.");
@@ -572,8 +489,23 @@ void PcSamplingEngine::StopAndCollectPcSampling_() {
         return;
     }
 
-    GFL_LOG_DEBUG("[PC Sampling] <<< COLLECTING (Scope End) >>>");
+    const auto collectNumPcs = pc_sampling_buffers_->data->collectNumPcs;
+    GFL_LOG_DEBUG("[PC Sampling] <<< COLLECTING (Session End) >>> collectNumPcs=",
+                  collectNumPcs);
     cudaDeviceSynchronize();
+
+    CUpti_PCSamplingStopParams stopParams = {};
+    stopParams.size = sizeof(CUpti_PCSamplingStopParams);
+    stopParams.ctx = ctx_.cuda_ctx;
+    const CUptiResult stopRes = cuptiPCSamplingStop(&stopParams);
+    if (stopRes != CUPTI_SUCCESS) {
+        if (IsInsufficientPrivilege(stopRes) ||
+            stopRes == CUPTI_ERROR_NOT_INITIALIZED) {
+            sampling_api_blocked_.store(true);
+        }
+        LogCuptiErrorIfFailed(this->name(), "cuptiPCSamplingStop", stopRes);
+        return;
+    }
 
     CUpti_PCSamplingGetDataParams getDataParams = {};
     getDataParams.size = sizeof(CUpti_PCSamplingGetDataParams);
@@ -701,11 +633,6 @@ void PcSamplingEngine::StopAndCollectPcSampling_() {
 
         if (!hasMore) break;
     }
-    // Note: on Blackwell/WDDM with enableStartStopControl=0, CUPTI only
-    // auto-samples the first kernel batch.  Subsequent getData calls drain
-    // leftover data from that kernel.  Session reset (Disable+Enable) was
-    // tested but the re-initialized session never collects new data.
-    // This is a known CUPTI platform limitation.
 }
 
 }  // namespace gpufl

--- a/include/gpufl/backends/nvidia/engine/pc_sampling_engine.cpp
+++ b/include/gpufl/backends/nvidia/engine/pc_sampling_engine.cpp
@@ -248,6 +248,7 @@ void PcSamplingEngine::drainData() {
 
     auto numPcs = pc_sampling_buffers_->data->totalNumPcs;
     if (numPcs == 0) return;
+    produced_data_.store(true, std::memory_order_relaxed);
 
     GFL_LOG_DEBUG("[PC Sampling] drainData: ", numPcs, " PC records");
 
@@ -545,26 +546,21 @@ void PcSamplingEngine::StopAndCollectPcSampling_() {
         return;
     }
 
-    if (pc_sampling_ref_count_.load() <= 0) {
-        GFL_LOG_DEBUG("[PC Sampling] StopAndCollect: exit — refCount <= 0");
-        return;
-    }
-
-    int refs = pc_sampling_ref_count_.fetch_sub(1);
-    if (refs > 1) {
-        GFL_LOG_DEBUG("[PC Sampling] still active (RefCount=", refs - 1, ")");
-        return;
-    }
-    if (refs < 1) {
-        GFL_LOG_ERROR("[PC Sampling] RefCount underflow!");
-        pc_sampling_ref_count_.store(0);
-        return;
-    }
-
+    // Terminal drain. Both callers — stop() and shutdown() — run at session
+    // teardown, and onScopeStop is a deliberate no-op, so pc_sampling_ref_count_
+    // is NOT a "still inside a scope" signal here: it only ever increments (once
+    // per scope start) and is never decremented per-scope. A refcount-gated
+    // collect therefore never reaches the drain for a multi-scope session — that
+    // was the "Deep on Blackwell armed PC sampling but drained ZERO rows" bug
+    // (refcount climbed to 7, the two terminal calls only walked it 7→6→5, never
+    // hit the refs==1 collect path). sampling_api_started_ (set by start() once
+    // CUPTI sampling actually armed) is the correct once-only guard here.
     if (!sampling_api_started_.exchange(false)) {
-        GFL_LOG_DEBUG("[PC Sampling] StopAndCollect: exit — sampling_api_started was false");
+        GFL_LOG_DEBUG(
+            "[PC Sampling] StopAndCollect: exit — already collected / not started");
         return;
     }
+    pc_sampling_ref_count_.store(0);
 
     if (!ctx_.cuda_ctx || !IsContextValid(ctx_.cuda_ctx)) {
         GFL_LOG_ERROR("[GPUFL] Aborting PC Sampling: Context invalid.");
@@ -621,6 +617,7 @@ void PcSamplingEngine::StopAndCollectPcSampling_() {
         }
 
         auto numPcs = pc_sampling_buffers_->data->totalNumPcs;
+        if (numPcs > 0) produced_data_.store(true, std::memory_order_relaxed);
         GFL_LOG_DEBUG("[PC Sampling] Collected ", numPcs, " PC records",
                       (hasMore ? " (more remaining)." : "."));
 

--- a/include/gpufl/backends/nvidia/engine/pc_sampling_engine.cpp
+++ b/include/gpufl/backends/nvidia/engine/pc_sampling_engine.cpp
@@ -494,9 +494,11 @@ bool PcSamplingEngine::EnableSamplingFeatures_() {
     sampling_api_ready_.store(true);
 
     // cuptiPCSamplingEnable / SetConfigurationAttribute can internally
-    // disable CUPTI_ACTIVITY_KIND_KERNEL.  Re-enable so kernel activity
-    // records continue to flow alongside PC samples.
-    cuptiActivityEnable(CUPTI_ACTIVITY_KIND_KERNEL);
+    // disable kernel activity tracing. Re-enable CONCURRENT_KERNEL so kernel
+    // records keep flowing alongside PC samples. We deliberately do NOT
+    // re-enable CUPTI_ACTIVITY_KIND_KERNEL — it serializes every kernel
+    // (distorts timing, adds overhead), and PC sampling is compatible with
+    // concurrent kernel tracing since CUDA 12.8 Update 1.
     cuptiActivityEnable(CUPTI_ACTIVITY_KIND_CONCURRENT_KERNEL);
 
     GFL_LOG_DEBUG("[PC Sampling] configured and enabled successfully.");

--- a/include/gpufl/backends/nvidia/engine/pc_sampling_engine.hpp
+++ b/include/gpufl/backends/nvidia/engine/pc_sampling_engine.hpp
@@ -63,6 +63,11 @@ class PcSamplingEngine final : public IProfilingEngine {
                && !sampling_api_blocked_.load(std::memory_order_relaxed);
     }
 
+    /** True once at least one PC sample was emitted this session. */
+    bool producedData() const override {
+        return produced_data_.load(std::memory_order_relaxed);
+    }
+
    private:
     enum class Method {
         None,        // PC Sampling not available / not initialized
@@ -82,6 +87,7 @@ class PcSamplingEngine final : public IProfilingEngine {
     std::atomic<bool> sampling_api_ready_{false};
     std::atomic<bool> sampling_api_started_{false};
     std::atomic<bool> sampling_api_blocked_{false};
+    std::atomic<bool> produced_data_{false};
     bool privilege_probed_ = false;
 
     std::unique_ptr<PCSamplingBuffers, PCSamplingDeleter> pc_sampling_buffers_;

--- a/include/gpufl/backends/nvidia/engine/pc_sampling_with_sass_engine.cpp
+++ b/include/gpufl/backends/nvidia/engine/pc_sampling_with_sass_engine.cpp
@@ -160,6 +160,7 @@ void PcSamplingWithSassEngine::shutdown() {
 
 void PcSamplingWithSassEngine::onScopeStart(const char* name) {
     if (pc_ && !skip_pc_scope_) pc_->onScopeStart(name);
+    if (sass_ok_) sass_->onScopeStart(name);
 }
 
 void PcSamplingWithSassEngine::onScopeStop(const char* name) {

--- a/include/gpufl/backends/nvidia/engine/pc_sampling_with_sass_engine.cpp
+++ b/include/gpufl/backends/nvidia/engine/pc_sampling_with_sass_engine.cpp
@@ -186,4 +186,8 @@ void PcSamplingWithSassEngine::drainData() {
     if (pc_) pc_->drainData();
 }
 
+void PcSamplingWithSassEngine::flushBeforeCudaTeardown(const char* reason) {
+    if (sass_ok_ && sass_) sass_->flushBeforeCudaTeardown(reason);
+}
+
 }  // namespace gpufl

--- a/include/gpufl/backends/nvidia/engine/pc_sampling_with_sass_engine.cpp
+++ b/include/gpufl/backends/nvidia/engine/pc_sampling_with_sass_engine.cpp
@@ -2,80 +2,160 @@
 
 #include <cupti.h>
 
+#include <cstdlib>
+
 #include "gpufl/core/debug_logger.hpp"
 
 namespace gpufl {
 
+namespace {
+// ── When does Deep attempt SASS metrics? ────────────────────────────────
+// Deep attempts SASS by default and falls back to PC sampling if SASS can't
+// arm. The two are mutually exclusive on current NVIDIA drivers (the Profiler
+// API that SASS uses blocks the PC Sampling API and vice versa), so Deep
+// collects ONE per session -- never both (unless GPUFL_DEEP_TRY_BOTH is set
+// to experiment with coexistence; see start()).
+//
+// SASS's CUPTI instrumentation can DEADLOCK against concurrent kernel launches
+// under CUDA's default LAZY module loading (each kernel is finalized +
+// SASS-patched on first launch; many such first-launches racing across
+// PyTorch's threads invert CUPTI/driver locks -- froze an RTX 3090 run). That
+// hazard is handled WITHOUT gating here:
+//   * the per-architecture exclusion gate in SassMetricsEngine::start()
+//     (GPUFL_SASS_EXCLUDE_ARCHS) skips SASS on confirmed-bad architectures, and
+//   * SassMetricsEngine's failure paths return not-enabled, so Deep degrades
+//     to PC sampling cleanly.
+// EAGER module loading is now an OPT-IN alternative workaround
+// (GPUFL_EAGER_MODULE_LOADING=1), no longer required for Deep to try SASS.
+//   * Normal Deep run        -> attempt SASS, PC fallback if it can't arm.
+//   * Arch in exclusion list -> SassMetricsEngine declines -> Deep is PC-only.
+//   * GPUFL_DEEP_PC_ONLY=1   -> always PC-only (manual override).
+// PC sampling is always the fallback, so a Deep session is never unsafe.
+bool ShouldAttemptSassInDeep() {
+    // Manual escape hatch: force PC-sampling-only regardless of hardware.
+    if (const char* e = std::getenv("GPUFL_DEEP_PC_ONLY");
+        e && e[0] != '\0' && e[0] != '0') {
+        return false;
+    }
+    // Otherwise attempt SASS. The per-architecture exclusion gate and the
+    // failure-handling paths in SassMetricsEngine::start() decide whether it
+    // actually arms; if not, start() leaves it not-enabled and Deep runs PC
+    // sampling only.
+    return true;
+}
+}  // namespace
+
 bool PcSamplingWithSassEngine::initialize(const MonitorOptions& opts,
                                           const EngineContext& ctx) {
-    pc_   = std::make_unique<PcSamplingEngine>();
-    sass_ = std::make_unique<SassMetricsEngine>();
+    pc_ = std::make_unique<PcSamplingEngine>();
     pc_->initialize(opts, ctx);
-    sass_->initialize(opts, ctx);
-    // sass_ok_ is set after start() once we know whether cuptiSassMetricsEnable
-    // succeeded.  initialize() itself is lightweight (stores opts/ctx).
+
+    // Decide once whether Deep should try SASS this session. Only construct
+    // the SASS sub-engine when it will — otherwise Deep touches no
+    // Profiler-API state and behaves as a PC sampling engine.
+    sass_gate_open_ = ShouldAttemptSassInDeep();
+    if (sass_gate_open_) {
+        sass_ = std::make_unique<SassMetricsEngine>();
+        sass_->initialize(opts, ctx);
+        GFL_LOG_DEBUG(
+            "[PcSamplingWithSass] eager module loading active — Deep will "
+            "attempt SASS metrics (PC sampling is the fallback; the two are "
+            "mutually exclusive, so Deep collects one or the other).");
+    } else {
+        GFL_LOG_DEBUG(
+            "[PcSamplingWithSass] SASS not attempted (CUDA_MODULE_LOADING is "
+            "not EAGER, or GPUFL_DEEP_PC_ONLY set) — Deep runs PC sampling "
+            "only, which avoids the lazy-patching deadlock.");
+    }
+    // sass_ok_ is finalized in start() once we know whether
+    // cuptiSassMetricsEnable actually succeeded.
     return true;
 }
 
 void PcSamplingWithSassEngine::start() {
-    // SASS metrics (Profiler API) and PC Sampling API are mutually
-    // exclusive on current NVIDIA drivers (confirmed on Ampere sm_86
-    // and Blackwell sm_120; almost certainly the same on Hopper). The
-    // old design armed both, then tried to tear PC sampling down if
-    // SASS succeeded — but `cuptiPCSamplingDisable` itself is unsafe
-    // while another CUPTI API is initialized (see pc_sampling_engine
-    // comment around stop()), and on Ampere this teardown hangs
-    // indefinitely at the next flush (observed in
-    // example/cuda/manykernel_benchmark Deep-mode run, where the
-    // process froze after `[flushDisassembly] parsed 40 functions`).
-    //
-    // The safer pattern: try SASS first, and only arm PC sampling at
-    // all if SASS didn't succeed. No risky disable path because PC
-    // sampling was never armed alongside the Profiler API.
-    //
-    // Trade-off: Deep mode now provides SASS-only data when SASS works,
-    // and PC-sampling-only data when SASS doesn't. Users wanting both
-    // streams need to run two separate sessions until NVIDIA exposes
-    // a way to multiplex the underlying hardware counters.
-    sass_->start();
-    sass_ok_ = sass_->isEnabled();
+    // Deep attempts SASS only where ShouldAttemptSassInDeep() allowed it
+    // (eager module loading in effect, unless GPUFL_DEEP_PC_ONLY is set).
+    // Otherwise sass_ was never constructed and we go straight to PC
+    // sampling — no Profiler API, no lazy patching, no deadlock.
+    if (sass_gate_open_ && sass_) {
+        sass_->start();
+        sass_ok_ = sass_->isEnabled();
+    } else {
+        sass_ok_ = false;
+    }
 
     if (sass_ok_) {
-        // PcSamplingEngine::initialize() is CUPTI-free (just sets
-        // fields), so pc_ has touched no CUPTI state yet. Dropping it
-        // here is clean — no disable / unsubscribe needed.
-        GFL_LOG_DEBUG(
-            "[PcSamplingWithSass] SASS active — skipping PC sampling "
-            "(mutually exclusive with Profiler API). Deep mode provides "
-            "SASS metrics only for this session.");
-        pc_.reset();
+        // SASS armed. PC sampling and the Profiler API have been mutually
+        // exclusive on every driver we've tested — BUT that was only ever
+        // observed under lazy module loading, tangled up with the now-fixed
+        // deadlock. GPUFL_DEEP_TRY_BOTH=1 tests whether they can COEXIST
+        // under eager loading: try arming PC sampling alongside SASS and keep
+        // both if it actually arms; otherwise (the expected outcome) fall
+        // back to SASS only. If the enable is rejected, nothing armed, so
+        // there's nothing to disable (avoids the unsafe disable-PC-while-
+        // Profiler-API-active teardown).
+        bool tryBoth = false;
+        if (const char* e = std::getenv("GPUFL_DEEP_TRY_BOTH"))
+            tryBoth = (e[0] != '\0' && e[0] != '0');
+
+        if (tryBoth && pc_) {
+            pc_->start();
+            if (pc_->isOperational()) {
+                // Coexistence — keep BOTH sub-engines. Logged at error level
+                // (always visible) because it would overturn the long-standing
+                // mutual-exclusion assumption and warrants verification.
+                GFL_LOG_ERROR(
+                    "[PcSamplingWithSass] EXPERIMENTAL: SASS + PC sampling are "
+                    "BOTH armed (GPUFL_DEEP_TRY_BOTH). Confirm BOTH data streams "
+                    "populate (sass_metric rows AND pc_sampling rows) and the "
+                    "run stays stable before trusting this.");
+            } else {
+                GFL_LOG_DEBUG(
+                    "[PcSamplingWithSass] GPUFL_DEEP_TRY_BOTH: PC sampling did "
+                    "not arm alongside SASS (still mutually exclusive) — "
+                    "keeping SASS only.");
+                pc_.reset();  // enable rejected; nothing armed to disable
+            }
+        } else {
+            GFL_LOG_DEBUG(
+                "[PcSamplingWithSass] SASS active — skipping PC sampling "
+                "(mutually exclusive with Profiler API). Deep = SASS metrics "
+                "this session.");
+            pc_.reset();
+        }
     } else {
         pc_->start();
+        // Expected Deep behavior when SASS isn't attempted (eager loading
+        // not in effect) or SASS declined to arm — not an error.
         GFL_LOG_DEBUG(
-            "[PcSamplingWithSass] SASS unavailable — running PC sampling only.");
+            "[PcSamplingWithSass] Deep mode: PC sampling active (stall-reason "
+            "data, drains on the collector thread).");
     }
 }
 
 void PcSamplingWithSassEngine::stop() {
-    if (pc_) pc_->stop();
-    // SASS needs a final drain at stop — onScopeStop is the normal
-    // per-scope drain trigger, but workloads that don't wrap kernels
-    // in scopes (e.g. PyTorch training loops without a surrounding
-    // gpufl.Scope) would otherwise lose every sample because nothing
-    // pulls CUPTI's pending data into g_profileBatch before shutdown
-    // tears the buffers down. SassMetricsEngine::stop() now performs
-    // that drain — calling it here so the per-scope and per-session
-    // paths both flush.
+    // Tear SASS down BEFORE PC sampling. cuptiPCSamplingDisable is unsafe
+    // while another CUPTI API (the Profiler API, which SASS uses) is still
+    // initialized — it can hang. When only one sub-engine is active the
+    // other call is a no-op, so this order is safe in every case, and it's
+    // required for the GPUFL_DEEP_TRY_BOTH path where both are armed.
+    //
+    // SassMetricsEngine::stop() also performs a final drain — important for
+    // workloads that don't wrap kernels in a gpufl.Scope (e.g. a PyTorch
+    // training loop), which would otherwise lose all pending SASS data
+    // because nothing pulls CUPTI's buffer into g_profileBatch before
+    // shutdown tears it down.
     if (sass_ok_) sass_->stop();
+    if (pc_) pc_->stop();
 }
 
 void PcSamplingWithSassEngine::shutdown() {
-    if (pc_) pc_->shutdown();
-    // Belt-and-suspenders: SassMetricsEngine::shutdown() also drains
-    // before disabling CUPTI, so a teardown path that skips stop()
-    // (or one where stop()'s drain was a no-op because the engine
-    // wasn't enabled yet) still gets a final flush.
+    // Same ordering as stop(): SASS (Profiler API) down before PC sampling.
+    // SassMetricsEngine::shutdown() also drains before disabling CUPTI, so a
+    // teardown path that skipped stop() (or where stop()'s drain was a no-op)
+    // still gets a final flush.
     if (sass_ok_) sass_->shutdown();
+    if (pc_) pc_->shutdown();
 }
 
 void PcSamplingWithSassEngine::onScopeStart(const char* name) {
@@ -85,6 +165,25 @@ void PcSamplingWithSassEngine::onScopeStart(const char* name) {
 void PcSamplingWithSassEngine::onScopeStop(const char* name) {
     if (pc_ && !skip_pc_scope_) pc_->onScopeStop(name);
     if (sass_ok_) sass_->onScopeStop(name);
+}
+
+void PcSamplingWithSassEngine::drainData() {
+    // CRITICAL: forward the collector thread's periodic (250 ms),
+    // non-blocking drain to the PC sampling sub-engine. PC sampling runs
+    // in CONTINUOUS mode — CUPTI fills a sampling buffer as kernels execute
+    // and we MUST call cuptiPCSamplingGetData regularly to empty it. The
+    // base IProfilingEngine::drainData() is a no-op, so before this
+    // override Deep mode never drained mid-run: on a long scope (e.g. a
+    // whole training epoch wrapped in one gpufl.Scope) the buffer filled,
+    // the driver back-pressured sample collection, and a CUPTI helper
+    // thread blocked on a driver rwlock — freezing the whole process.
+    // (Plain PcSampling mode was unaffected because PcSamplingEngine
+    // exposes the real drainData() directly.)
+    //
+    // pc_ is null when SASS won the session (the two are mutually
+    // exclusive on current drivers — see start()); on that path SASS
+    // flushes at scope stop, so this is correctly a no-op.
+    if (pc_) pc_->drainData();
 }
 
 }  // namespace gpufl

--- a/include/gpufl/backends/nvidia/engine/pc_sampling_with_sass_engine.hpp
+++ b/include/gpufl/backends/nvidia/engine/pc_sampling_with_sass_engine.hpp
@@ -57,6 +57,7 @@ class PcSamplingWithSassEngine final : public IProfilingEngine {
      *  driver back-pressured sample collection, and a CUPTI helper thread
      *  deadlocked on a driver lock. No-op when SASS won the session. */
     void drainData() override;
+    void flushBeforeCudaTeardown(const char* reason) override;
 
     /** Insufficient if EITHER sub-engine was blocked — the composite
      *  requires both to be fully operational. */
@@ -72,6 +73,9 @@ class PcSamplingWithSassEngine final : public IProfilingEngine {
     bool isOperational() const override {
         return (pc_ && pc_->isOperational()) || sass_ok_;
     }
+
+    bool sassActive() const { return sass_ok_; }
+    bool pcSamplingActive() const { return pc_ && pc_->isOperational(); }
 
    private:
     std::unique_ptr<PcSamplingEngine>  pc_;

--- a/include/gpufl/backends/nvidia/engine/pc_sampling_with_sass_engine.hpp
+++ b/include/gpufl/backends/nvidia/engine/pc_sampling_with_sass_engine.hpp
@@ -77,6 +77,11 @@ class PcSamplingWithSassEngine final : public IProfilingEngine {
     bool sassActive() const { return sass_ok_; }
     bool pcSamplingActive() const { return pc_ && pc_->isOperational(); }
 
+    /** True once the corresponding sub-engine actually emitted rows (not merely
+     *  armed) — drives the "enabled but 0 data" capability state. */
+    bool sassProducedData() const { return sass_ && sass_->producedData(); }
+    bool pcProducedData() const { return pc_ && pc_->producedData(); }
+
    private:
     std::unique_ptr<PcSamplingEngine>  pc_;
     std::unique_ptr<SassMetricsEngine> sass_;

--- a/include/gpufl/backends/nvidia/engine/pc_sampling_with_sass_engine.hpp
+++ b/include/gpufl/backends/nvidia/engine/pc_sampling_with_sass_engine.hpp
@@ -9,22 +9,30 @@
 namespace gpufl {
 
 /**
- * @brief Composite engine that runs PcSampling and SassMetrics simultaneously.
+ * @brief Deep-mode engine: the deepest analysis the GPU supports.
  *
- * PcSampling uses hardware stall-reason counters; SassMetrics uses software
- * lazy SASS patching (cuptiSassMetricsEnable with enableLazyPatching=1) and
- * does not lock hardware perf counters.  The two subsystems are independent
- * and can coexist on the same CUDA context.
+ * "Deep" combines two complementary CUPTI capabilities — PC sampling
+ * (hardware stall-reason sampling: where/why warps stall) and SASS metrics
+ * (per-instruction execution counts + coalescing efficiency). Current NVIDIA
+ * drivers make the two MUTUALLY EXCLUSIVE (the Profiler API blocks the PC
+ * Sampling API and vice versa), so Deep collects ONE per session, not both.
  *
- * Scope lifecycle:
- *   start  → pc start, then sass start
- *   onScopeStart → pc only (sass has no scope-start work)
- *   onScopeStop  → pc first (includes cudaDeviceSynchronize), then sass
- *                  (GPU is idle so sass flush is safe)
- *   shutdown → pc shutdown, then sass shutdown (if sass started ok)
+ * Deep attempts SASS metrics by default and falls back to PC sampling if SASS
+ * can't arm (see ShouldAttemptSassInDeep in the .cpp). The lazy-patching
+ * deadlock is guarded by the per-architecture SASS exclusion gate, not by
+ * forcing eager module loading:
+ *   - Default: attempt SASS; fall back to PC sampling if SASS fails to arm.
+ *   - Architecture in GPUFL_SASS_EXCLUDE_ARCHS (e.g. RTX 3090 / sm_86):
+ *     SassMetricsEngine::start() declines, so Deep runs PC sampling only.
+ *   - GPUFL_EAGER_MODULE_LOADING=1: opt-in EAGER loading as an alternative
+ *     deadlock workaround (no longer required / forced).
+ *   - GPUFL_DEEP_PC_ONLY=1: force PC-sampling-only regardless (escape hatch).
  *
- * If SASS fails to initialise (e.g. unsupported GPU, profiler conflict), the
- * engine silently falls back to PC-sampling-only.
+ * This is what distinguishes Deep from ProfilingEngine::PcSampling (always
+ * pure PC sampling) and ProfilingEngine::SassMetrics (always SASS — caller
+ * accepts the risk). When SASS isn't attempted, `sass_` is never constructed
+ * and every `sass_` path is guarded by `sass_ok_` (false), so the engine
+ * behaves as a thin wrapper over PcSamplingEngine.
  */
 class PcSamplingWithSassEngine final : public IProfilingEngine {
    public:
@@ -42,6 +50,14 @@ class PcSamplingWithSassEngine final : public IProfilingEngine {
     void onScopeStart(const char* name) override;
     void onScopeStop(const char* name)  override;
 
+    /** Forward the collector thread's periodic, non-blocking drain to the
+     *  active PC sampling sub-engine. Without this override Deep mode
+     *  inherited the base-class no-op drainData(), so PC sampling's
+     *  CONTINUOUS-mode buffer was never emptied mid-run — it filled, the
+     *  driver back-pressured sample collection, and a CUPTI helper thread
+     *  deadlocked on a driver lock. No-op when SASS won the session. */
+    void drainData() override;
+
     /** Insufficient if EITHER sub-engine was blocked — the composite
      *  requires both to be fully operational. */
     bool hasInsufficientPrivileges() const override {
@@ -49,16 +65,19 @@ class PcSamplingWithSassEngine final : public IProfilingEngine {
             || (sass_ && sass_->hasInsufficientPrivileges());
     }
 
-    /** Operational if at least the PC sampling sub-engine started
-     *  (SASS falling back is non-fatal; PC samples alone are useful). */
+    /** Operational if EITHER path armed: PC sampling running, or SASS
+     *  enabled. On Blackwell, start() resets pc_ once SASS wins, so we must
+     *  also accept sass_ok_ — otherwise an active SASS session would
+     *  wrongly report not-operational. */
     bool isOperational() const override {
-        return pc_ && pc_->isOperational();
+        return (pc_ && pc_->isOperational()) || sass_ok_;
     }
 
    private:
     std::unique_ptr<PcSamplingEngine>  pc_;
     std::unique_ptr<SassMetricsEngine> sass_;
-    bool sass_ok_ = false;       // true only if SASS engine started successfully
+    bool sass_ok_ = false;        // true only if SASS engine started successfully
+    bool sass_gate_open_ = false; // GPU is one where Deep may attempt SASS (Blackwell+)
     bool skip_pc_scope_ = false;  // SamplingAPI + SASS conflict → skip PC scope work
 };
 

--- a/include/gpufl/backends/nvidia/engine/profiling_engine.hpp
+++ b/include/gpufl/backends/nvidia/engine/profiling_engine.hpp
@@ -104,6 +104,15 @@ class IProfilingEngine {
      * data. False if start() was skipped, failed, or the engine is None.
      */
     virtual bool isOperational() const { return true; }
+
+    /**
+     * @brief True if this engine actually emitted at least one profiling
+     * record/sample this session — not merely armed. Lets the capability
+     * report distinguish "collected" from "enabled but produced 0 data"
+     * (e.g. SASS / PC sampling armed but the kernels were too short, or CUPTI
+     * returned nothing). Default false; engines that emit data override it.
+     */
+    virtual bool producedData() const { return false; }
 };
 
 }  // namespace gpufl

--- a/include/gpufl/backends/nvidia/engine/profiling_engine.hpp
+++ b/include/gpufl/backends/nvidia/engine/profiling_engine.hpp
@@ -64,6 +64,12 @@ class IProfilingEngine {
      *  Called from the collector thread every ~250ms. */
     virtual void drainData() {}
 
+    /**
+     * @brief Last-chance drain before CUDA cleanup APIs such as cudaFree or
+     * cudaDeviceReset can invalidate state needed by a profiling engine.
+     */
+    virtual void flushBeforeCudaTeardown(const char* /*reason*/) {}
+
     // ---- Perf-scope hooks (Range Profiler / Perfworks) ----
     virtual void onPerfScopeStart(const char* /*name*/) {}
     virtual void onPerfScopeStop(const char* /*name*/) {}

--- a/include/gpufl/backends/nvidia/engine/sass_metrics_engine.cpp
+++ b/include/gpufl/backends/nvidia/engine/sass_metrics_engine.cpp
@@ -157,14 +157,9 @@ bool EnvFlagEnabled(const char* name) {
 }
 
 bool ShouldUseLazyPatching() {
-    // Lazy SASS patching instruments each cubin on its first kernel launch.
-    // That is cheap for small standalone CUDA programs, but framework stacks
-    // such as PyTorch often issue many first launches from multiple runtime
-    // paths while CUDA/CUPTI helper threads are also active.  The observed
-    // deadlock has the app thread in cuLaunchKernel -> libcupti and a CUPTI
-    // helper blocked on a libcuda rwlock.  Patch modules at load/profile time
-    // by default so SASS remains enabled without entering the launch-time
-    // patching path.  Keep an env override for experiments and tiny samples.
+    // Isolation test: keep main-like SASS start timing and kernel activity, but
+    // switch lazy patching off by default to test whether eager patching causes
+    // the all-zero SASS counter behavior.
     return EnvFlagEnabled("GPUFL_SASS_LAZY_PATCHING");
 }
 }  // namespace
@@ -277,8 +272,11 @@ void SassMetricsEngine::DeInitProfilerIfNeeded_() {
 }
 
 void SassMetricsEngine::stop() {
-    // Scope-bounded mode drains at onScopeStop(). If the application exits while
-    // a scope is still armed, shutdown() performs the final drain/disable.
+    // Scope-bounded isolation test: scope stop drains and disables SASS. If a
+    // scope is still armed at session stop, drain it here before shutdown.
+    if (enabled_) {
+        StopAndCollectSassMetrics_();
+    }
 }
 
 void SassMetricsEngine::shutdown() {
@@ -574,11 +572,15 @@ void SassMetricsEngine::StopAndCollectSassMetrics_() {
         return;
     }
     if (props.numOfPatchedInstructionRecords == 0) {
+        if (produced_data_.load(std::memory_order_relaxed)) {
+            GFL_LOG_DEBUG(
+                "[SassMetricsEngine] no pending SASS instruction records to "
+                "flush; data was already collected earlier in the session.");
+            return;
+        }
         // SASS enabled successfully but CUPTI instrumented ZERO instructions
-        // this session — no patched records to flush. Seen on consumer
-        // Blackwell (sm_120) laptops under Windows WDDM with CUPTI 13.x, and
-        // when GPU performance-counter access is restricted. This is the
-        // "sass_metrics: on, no data" capability state; not a code error.
+        // before any data was collected. This is the "sass_metrics: on, no
+        // data" capability state; not a code error.
         GFL_LOG_ERROR(
             "[SassMetricsEngine] SASS armed but CUPTI reports 0 patched "
             "instruction records — no kernel was SASS-instrumented this "

--- a/include/gpufl/backends/nvidia/engine/sass_metrics_engine.cpp
+++ b/include/gpufl/backends/nvidia/engine/sass_metrics_engine.cpp
@@ -150,6 +150,23 @@ bool ArchExcludedForSass(const ComputeCapability& cc) {
     }
     return false;
 }
+
+bool EnvFlagEnabled(const char* name) {
+    const char* v = std::getenv(name);
+    return v && v[0] != '\0' && v[0] != '0';
+}
+
+bool ShouldUseLazyPatching() {
+    // Lazy SASS patching instruments each cubin on its first kernel launch.
+    // That is cheap for small standalone CUDA programs, but framework stacks
+    // such as PyTorch often issue many first launches from multiple runtime
+    // paths while CUDA/CUPTI helper threads are also active.  The observed
+    // deadlock has the app thread in cuLaunchKernel -> libcupti and a CUPTI
+    // helper blocked on a libcuda rwlock.  Patch modules at load/profile time
+    // by default so SASS remains enabled without entering the launch-time
+    // patching path.  Keep an env override for experiments and tiny samples.
+    return EnvFlagEnabled("GPUFL_SASS_LAZY_PATCHING");
+}
 }  // namespace
 
 bool SassMetricsEngine::initialize(const MonitorOptions& opts,
@@ -257,21 +274,11 @@ void SassMetricsEngine::DeInitProfilerIfNeeded_() {
 }
 
 void SassMetricsEngine::stop() {
-    // Drain any SASS samples still pending in CUPTI's internal buffer
-    // BEFORE the engine is torn down. Without this, sessions that end
-    // without a final scope-stop (e.g. PyTorch training pipelines that
-    // run iterations outside a `with gpufl.Scope(...)` block, or where
-    // the last scope's onScopeStop hasn't fired before shutdown) lose
-    // every SASS sample — silently — because shutdown() below calls
-    // cuptiSassMetricsDisable + frees buffers without flushing.
-    //
-    // The drain itself is the same path onScopeStop uses
-    // (StopAndCollectSassMetrics_), which is safe to call multiple
-    // times: each call only collects what's currently in CUPTI's
-    // queue. Belt-and-suspenders.
-    if (enabled_) {
-        StopAndCollectSassMetrics_();
-    }
+    // Do not drain SASS data at ordinary scope/session stop.  On CUDA 13.1
+    // + PyTorch + sm_86, calling cuptiSassMetricsFlushData while the process
+    // continues launching kernels leaves CUPTI's launch-path mutex wedged; the
+    // next cudaLaunchKernel blocks in libcupti.  Keep SASS armed and defer the
+    // one required drain until shutdown(), immediately before disable/teardown.
 }
 
 void SassMetricsEngine::shutdown() {
@@ -318,8 +325,8 @@ void SassMetricsEngine::shutdown() {
 }
 
 void SassMetricsEngine::onScopeStop(const char* /*name*/) {
-    if (!enabled_) return;
-    StopAndCollectSassMetrics_();
+    // See stop(): mid-run SASS flush can deadlock the following PyTorch kernel
+    // launch.  SASS remains enabled; samples are drained once during shutdown.
 }
 
 // ---- Private helpers -------------------------------------------------------
@@ -451,19 +458,14 @@ void SassMetricsEngine::EnableSassMetrics_() {
         CUpti_SassMetricsEnable_Params enableParams = {
             CUpti_SassMetricsEnable_Params_STRUCT_SIZE};
         enableParams.ctx = ctx_.cuda_ctx;
-        // Always use lazy patching (=1): cubins are patched on their first
-        // cuLaunchKernel call rather than at module-load time, avoiding upfront
-        // cost on unexecuted kernels.
-        //
-        // The original concern was that lazy patching intercepts cuLaunchKernel
-        // at the same level as KERNEL_SERIALIZED PC Sampling (SamplingAPI),
-        // which could deadlock in PcSamplingWithSass mode.  In practice this
-        // conflict is impossible: SamplingAPI requires cuptiPCSamplingEnable(),
-        // but SASS requires cuptiProfilerInitialize() first, and that call
-        // blocks the PC Sampling API.  Whenever SASS enables successfully,
-        // SamplingAPI PC sampling is already disabled, so the deadlock
-        // condition can never be reached.
-        enableParams.enableLazyPatching = 1;
+        // Default to non-lazy patching.  Lazy patching hooks the first
+        // cuLaunchKernel for each cubin, which is exactly where PyTorch
+        // deadlocks on CUDA 13/CUPTI 13 in the captured gdb dump.  Non-lazy
+        // patching keeps SASS metrics enabled but moves CUPTI's work out of
+        // the hot launch path.  Set GPUFL_SASS_LAZY_PATCHING=1 to restore the
+        // old behavior for experiments.
+        const bool lazyPatching = ShouldUseLazyPatching();
+        enableParams.enableLazyPatching = lazyPatching ? 1 : 0;
         CUptiResult enableRes = cuptiSassMetricsEnable(&enableParams);
         if (LogCuptiErrorIfFailed(this->name(), "cuptiSassMetricsEnable",
                                   enableRes)) {
@@ -517,7 +519,8 @@ void SassMetricsEngine::EnableSassMetrics_() {
         DeInitProfilerIfNeeded_();
         return;
     }
-    GFL_LOG_DEBUG("[SassMetricsEngine] SASS Metrics Enabled");
+    GFL_LOG_DEBUG("[SassMetricsEngine] SASS Metrics Enabled (lazy_patching=",
+                  ShouldUseLazyPatching() ? "true" : "false", ")");
 
     // Emit sass_config event so the backend can distinguish "metric not
     // supported on this GPU" from "metric produced no data for this kernel".

--- a/include/gpufl/backends/nvidia/engine/sass_metrics_engine.cpp
+++ b/include/gpufl/backends/nvidia/engine/sass_metrics_engine.cpp
@@ -258,8 +258,11 @@ void SassMetricsEngine::start() {
         return;
     }
     profiler_initialized_ = true;
-
-    EnableSassMetrics_();
+    ConfigureSassMetrics_();
+    if (!config_set_) return;
+    GFL_LOG_DEBUG(
+        "[SassMetricsEngine] profiler initialized and SASS config is set; "
+        "metrics will arm on scope start and flush on scope stop.");
 }
 
 void SassMetricsEngine::DeInitProfilerIfNeeded_() {
@@ -274,15 +277,13 @@ void SassMetricsEngine::DeInitProfilerIfNeeded_() {
 }
 
 void SassMetricsEngine::stop() {
-    // Do not drain SASS data at ordinary scope/session stop.  On CUDA 13.1
-    // + PyTorch + sm_86, calling cuptiSassMetricsFlushData while the process
-    // continues launching kernels leaves CUPTI's launch-path mutex wedged; the
-    // next cudaLaunchKernel blocks in libcupti.  Keep SASS armed and defer the
-    // one required drain until shutdown(), immediately before disable/teardown.
+    // Scope-bounded mode drains at onScopeStop(). If the application exits while
+    // a scope is still armed, shutdown() performs the final drain/disable.
 }
 
 void SassMetricsEngine::shutdown() {
-    if (enabled_) {
+    if (enabled_ && ctx_.cuda_ctx) {
+        cudaDeviceSynchronize();
         // Final drain pass — Monitor::Shutdown() may call shutdown()
         // directly without going through stop() in some teardown paths,
         // so we belt-and-suspender here too. StopAndCollectSassMetrics_
@@ -324,21 +325,45 @@ void SassMetricsEngine::shutdown() {
     config_set_ = false;
 }
 
-void SassMetricsEngine::onScopeStop(const char* /*name*/) {
-    // See stop(): mid-run SASS flush can deadlock the following PyTorch kernel
-    // launch.  SASS remains enabled; samples are drained once during shutdown.
+void SassMetricsEngine::onScopeStart(const char* name) {
+    if (!profiler_initialized_ || !config_set_ || enabled_) return;
+    GFL_LOG_DEBUG("[SassMetricsEngine] arming SASS metrics for scope: ",
+                  name ? name : "<unnamed>");
+    ArmSassMetrics_();
+}
+
+void SassMetricsEngine::onScopeStop(const char* name) {
+    if (!enabled_ || !ctx_.cuda_ctx) return;
+
+    GFL_LOG_DEBUG("[SassMetricsEngine] flushing SASS metrics for scope: ",
+                  name ? name : "<unnamed>");
+    cudaDeviceSynchronize();
+    StopAndCollectSassMetrics_();
+
+    CUpti_SassMetricsDisable_Params disableParams = {
+        CUpti_SassMetricsDisable_Params_STRUCT_SIZE};
+    disableParams.ctx = ctx_.cuda_ctx;
+    CUptiResult disableRes = cuptiSassMetricsDisable(&disableParams);
+    if (!IsExpectedTeardownError(disableRes)) {
+        LogCuptiErrorIfFailed(this->name(), "cuptiSassMetricsDisable",
+                              disableRes);
+    }
+
+    enabled_ = false;
 }
 
 void SassMetricsEngine::flushBeforeCudaTeardown(const char* reason) {
     if (!enabled_) return;
-    GFL_LOG_DEBUG("[SassMetricsEngine] flushing SASS metrics before CUDA cleanup: ",
-                  reason ? reason : "unknown");
-    StopAndCollectSassMetrics_();
+    GFL_LOG_DEBUG(
+        "[SassMetricsEngine] skipping SASS flush from CUDA cleanup callback: ",
+        reason ? reason : "unknown",
+        "; SASS metrics flush must run from gpufl shutdown before CUDA "
+        "teardown, after cudaDeviceSynchronize().");
 }
 
 // ---- Private helpers -------------------------------------------------------
 
-void SassMetricsEngine::EnableSassMetrics_() {
+void SassMetricsEngine::ConfigureSassMetrics_() {
     if (ctx_.chip_name.empty()) {
         if (LogCuptiErrorIfFailed(
                 this->name(), "cuptiGetDeviceId",
@@ -362,6 +387,7 @@ void SassMetricsEngine::EnableSassMetrics_() {
     // defaults to empty, so nothing is excluded unless explicitly set.)
 
     metric_id_to_name_.clear();
+    skipped_metrics_.clear();
     if (!sass_metrics_buffers_) {
         sass_metrics_buffers_ = new SassMetricsBuffers();
         sass_metrics_buffers_->numMetrics = kSassMetricNames.size();
@@ -464,43 +490,8 @@ void SassMetricsEngine::EnableSassMetrics_() {
     CUptiResult res = cuptiSassMetricsSetConfig(&setConfigParams);
     if (res == CUPTI_SUCCESS || res == CUPTI_ERROR_INVALID_OPERATION) {
         if (res == CUPTI_SUCCESS) config_set_ = true;
-
-        CUpti_SassMetricsEnable_Params enableParams = {
-            CUpti_SassMetricsEnable_Params_STRUCT_SIZE};
-        enableParams.ctx = ctx_.cuda_ctx;
-        // Default to non-lazy patching.  Lazy patching hooks the first
-        // cuLaunchKernel for each cubin, which is exactly where PyTorch
-        // deadlocks on CUDA 13/CUPTI 13 in the captured gdb dump.  Non-lazy
-        // patching keeps SASS metrics enabled but moves CUPTI's work out of
-        // the hot launch path.  Set GPUFL_SASS_LAZY_PATCHING=1 to restore the
-        // old behavior for experiments.
-        const bool lazyPatching = ShouldUseLazyPatching();
-        enableParams.enableLazyPatching = lazyPatching ? 1 : 0;
-        CUptiResult enableRes = cuptiSassMetricsEnable(&enableParams);
-        if (LogCuptiErrorIfFailed(this->name(), "cuptiSassMetricsEnable",
-                                  enableRes)) {
-            if (config_set_) {
-                CUpti_SassMetricsUnsetConfig_Params unsetParams = {
-                    CUpti_SassMetricsUnsetConfig_Params_STRUCT_SIZE};
-                unsetParams.deviceIndex = ctx_.device_id;
-                CUptiResult unsetRes =
-                    cuptiSassMetricsUnsetConfig(&unsetParams);
-                if (!IsExpectedTeardownError(unsetRes)) {
-                    LogCuptiErrorIfFailed(
-                        this->name(), "cuptiSassMetricsUnsetConfig", unsetRes);
-                }
-                config_set_ = false;
-            }
-            if (IsInsufficientPrivilege(enableRes)) {
-                insufficient_privileges_ = true;
-                GFL_LOG_ERROR(
-                    "[SassMetricsEngine] Insufficient privileges for CUPTI "
-                    "SASS metrics. Skipping SASS instrumentation.");
-            }
-            DeInitProfilerIfNeeded_();
-            return;
-        }
-        enabled_ = true;
+        GFL_LOG_DEBUG("[SassMetricsEngine] SASS metric config set (",
+                      validConfigs, " metric(s)).");
     } else {
         LogCuptiErrorIfFailed(this->name(), "cuptiSassMetricsSetConfig", res);
         // OUT_OF_MEMORY here is the signature of a GPU/driver that can't
@@ -529,8 +520,6 @@ void SassMetricsEngine::EnableSassMetrics_() {
         DeInitProfilerIfNeeded_();
         return;
     }
-    GFL_LOG_DEBUG("[SassMetricsEngine] SASS Metrics Enabled (lazy_patching=",
-                  ShouldUseLazyPatching() ? "true" : "false", ")");
 
     // Emit sass_config event so the backend can distinguish "metric not
     // supported on this GPU" from "metric produced no data for this kernel".
@@ -544,6 +533,30 @@ void SassMetricsEngine::EnableSassMetrics_() {
         evt.skipped_metrics = skipped_metrics_;
         rt->logger->write(model::SassConfigModel(evt));
     }
+}
+
+void SassMetricsEngine::ArmSassMetrics_() {
+    if (!config_set_ || enabled_ || !ctx_.cuda_ctx) return;
+
+    CUpti_SassMetricsEnable_Params enableParams = {
+        CUpti_SassMetricsEnable_Params_STRUCT_SIZE};
+    enableParams.ctx = ctx_.cuda_ctx;
+    const bool lazyPatching = ShouldUseLazyPatching();
+    enableParams.enableLazyPatching = lazyPatching ? 1 : 0;
+    CUptiResult enableRes = cuptiSassMetricsEnable(&enableParams);
+    if (LogCuptiErrorIfFailed(this->name(), "cuptiSassMetricsEnable",
+                              enableRes)) {
+        if (IsInsufficientPrivilege(enableRes)) {
+            insufficient_privileges_ = true;
+            GFL_LOG_ERROR(
+                "[SassMetricsEngine] Insufficient privileges for CUPTI "
+                "SASS metrics. Skipping SASS instrumentation.");
+        }
+        return;
+    }
+    enabled_ = true;
+    GFL_LOG_DEBUG("[SassMetricsEngine] SASS Metrics Enabled (lazy_patching=",
+                  lazyPatching ? "true" : "false", ")");
 }
 
 void SassMetricsEngine::StopAndCollectSassMetrics_() {
@@ -614,6 +627,7 @@ void SassMetricsEngine::StopAndCollectSassMetrics_() {
         // g_profileBatch under g_scopeBatchMu eliminates the contention.
         std::vector<ProfileSampleInput> samples;
         samples.reserve(nRecords * nInstances);
+        bool anyNonZeroMetric = false;
         const int64_t now_ns = detail::GetTimestampNs();
         for (size_t i = 0; i < nRecords; ++i) {
             char srcFile[256]{};
@@ -681,13 +695,24 @@ void SassMetricsEngine::StopAndCollectSassMetrics_() {
                                     ? itName->second
                                     : "metric_" + std::to_string(metricId);
                 s.metric_value = value;
+                if (value != 0) anyNonZeroMetric = true;
                 s.source_file = sourceFile;
                 s.source_line = hasSource ? srcLine : 0;
                 samples.push_back(std::move(s));
             }
+            if (data[i].functionName) {
+                std::free(const_cast<char*>(data[i].functionName));
+                data[i].functionName = nullptr;
+            }
         }
-        if (!samples.empty())
+        if (anyNonZeroMetric) {
             produced_data_.store(true, std::memory_order_relaxed);
+        } else if (!samples.empty()) {
+            GFL_LOG_ERROR(
+                "[SassMetricsEngine] SASS metrics produced ", samples.size(),
+                " profile row(s), but every metric value was 0. Treating this "
+                "as enabled-but-no-data for capabilities/reporting.");
+        }
         Monitor::PushProfileSamples(samples);
     } else {
         LogCuptiErrorIfFailed(this->name(), "cuptiSassMetricsFlushData",

--- a/include/gpufl/backends/nvidia/engine/sass_metrics_engine.cpp
+++ b/include/gpufl/backends/nvidia/engine/sass_metrics_engine.cpp
@@ -702,8 +702,15 @@ void SassMetricsEngine::StopAndCollectSassMetrics_() {
                 s.source_line = hasSource ? srcLine : 0;
                 samples.push_back(std::move(s));
             }
+            // functionName is a CUPTI-filled (Release-CRT) string, same as the
+            // source-correlation fileName/dirName above. Free it via the same
+            // guarded helper so a _DEBUG build doesn't trip
+            // _CrtIsValidHeapPointer when the debug-CRT app frees a pointer
+            // from CUPTI's heap (the assertion seen running this demo from
+            // cmake-build-debug on Windows). On Release it still frees.
             if (data[i].functionName) {
-                std::free(const_cast<char*>(data[i].functionName));
+                FreeCuptiCorrelationString(
+                    const_cast<char*>(data[i].functionName));
                 data[i].functionName = nullptr;
             }
         }

--- a/include/gpufl/backends/nvidia/engine/sass_metrics_engine.cpp
+++ b/include/gpufl/backends/nvidia/engine/sass_metrics_engine.cpp
@@ -5,7 +5,9 @@
 #include <cupti_profiler_target.h>
 #include <cupti_sass_metrics.h>
 
+#include <cctype>
 #include <cstdio>
+#include <cstdlib>
 #include <cstring>
 #include <vector>
 
@@ -70,6 +72,84 @@ void FreeCuptiCorrelationString(char* s) {
     std::free(s);
 #endif
 }
+
+// ── Device-architecture exclusion for SASS ───────────────────────────────
+// SASS metrics intermittently hang or fail on specific GPU architectures
+// (notably RTX 3090 / Ampere sm_86: cuptiSassMetricsSetConfig OUT_OF_MEMORY,
+// plus lazy-patch launch hangs that EAGER module loading does not always
+// cure). GPUFL_SASS_EXCLUDE_ARCHS turns SASS off for confirmed-bad
+// architectures WITHOUT a rebuild, so we can compare e.g. sm_86 vs sm_120
+// empirically and then exclude only what is actually broken.
+//
+// Syntax: comma-separated compute capabilities. Each entry is one of:
+//   "86"  / "8.6"  → exact match (major 8, minor 6)
+//   "120" / "12.0" → exact match (major 12, minor 0)
+//   "8"   / "8.x"  → whole generation (any sm_8x)
+// Default (env unset): use kDefaultSassExcludeArchs (empty = attempt on every
+// architecture). Setting the env var — even to "" — overrides the compiled
+// default, so an end user can clear a baked-in exclusion at runtime.
+constexpr const char* kDefaultSassExcludeArchs = "";
+
+// True if the trimmed token [begin, end) names the given compute capability.
+bool CcMatchesToken(const ComputeCapability& cc, const char* begin,
+                    const char* end) {
+    while (begin < end && std::isspace(static_cast<unsigned char>(*begin)))
+        ++begin;
+    while (end > begin && std::isspace(static_cast<unsigned char>(end[-1])))
+        --end;
+    if (begin >= end) return false;
+
+    const std::string tok(begin, end);
+    int wantMajor = -1;
+    int wantMinor = -1;
+    bool wholeGen = false;
+
+    const auto dot = tok.find('.');
+    if (dot != std::string::npos) {
+        wantMajor = std::atoi(tok.substr(0, dot).c_str());
+        const std::string m = tok.substr(dot + 1);
+        if (m.empty() || m == "x" || m == "X") {
+            wholeGen = true;
+        } else {
+            wantMinor = std::atoi(m.c_str());
+        }
+    } else {
+        // All-digit form. A single digit means the whole generation;
+        // otherwise the last digit is the minor and the rest is the major
+        // (so "86" → 8.6, "120" → 12.0).
+        for (const char c : tok)
+            if (c < '0' || c > '9') return false;
+        if (tok.size() == 1) {
+            wantMajor = tok[0] - '0';
+            wholeGen = true;
+        } else {
+            wantMinor = tok.back() - '0';
+            wantMajor = std::atoi(tok.substr(0, tok.size() - 1).c_str());
+        }
+    }
+
+    if (wantMajor < 0 || cc.major != wantMajor) return false;
+    return wholeGen || cc.minor == wantMinor;
+}
+
+// True if SASS is excluded on this GPU's architecture via the configured
+// exclusion list. Never excludes on an unknown architecture (don't
+// over-exclude when the capability query failed).
+bool ArchExcludedForSass(const ComputeCapability& cc) {
+    if (!cc.valid()) return false;
+    const char* env = std::getenv("GPUFL_SASS_EXCLUDE_ARCHS");
+    const char* list = env ? env : kDefaultSassExcludeArchs;
+    if (!list || !*list) return false;
+
+    for (const char* p = list; *p;) {
+        const char* comma = std::strchr(p, ',');
+        const char* end = comma ? comma : (p + std::strlen(p));
+        if (CcMatchesToken(cc, p, end)) return true;
+        if (!comma) break;
+        p = comma + 1;
+    }
+    return false;
+}
 }  // namespace
 
 bool SassMetricsEngine::initialize(const MonitorOptions& opts,
@@ -88,6 +168,41 @@ void SassMetricsEngine::start() {
         return;
     }
 
+    // Resolve the device id + chip name up front. cuptiGetDeviceId is a
+    // standalone query (it does NOT require the Profiler API), so it's safe
+    // to call before cuptiProfilerInitialize — and it lets the architecture
+    // gate below run BEFORE we touch any Profiler/SASS state on an excluded
+    // GPU. EnableSassMetrics_ repeats this guarded by chip_name.empty(), so
+    // it becomes a no-op there.
+    if (ctx_.chip_name.empty()) {
+        if (LogCuptiErrorIfFailed(
+                this->name(), "cuptiGetDeviceId",
+                cuptiGetDeviceId(ctx_.cuda_ctx, &ctx_.device_id))) {
+            return;
+        }
+        ctx_.chip_name = getChipName(ctx_.device_id);
+    }
+
+    // ── Device-architecture exclusion gate ───────────────────────────────
+    // Turn SASS off for architectures confirmed to hang/fail — e.g. run with
+    // GPUFL_SASS_EXCLUDE_ARCHS=86 for RTX 3090 / Ampere sm_86. This runs
+    // before cuptiProfilerInitialize, so an excluded GPU never enters the
+    // Profiler API / lazy-patching path at all. enabled_ stays false →
+    // standalone SassMetrics produces no data (use PcSampling instead) and
+    // Deep mode degrades to PC sampling (sass_->isEnabled() == false).
+    const ComputeCapability cc =
+        GetComputeCapability(static_cast<int>(ctx_.device_id));
+    if (ArchExcludedForSass(cc)) {
+        GFL_LOG_ERROR(
+            "[SassMetricsEngine] SASS metrics DISABLED on sm_", cc.major,
+            cc.minor,
+            " via GPUFL_SASS_EXCLUDE_ARCHS (this architecture is configured as "
+            "unsupported for SASS). Standalone SassMetrics produces no data — "
+            "use ProfilingEngine.PcSampling instead; Deep mode degrades to PC "
+            "sampling. Monitor / Trace / PcSampling are unaffected.");
+        return;
+    }
+
     // Initialize profiler device — required before SASS Metrics APIs.
     // Mark profiler_initialized_ on success so EnableSassMetrics_'s
     // failure paths can undo this via cuptiProfilerDeInitialize.
@@ -103,7 +218,25 @@ void SassMetricsEngine::start() {
             insufficient_privileges_ = true;
             GFL_LOG_ERROR(
                 "[SassMetricsEngine] Insufficient privileges for CUPTI "
-                "SASS metrics. Skipping SASS instrumentation.");
+                "SASS metrics. Enable GPU performance counter access or "
+                "run with elevated privileges. Skipping SASS; the session "
+                "continues with kernel-trace data only.");
+        } else {
+            // The Profiler API wants to initialize against a context that
+            // hasn't already loaded modules / run kernels. The #1 cause
+            // of this failure in framework apps (PyTorch, etc.) is calling
+            // gpufl.init() AFTER GPU work has started. Name that explicitly
+            // so users get an actionable fix instead of a raw CUPTI code.
+            GFL_LOG_ERROR(
+                "[SassMetricsEngine] cuptiProfilerInitialize failed (CUptiResult ",
+                static_cast<int>(initRes),
+                "). SASS / Deep mode cannot start. Two common causes: "
+                "(1) gpufl.init() was called AFTER CUDA work already "
+                "began — the CUPTI Profiler API must initialize against a "
+                "clean context, so call gpufl.init() BEFORE the first CUDA "
+                "kernel (right after `import torch`); (2) this GPU + driver "
+                "does not support CUPTI SASS metrics. Skipping SASS; "
+                "Monitor / Trace / PcSampling are unaffected.");
         }
         return;
     }
@@ -209,7 +342,10 @@ void SassMetricsEngine::EnableSassMetrics_() {
     // cuptiSassMetricsSetConfig OOM, the partial-failure bailout for
     // Blackwell below — all call DeInitProfilerIfNeeded_ and return
     // with isEnabled() == false, which the composite engine handles
-    // cleanly. No reason to blocklist Ampere preemptively.)
+    // cleanly. No reason to blocklist Ampere preemptively. An opt-in,
+    // per-architecture gate now lives at the top of start()
+    // (GPUFL_SASS_EXCLUDE_ARCHS) for architectures CONFIRMED broken; it
+    // defaults to empty, so nothing is excluded unless explicitly set.)
 
     metric_id_to_name_.clear();
     if (!sass_metrics_buffers_) {
@@ -355,7 +491,29 @@ void SassMetricsEngine::EnableSassMetrics_() {
         enabled_ = true;
     } else {
         LogCuptiErrorIfFailed(this->name(), "cuptiSassMetricsSetConfig", res);
-        GFL_LOG_ERROR("[SassMetricsEngine] Failed to enable SASS Metrics");
+        // OUT_OF_MEMORY here is the signature of a GPU/driver that can't
+        // allocate the SASS metric configuration — observed on Ampere
+        // (RTX 3090, sm_86). It is a hardware/driver limitation, NOT a
+        // late-init problem (cuptiProfilerInitialize already succeeded by
+        // this point). SASS metrics simply aren't available on this
+        // setup; Deep degrades to PC sampling and the other engines are
+        // unaffected. Spell that out so the raw CUPTI code isn't the only
+        // signal the user gets.
+        if (res == CUPTI_ERROR_OUT_OF_MEMORY) {
+            GFL_LOG_ERROR(
+                "[SassMetricsEngine] cuptiSassMetricsSetConfig returned "
+                "OUT_OF_MEMORY — this GPU/driver can't allocate SASS metric "
+                "counters (seen on Ampere / sm_86). SASS metrics are "
+                "unavailable on this setup; this is a hardware/driver limit, "
+                "not a configuration error. Deep mode runs as PC Sampling "
+                "here; use ProfilingEngine.PcSampling directly to skip this "
+                "message. Monitor / Trace / PcSampling are unaffected.");
+        } else {
+            GFL_LOG_ERROR(
+                "[SassMetricsEngine] Failed to enable SASS Metrics "
+                "(cuptiSassMetricsSetConfig). Deep degrades to PC sampling; "
+                "Monitor / Trace / PcSampling are unaffected.");
+        }
         DeInitProfilerIfNeeded_();
         return;
     }

--- a/include/gpufl/backends/nvidia/engine/sass_metrics_engine.cpp
+++ b/include/gpufl/backends/nvidia/engine/sass_metrics_engine.cpp
@@ -329,6 +329,13 @@ void SassMetricsEngine::onScopeStop(const char* /*name*/) {
     // launch.  SASS remains enabled; samples are drained once during shutdown.
 }
 
+void SassMetricsEngine::flushBeforeCudaTeardown(const char* reason) {
+    if (!enabled_) return;
+    GFL_LOG_DEBUG("[SassMetricsEngine] flushing SASS metrics before CUDA cleanup: ",
+                  reason ? reason : "unknown");
+    StopAndCollectSassMetrics_();
+}
+
 // ---- Private helpers -------------------------------------------------------
 
 void SassMetricsEngine::EnableSassMetrics_() {

--- a/include/gpufl/backends/nvidia/engine/sass_metrics_engine.cpp
+++ b/include/gpufl/backends/nvidia/engine/sass_metrics_engine.cpp
@@ -389,11 +389,22 @@ void SassMetricsEngine::EnableSassMetrics_() {
             "unavailable.");
     }
 
+    // The op-level ideal-sector fallbacks (smsp__sass_sectors_mem_global_op_*_ideal)
+    // are ALSO invalid on sm_120+ (Blackwell): cuptiSassMetricsGetProperties returns
+    // CUPTI_ERROR_INVALID_PARAMETER there because they're superseded by the aggregate
+    // smsp__sass_sectors_mem_global_ideal. Querying them on sm_120 produced 2 failed
+    // queries that tripped the conservative sm_120 bail below and discarded ALL of
+    // SASS — so Deep collected zero SASS metrics on Blackwell. Skip them on every
+    // identified architecture: expensive on pre-sm_120, invalid on sm_120+. They're
+    // only ever attempted on an UNKNOWN arch (cc invalid) as a last resort.
+    const bool skipOpLevelIdeal = cc.valid();
+
     size_t validConfigs = 0;
     size_t failedQueries = 0;
     for (size_t i = 0; i < kSassMetricNames.size(); ++i) {
-        // Proactive skip for known-expensive metrics on older GPUs.
-        if (skipExpensive && IsExpensiveOnPreSm120(kSassMetricNames[i])) {
+        // Skip the op-level ideal-sector fallbacks: expensive (~120x replay) on
+        // pre-sm_120, invalid (INVALID_PARAMETER) on sm_120+. See skipOpLevelIdeal.
+        if (skipOpLevelIdeal && IsExpensiveOnPreSm120(kSassMetricNames[i])) {
             skipped_metrics_.push_back(kSassMetricNames[i]);
             continue;
         }
@@ -429,28 +440,20 @@ void SassMetricsEngine::EnableSassMetrics_() {
         return;
     }
 
-    // Conservative bail on sm_120+ (Blackwell): any metric-query failure
-    // here historically indicated a deeper compatibility issue with the
-    // SASS API on this hardware path (Blackwell laptop + Windows WDDM),
-    // not just an isolated unsupported metric. Proceeding to
-    // cuptiSassMetricsSetConfig + cuptiSassMetricsEnable in that
-    // partially-failed state hung the next cuLaunchKernel in lazy-
-    // patching interception, because CUPTI's profiler state was
-    // already corrupted by the partial init. Bail cleanly instead so
-    // Deep mode degrades to PC Sampling only — same UX as the all-
-    // failed case above, just triggered by one-or-more failures
-    // instead of strictly all.
-    if (failedQueries > 0 && cc.valid() && cc.atLeast(12, 0)) {
-        GFL_LOG_ERROR(
+    // Partial metric availability is NOT fatal — collect whatever armed.
+    // (Historically sm_120 bailed entirely on ANY failed metric query, to dodge
+    // a CUPTI hang seen on Blackwell laptop + Windows WDDM. That hang was a
+    // property of LAZY patching — no longer the default (see enableLazyPatching
+    // below) — and the only metrics that failed on sm_120 were the op-level
+    // ideal-sector fallbacks, now skipped above. A non-zero failedQueries here
+    // therefore just means a few optional metrics were unavailable; proceed with
+    // the validConfigs we have. The "nothing usable" case already returned at
+    // validConfigs == 0 above.)
+    if (failedQueries > 0) {
+        GFL_LOG_DEBUG(
             "[SassMetricsEngine] ", failedQueries,
-            " of ", kSassMetricNames.size(),
-            " SASS metric queries failed on sm_", cc.major, cc.minor,
-            ". On this hardware family a partial-failure state has been "
-            "observed to hang subsequent kernel launches via CUPTI's "
-            "lazy-patching path. Skipping SASS entirely; Deep mode will "
-            "degrade to PC Sampling only this session.");
-        DeInitProfilerIfNeeded_();
-        return;
+            " optional SASS metric(s) unavailable on sm_", cc.major, cc.minor,
+            "; continuing with ", validConfigs, " metric(s).");
     }
 
     CUpti_SassMetricsSetConfig_Params setConfigParams = {
@@ -549,10 +552,31 @@ void SassMetricsEngine::StopAndCollectSassMetrics_() {
     CUpti_SassMetricsGetDataProperties_Params props = {
         CUpti_SassMetricsGetDataProperties_Params_STRUCT_SIZE};
     props.ctx = ctx_.cuda_ctx;
-    if (cuptiSassMetricsGetDataProperties(&props) != CUPTI_SUCCESS ||
-        props.numOfPatchedInstructionRecords == 0) {
+    CUptiResult propRes = cuptiSassMetricsGetDataProperties(&props);
+    if (propRes != CUPTI_SUCCESS) {
+        // CUPTI errored on the data-properties query — distinct from "armed but
+        // patched nothing". Surface it so the empty-SASS case isn't silent.
+        LogCuptiErrorIfFailed(this->name(),
+                              "cuptiSassMetricsGetDataProperties", propRes);
         return;
     }
+    if (props.numOfPatchedInstructionRecords == 0) {
+        // SASS enabled successfully but CUPTI instrumented ZERO instructions
+        // this session — no patched records to flush. Seen on consumer
+        // Blackwell (sm_120) laptops under Windows WDDM with CUPTI 13.x, and
+        // when GPU performance-counter access is restricted. This is the
+        // "sass_metrics: on, no data" capability state; not a code error.
+        GFL_LOG_ERROR(
+            "[SassMetricsEngine] SASS armed but CUPTI reports 0 patched "
+            "instruction records — no kernel was SASS-instrumented this "
+            "session. Check GPU performance-counter access (NVIDIA Control "
+            "Panel / run elevated); may be unsupported on this GPU+driver.");
+        return;
+    }
+    GFL_LOG_DEBUG("[SassMetricsEngine] draining ",
+                  props.numOfPatchedInstructionRecords,
+                  " patched instruction record(s), ", props.numOfInstances,
+                  " instance(s).");
 
     size_t nRecords = props.numOfPatchedInstructionRecords;
     size_t nInstances = props.numOfInstances;
@@ -662,6 +686,8 @@ void SassMetricsEngine::StopAndCollectSassMetrics_() {
                 samples.push_back(std::move(s));
             }
         }
+        if (!samples.empty())
+            produced_data_.store(true, std::memory_order_relaxed);
         Monitor::PushProfileSamples(samples);
     } else {
         LogCuptiErrorIfFailed(this->name(), "cuptiSassMetricsFlushData",

--- a/include/gpufl/backends/nvidia/engine/sass_metrics_engine.hpp
+++ b/include/gpufl/backends/nvidia/engine/sass_metrics_engine.hpp
@@ -22,7 +22,8 @@ class SassMetricsEngine final : public IProfilingEngine {
     void stop()     override;
     void shutdown() override;
 
-    // SASS metrics are armed at scope start and collected at scope end.
+    // SASS metrics are configured at engine start, armed at scope start, and
+    // collected at scope end.
     void onScopeStart(const char* name) override;
     void onScopeStop(const char* name) override;
     void flushBeforeCudaTeardown(const char* reason) override;

--- a/include/gpufl/backends/nvidia/engine/sass_metrics_engine.hpp
+++ b/include/gpufl/backends/nvidia/engine/sass_metrics_engine.hpp
@@ -23,6 +23,7 @@ class SassMetricsEngine final : public IProfilingEngine {
 
     // SASS metrics are collected at scope end.
     void onScopeStop(const char* name) override;
+    void flushBeforeCudaTeardown(const char* reason) override;
 
     bool isEnabled() const { return enabled_; }
 

--- a/include/gpufl/backends/nvidia/engine/sass_metrics_engine.hpp
+++ b/include/gpufl/backends/nvidia/engine/sass_metrics_engine.hpp
@@ -22,11 +22,12 @@ class SassMetricsEngine final : public IProfilingEngine {
     void stop()     override;
     void shutdown() override;
 
-    // SASS metrics are collected at scope end.
+    // SASS metrics are armed at scope start and collected at scope end.
+    void onScopeStart(const char* name) override;
     void onScopeStop(const char* name) override;
     void flushBeforeCudaTeardown(const char* reason) override;
 
-    bool isEnabled() const { return enabled_; }
+    bool isEnabled() const { return profiler_initialized_ && config_set_ && !insufficient_privileges_; }
 
     /**
      * True when cuptiProfilerInitialize / cuptiSassMetricsEnable returned
@@ -37,7 +38,7 @@ class SassMetricsEngine final : public IProfilingEngine {
         return insufficient_privileges_;
     }
 
-    bool isOperational() const override { return enabled_; }
+    bool isOperational() const override { return isEnabled(); }
 
     /** True once at least one SASS metric sample was pushed this session. */
     bool producedData() const override {
@@ -45,7 +46,8 @@ class SassMetricsEngine final : public IProfilingEngine {
     }
 
    private:
-    void EnableSassMetrics_();
+    void ConfigureSassMetrics_();
+    void ArmSassMetrics_();
     void StopAndCollectSassMetrics_();
     /**
      * Undo cuptiProfilerInitialize if start() got that far before

--- a/include/gpufl/backends/nvidia/engine/sass_metrics_engine.hpp
+++ b/include/gpufl/backends/nvidia/engine/sass_metrics_engine.hpp
@@ -2,6 +2,7 @@
 
 #include <cupti_sass_metrics.h>
 
+#include <atomic>
 #include <string>
 #include <unordered_map>
 
@@ -38,6 +39,11 @@ class SassMetricsEngine final : public IProfilingEngine {
 
     bool isOperational() const override { return enabled_; }
 
+    /** True once at least one SASS metric sample was pushed this session. */
+    bool producedData() const override {
+        return produced_data_.load(std::memory_order_relaxed);
+    }
+
    private:
     void EnableSassMetrics_();
     void StopAndCollectSassMetrics_();
@@ -66,6 +72,7 @@ class SassMetricsEngine final : public IProfilingEngine {
     std::unordered_map<uint64_t, std::string> metric_id_to_name_;
     std::vector<std::string> skipped_metrics_;
     bool enabled_ = false;
+    std::atomic<bool> produced_data_{false};
     bool config_set_ = false;
     bool insufficient_privileges_ = false;
     // True after cuptiProfilerInitialize() returned CUPTI_SUCCESS in

--- a/include/gpufl/backends/nvidia/kernel_launch_handler.cpp
+++ b/include/gpufl/backends/nvidia/kernel_launch_handler.cpp
@@ -63,6 +63,14 @@ const std::string& KernelLaunchHandler::cachedDemangle(const char* mangled) {
 
 std::vector<std::pair<CUpti_CallbackDomain, CUpti_CallbackId>>
 KernelLaunchHandler::requiredCallbacks() const {
+    if (backend_ && backend_->IsSassProfilerMode()) {
+        GFL_LOG_DEBUG(
+            "[KernelLaunchHandler] launch API callbacks disabled in SASS "
+            "profiler mode; kernel activity records and SASS metrics remain "
+            "enabled.");
+        return {};
+    }
+
     // The set of launch APIs that produce a kernel record we want
     // api_enter_ns / api_exit_ns for. Anything missing here means the
     // backend stores 0 for the API timestamps, the frontend can't
@@ -135,6 +143,13 @@ KernelLaunchHandler::requiredCallbacks() const {
 
 std::vector<CUpti_ActivityKind> KernelLaunchHandler::requiredActivityKinds()
     const {
+    if (backend_ && !backend_->AllowSassKernelActivity()) {
+        GFL_LOG_DEBUG(
+            "[KernelLaunchHandler] kernel activity tracing disabled in SASS "
+            "profiler mode. Set GPUFL_SASS_ALLOW_KERNEL_ACTIVITY=1 to test it.");
+        return {};
+    }
+
     // CONCURRENT_KERNEL only — deliberately NOT CUPTI_ACTIVITY_KIND_KERNEL.
     // Per CUPTI docs, enabling KERNEL "serializes all kernel executions on
     // the GPU," which distorts timing (hides real kernel overlap), adds

--- a/include/gpufl/backends/nvidia/kernel_launch_handler.cpp
+++ b/include/gpufl/backends/nvidia/kernel_launch_handler.cpp
@@ -5,6 +5,11 @@
 #include <cstring>    // strnlen — bounded read in cachedDemangle
 #include <iterator>   // std::begin / std::end on the user_scope C-array
 #include <set>
+#include <string>
+#if defined(__linux__)
+#include <sys/uio.h>
+#include <unistd.h>
+#endif
 
 #include "gpufl/backends/nvidia/cuda_feature_guards.hpp"
 #include "gpufl/backends/nvidia/cupti_utils.hpp"
@@ -20,6 +25,44 @@
 using gpufl::core::DemangleName;
 
 namespace gpufl {
+
+namespace {
+
+bool CopyReadableCString(const char* src, std::string* out) {
+    if (!src || !out) return false;
+
+#if defined(__linux__)
+    constexpr size_t kMaxNameLen = 4096;
+    char buf[kMaxNameLen] = {};
+
+    iovec local{};
+    local.iov_base = buf;
+    local.iov_len = sizeof(buf);
+
+    iovec remote{};
+    remote.iov_base = const_cast<char*>(src);
+    remote.iov_len = sizeof(buf);
+
+    const ssize_t nread = process_vm_readv(getpid(), &local, 1, &remote, 1, 0);
+    if (nread <= 0) return false;
+
+    const size_t n = static_cast<size_t>(nread);
+    const void* nul = std::memchr(buf, '\0', n);
+    if (!nul) return false;
+
+    const size_t len = static_cast<const char*>(nul) - buf;
+    if (len == 0) return false;
+
+    out->assign(buf, len);
+    return true;
+#else
+    (void)src;
+    (void)out;
+    return false;
+#endif
+}
+
+}  // namespace
 
 KernelLaunchHandler::KernelLaunchHandler(CuptiBackend* backend)
     : backend_(backend) {}
@@ -65,10 +108,9 @@ std::vector<std::pair<CUpti_CallbackDomain, CUpti_CallbackId>>
 KernelLaunchHandler::requiredCallbacks() const {
     if (backend_ && backend_->IsSassProfilerMode()) {
         GFL_LOG_DEBUG(
-            "[KernelLaunchHandler] launch API callbacks disabled in SASS "
-            "profiler mode; kernel activity records and SASS metrics remain "
-            "enabled.");
-        return {};
+            "[KernelLaunchHandler] launch API callbacks enabled in SASS "
+            "profiler mode for synthetic kernel rows; CUPTI kernel activity "
+            "remains controlled by the SASS activity policy.");
     }
 
     // The set of launch APIs that produce a kernel record we want
@@ -145,8 +187,10 @@ std::vector<CUpti_ActivityKind> KernelLaunchHandler::requiredActivityKinds()
     const {
     if (backend_ && !backend_->AllowSassKernelActivity()) {
         GFL_LOG_DEBUG(
-            "[KernelLaunchHandler] kernel activity tracing disabled in SASS "
-            "profiler mode. Set GPUFL_SASS_ALLOW_KERNEL_ACTIVITY=1 to test it.");
+            "[KernelLaunchHandler] CUPTI kernel activity disabled in SASS "
+            "profiler safe mode; launch callbacks will provide synthetic "
+            "kernel rows. Set GPUFL_SASS_ALLOW_KERNEL_ACTIVITY=1 to test "
+            "CONCURRENT_KERNEL explicitly.");
         return {};
     }
 
@@ -194,35 +238,22 @@ void KernelLaunchHandler::handle(CUpti_CallbackDomain domain,
         LaunchMeta meta{};
         meta.api_enter_ns = detail::GetTimestampNs();
 
-        // Always use cbInfo->functionName for the callback-path name.
-        //
-        // Background: cbInfo->symbolName was the obvious choice (it's
-        // documented as the kernel's symbol name), but on CUDA 13.1
-        // CUPTI populates that field with non-pointer values for some
-        // launch callbacks — e.g. 0x8000000001 (high bit + low bit
-        // set, clearly a tagged value or internal handle, not an
-        // address). Reading it as a pointer segfaults. An earlier
-        // address-range heuristic (reject pointers below 0x10000)
-        // worked on hardware where the garbage was zero-shaped but
-        // missed the high-bit-tagged variant — we can't reliably
-        // detect "is this a real pointer" from the value alone
-        // without a mincore() check or SIGSEGV-handler probe, both of
-        // which add complexity for marginal benefit.
-        //
-        // cbInfo->functionName is always the CUDA API name (literal
-        // string constant in libcupti.so's read-only data, e.g.
-        // "cudaLaunchKernel" / "cuLaunchKernel"), so it's safe on
-        // every CUDA version. The trade-off: meta.name shows the
-        // API name instead of the kernel symbol for a brief window
-        // between the launch callback and the corresponding
-        // CUpti_ActivityKernel record arriving. onActivityRecord (see
-        // below in this file) overwrites meta.name with the real
-        // kernel name from k->name before any record ships. So the
-        // user-visible output is unchanged; only the in-flight
-        // meta_by_corr_ entry briefly carries the API name.
-        const char* nm = cbInfo->functionName;
-        const std::string& demangledName = cachedDemangle(nm);
-        std::snprintf(meta.name, sizeof(meta.name), "%s", demangledName.c_str());
+        // Prefer cbInfo->symbolName so callback-only SASS safe mode can still
+        // group kernels by real symbol. CUDA 13.1 sometimes puts invalid tagged
+        // values in symbolName, so never dereference it directly; copy through
+        // process_vm_readv first and fall back to the stable API function name
+        // (cudaLaunchKernel / cuLaunchKernelEx) if the probe fails.
+        std::string copiedSymbol;
+        if (CopyReadableCString(cbInfo->symbolName, &copiedSymbol)) {
+            const std::string demangledName = DemangleName(copiedSymbol.c_str());
+            std::snprintf(meta.name, sizeof(meta.name), "%s",
+                          demangledName.c_str());
+        } else {
+            const char* nm = cbInfo->functionName;
+            const std::string& demangledName = cachedDemangle(nm);
+            std::snprintf(meta.name, sizeof(meta.name), "%s",
+                          demangledName.c_str());
+        }
 
         if (backend_->GetOptions().enable_stack_trace) {
             const std::string trace = core::GetCallStack(2);

--- a/include/gpufl/backends/nvidia/kernel_launch_handler.cpp
+++ b/include/gpufl/backends/nvidia/kernel_launch_handler.cpp
@@ -235,6 +235,7 @@ void KernelLaunchHandler::handle(CUpti_CallbackDomain domain,
     }
 
     if (cbInfo->callbackSite == CUPTI_API_ENTER) {
+        backend_->NoteKernelLaunchForCleanupFlush();
         LaunchMeta meta{};
         meta.api_enter_ns = detail::GetTimestampNs();
 
@@ -354,25 +355,34 @@ void KernelLaunchHandler::handle(CUpti_CallbackDomain domain,
         }
 
         // Store metadata — emit later from scope stop (PC Sampling path)
-        // or handleActivityRecord (normal path).
+        // or handleActivityRecord (normal path). Runtime and driver launch
+        // callbacks can share one correlation id, so keep the richest metadata
+        // and avoid duplicate diagnostic lines for the same logical launch.
+        bool shouldLogLaunch = false;
         {
             std::lock_guard lk(backend_->meta_mu_);
-            auto& existing = backend_->meta_by_corr_[cbInfo->correlationId];
-            if (existing.has_details && !meta.has_details) {
+            auto it = backend_->meta_by_corr_.find(cbInfo->correlationId);
+            if (it == backend_->meta_by_corr_.end()) {
+                backend_->meta_by_corr_.emplace(cbInfo->correlationId, meta);
+                shouldLogLaunch = true;
+            } else if (it->second.has_details && !meta.has_details) {
                 GFL_LOG_DEBUG(
                     "[DEBUG-CALLBACK] Skipping overwrite of rich metadata "
                     "for CorrID ",
                     cbInfo->correlationId, " by Driver API.");
-            } else {
-                existing = meta;
+            } else if (!it->second.has_details && meta.has_details) {
+                it->second = meta;
+                shouldLogLaunch = true;
             }
         }
-        // Diagnostic: confirm every kernel launch fires this callback.
+        // Diagnostic: confirm every logical kernel launch fires this callback.
         // If "GPU Time by Scope" shows only N kernels but this logs M>N,
         // the loss is downstream (activity records / FlushPendingKernels).
-        GFL_LOG_DEBUG("[KernelLaunchHandler] API_ENTER corr=",
-                      cbInfo->correlationId, " name=", meta.name,
-                      " scope=", meta.user_scope);
+        if (shouldLogLaunch) {
+            GFL_LOG_DEBUG("[KernelLaunchHandler] API_ENTER corr=",
+                          cbInfo->correlationId, " name=", meta.name,
+                          " scope=", meta.user_scope);
+        }
     } else if (cbInfo->callbackSite == CUPTI_API_EXIT) {
         const int64_t exitNs = detail::GetTimestampNs();
         std::lock_guard lk(backend_->meta_mu_);

--- a/include/gpufl/backends/nvidia/kernel_launch_handler.cpp
+++ b/include/gpufl/backends/nvidia/kernel_launch_handler.cpp
@@ -135,7 +135,16 @@ KernelLaunchHandler::requiredCallbacks() const {
 
 std::vector<CUpti_ActivityKind> KernelLaunchHandler::requiredActivityKinds()
     const {
-    return {CUPTI_ACTIVITY_KIND_KERNEL, CUPTI_ACTIVITY_KIND_CONCURRENT_KERNEL};
+    // CONCURRENT_KERNEL only — deliberately NOT CUPTI_ACTIVITY_KIND_KERNEL.
+    // Per CUPTI docs, enabling KERNEL "serializes all kernel executions on
+    // the GPU," which distorts timing (hides real kernel overlap), adds
+    // overhead, and routes every launch through CUPTI's serialization path.
+    // CONCURRENT_KERNEL produces the same CUpti_ActivityKernel records
+    // without serializing. The serialized kind was historically needed
+    // because the PC Sampling API required serialized kernels; CUDA 12.8
+    // Update 1 made PC sampling compatible with concurrent kernel tracing,
+    // so it's pure downside now.
+    return {CUPTI_ACTIVITY_KIND_CONCURRENT_KERNEL};
 }
 
 bool KernelLaunchHandler::shouldHandle(const CUpti_CallbackDomain domain,

--- a/include/gpufl/backends/nvidia/kernel_launch_handler.cpp
+++ b/include/gpufl/backends/nvidia/kernel_launch_handler.cpp
@@ -201,16 +201,11 @@ std::vector<CUpti_ActivityKind> KernelLaunchHandler::requiredActivityKinds()
         return {};
     }
 
-    // CONCURRENT_KERNEL only — deliberately NOT CUPTI_ACTIVITY_KIND_KERNEL.
-    // Per CUPTI docs, enabling KERNEL "serializes all kernel executions on
-    // the GPU," which distorts timing (hides real kernel overlap), adds
-    // overhead, and routes every launch through CUPTI's serialization path.
-    // CONCURRENT_KERNEL produces the same CUpti_ActivityKernel records
-    // without serializing. The serialized kind was historically needed
-    // because the PC Sampling API required serialized kernels; CUDA 12.8
-    // Update 1 made PC sampling compatible with concurrent kernel tracing,
-    // so it's pure downside now.
-    return {CUPTI_ACTIVITY_KIND_CONCURRENT_KERNEL};
+    // SASS metrics on sm_86/CUDA 13.2 produce all-zero counters when only
+    // CONCURRENT_KERNEL is enabled. Main's validated coexistence path enables
+    // both serialized and concurrent kernel activity; keep that combination so
+    // kernel rows and non-zero SASS counters are collected in one run.
+    return {CUPTI_ACTIVITY_KIND_KERNEL, CUPTI_ACTIVITY_KIND_CONCURRENT_KERNEL};
 }
 
 bool KernelLaunchHandler::shouldHandle(const CUpti_CallbackDomain domain,

--- a/include/gpufl/backends/nvidia/kernel_launch_handler.cpp
+++ b/include/gpufl/backends/nvidia/kernel_launch_handler.cpp
@@ -192,6 +192,15 @@ KernelLaunchHandler::requiredCallbacks() const {
 
 std::vector<CUpti_ActivityKind> KernelLaunchHandler::requiredActivityKinds()
     const {
+    if (backend_ && backend_->GetOptions().profiling_engine ==
+                        ProfilingEngine::PcSampling) {
+        GFL_LOG_DEBUG(
+            "[KernelLaunchHandler] CUPTI kernel activity disabled in PC "
+            "Sampling mode; launch callbacks will provide synthetic kernel "
+            "rows.");
+        return {};
+    }
+
     if (backend_ && !backend_->AllowSassKernelActivity()) {
         GFL_LOG_DEBUG(
             "[KernelLaunchHandler] CUPTI kernel activity disabled in SASS "

--- a/include/gpufl/backends/nvidia/kernel_launch_handler.cpp
+++ b/include/gpufl/backends/nvidia/kernel_launch_handler.cpp
@@ -106,6 +106,13 @@ const std::string& KernelLaunchHandler::cachedDemangle(const char* mangled) {
 
 std::vector<std::pair<CUpti_CallbackDomain, CUpti_CallbackId>>
 KernelLaunchHandler::requiredCallbacks() const {
+    if (backend_ && backend_->SassMetricsOnlyMode()) {
+        GFL_LOG_DEBUG(
+            "[KernelLaunchHandler] launch API callbacks disabled in SASS "
+            "metrics-only mode. Set GPUFL_SASS_ALLOW_ACTIVITY_WITH_METRICS=1 "
+            "to test CUPTI activity/callback coexistence.");
+        return {};
+    }
     if (backend_ && backend_->IsSassProfilerMode()) {
         GFL_LOG_DEBUG(
             "[KernelLaunchHandler] launch API callbacks enabled in SASS "

--- a/include/gpufl/backends/nvidia/mem_transfer_handler.cpp
+++ b/include/gpufl/backends/nvidia/mem_transfer_handler.cpp
@@ -19,6 +19,12 @@ MemTransferHandler::MemTransferHandler(CuptiBackend* backend)
 
 std::vector<std::pair<CUpti_CallbackDomain, CUpti_CallbackId>>
 MemTransferHandler::requiredCallbacks() const {
+    if (backend_ && backend_->IsSassProfilerMode()) {
+        GFL_LOG_DEBUG(
+            "[MemTransferHandler] memcpy/memset API callbacks disabled in "
+            "SASS profiler mode.");
+        return {};
+    }
     return {
         // Runtime API memcpy
         {CUPTI_CB_DOMAIN_RUNTIME_API, CUPTI_RUNTIME_TRACE_CBID_cudaMemcpy_v3020},
@@ -85,6 +91,7 @@ MemTransferHandler::requiredCallbacks() const {
 
 std::vector<CUpti_ActivityKind> MemTransferHandler::requiredActivityKinds()
     const {
+    if (backend_ && !backend_->AllowSassMemTransferActivity()) return {};
     return {CUPTI_ACTIVITY_KIND_MEMCPY, CUPTI_ACTIVITY_KIND_MEMCPY2,
             CUPTI_ACTIVITY_KIND_MEMSET};
 }

--- a/include/gpufl/backends/nvidia/mem_transfer_handler.cpp
+++ b/include/gpufl/backends/nvidia/mem_transfer_handler.cpp
@@ -264,6 +264,7 @@ bool MemTransferHandler::handleActivityRecord(const CUpti_Activity* record,
             }
         }
         g_monitorBuffer.Push(out);
+        backend_->NoteMemoryActivityEmitted();
         return true;
     }
 
@@ -295,6 +296,7 @@ bool MemTransferHandler::handleActivityRecord(const CUpti_Activity* record,
             }
         }
         g_monitorBuffer.Push(out);
+        backend_->NoteMemoryActivityEmitted();
         return true;
     }
 

--- a/include/gpufl/backends/nvidia/resource_handler.cpp
+++ b/include/gpufl/backends/nvidia/resource_handler.cpp
@@ -68,7 +68,7 @@ void ResourceHandler::handle(CUpti_CallbackDomain domain, CUpti_CallbackId cbid,
             // MODULE_LOADED cubin, and CUPTI's PC sampling data
             // references that CRC for source correlation.
             {
-                std::lock_guard<std::mutex> lk(backend_->cubin_mu_);
+                std::lock_guard lk(backend_->cubin_mu_);
                 if (backend_->seen_cubin_ptrs_.count(cubinPtr)) return;
                 backend_->seen_cubin_ptrs_.insert(cubinPtr);
             }
@@ -81,11 +81,11 @@ void ResourceHandler::handle(CUpti_CallbackDomain domain, CUpti_CallbackId cbid,
             // cuptiGetCubinCrc() here deadlocks. Defer to the worker thread.
             GFL_LOG_DEBUG("Queuing Cubin for CRC at ", cubinPtr,
                           " Size: ", cubinSize);
-            std::vector<uint8_t> bytes(
+            std::vector bytes(
                 static_cast<const uint8_t *>(cubinPtr),
                 static_cast<const uint8_t *>(cubinPtr) + cubinSize);
             {
-                std::lock_guard<std::mutex> lk(pending_mu_);
+                std::lock_guard lk(pending_mu_);
                 pending_.push(std::move(bytes));
             }
             pending_cv_.notify_one();

--- a/include/gpufl/backends/nvidia/synchronization_handler.cpp
+++ b/include/gpufl/backends/nvidia/synchronization_handler.cpp
@@ -12,6 +12,14 @@ SynchronizationHandler::SynchronizationHandler(CuptiBackend* backend)
 
 std::vector<std::pair<CUpti_CallbackDomain, CUpti_CallbackId>>
 SynchronizationHandler::requiredCallbacks() const {
+    if (backend_ && backend_->IsSassProfilerMode()) {
+        GFL_LOG_DEBUG(
+            "[SynchronizationHandler] synchronization API callbacks disabled "
+            "in SASS profiler mode; synchronization activity records remain "
+            "available without stack attribution.");
+        return {};
+    }
+
     // CUDA synchronization API CBIDs we capture stacks for. Add new
     // CBIDs here as CUPTI exposes them (e.g. cuStreamWaitValue32/64
     // are semaphore-style waits that can also produce SYNCHRONIZATION

--- a/include/gpufl/core/config_file_loader.cpp
+++ b/include/gpufl/core/config_file_loader.cpp
@@ -15,19 +15,17 @@ void ConfigFileLoader::apply(InitOptions& opts, const std::string& path) {
 
     GFL_LOG_DEBUG("Config file loaded: ", path, " (", cfg.size(), " keys)");
 
-    // Profiling engine (string → enum). Accepts both the technical
-    // names (PcSampling / PcSamplingWithSass / RangeProfiler) and the
-    // friendly aliases (Continuous / Deep / Range) — same underlying
-    // enum values, so customer configs from either generation work.
-    // See gpufl-manual/client/mode-data-layers.html for the naming
-    // rationale.
+    // Profiling engine (string → enum). Accepts the six canonical
+    // engine names (see ProfilingEngine in monitor.hpp). Unrecognized
+    // values leave the existing default untouched.
     if (cfg.contains("profiling_engine")) {
         const auto& v = cfg["profiling_engine"].get_string();
-        if (v == "None")                                       opts.profiling_engine = ProfilingEngine::None;
-        else if (v == "PcSampling" || v == "Continuous")       opts.profiling_engine = ProfilingEngine::PcSampling;
-        else if (v == "SassMetrics")                           opts.profiling_engine = ProfilingEngine::SassMetrics;
-        else if (v == "RangeProfiler" || v == "Range")         opts.profiling_engine = ProfilingEngine::RangeProfiler;
-        else if (v == "PcSamplingWithSass" || v == "Deep")     opts.profiling_engine = ProfilingEngine::PcSamplingWithSass;
+        if (v == "Monitor")            opts.profiling_engine = ProfilingEngine::Monitor;
+        else if (v == "Trace")         opts.profiling_engine = ProfilingEngine::Trace;
+        else if (v == "PcSampling")    opts.profiling_engine = ProfilingEngine::PcSampling;
+        else if (v == "SassMetrics")   opts.profiling_engine = ProfilingEngine::SassMetrics;
+        else if (v == "RangeProfiler") opts.profiling_engine = ProfilingEngine::RangeProfiler;
+        else if (v == "Deep")          opts.profiling_engine = ProfilingEngine::Deep;
     }
 
     // Integer fields

--- a/include/gpufl/core/dictionary_manager.cpp
+++ b/include/gpufl/core/dictionary_manager.cpp
@@ -7,6 +7,7 @@
 #include <fstream>
 #include <sstream>
 #include <stdexcept>
+#include <vector>
 
 #include "gpufl/core/sass_compressor.hpp"
 
@@ -15,13 +16,21 @@
 #include <fcntl.h>    // _O_CREAT, _O_WRONLY, _O_BINARY
 #include <windows.h>  // GetTempPathA
 #else
-#include <unistd.h>
+#include <fcntl.h>     // O_WRONLY (redirect child stderr -> /dev/null)
+#include <spawn.h>     // posix_spawn — fork-safe subprocess (NOT popen)
+#include <sys/wait.h>  // waitpid
+#include <unistd.h>    // pipe, close, dup2, STDOUT_FILENO
 #endif
 
 #include "gpufl/core/debug_logger.hpp"
 #include "gpufl/core/logger/logger.hpp"
 #include "gpufl/core/model/model_utils.hpp"
 #include "gpufl/core/model/serializable.hpp"
+
+#ifndef _WIN32
+// posix_spawn needs the current environment for the disassembler child.
+extern "C" char **environ;
+#endif
 
 namespace gpufl {
 namespace {
@@ -59,6 +68,52 @@ void appendDict(std::ostringstream& oss, const char* key,
     }
     oss << '}';
 }
+
+#ifndef _WIN32
+// Launch argv[0] with stdout connected to a pipe we read and stderr sent
+// to /dev/null, via posix_spawn — deliberately NOT popen/system.
+//
+// popen() forks and runs /bin/sh. A plain fork() in a multithreaded
+// process clones only the calling thread but inherits every lock in its
+// current state; if another thread holds the glibc malloc arena lock at
+// the instant of the fork, the child deadlocks the first time it needs
+// that lock during pre-exec setup, never exec's, and the parent then
+// blocks forever reading the pipe. flushDisassembly runs on the collector
+// thread while application threads are busy launching kernels, so a fork
+// there frequently coincides with a held malloc lock — that is the
+// Deep-mode hang. posix_spawn runs only async-signal-safe code in the
+// child before exec (vfork/CLONE_VFORK semantics), so it cannot deadlock
+// on an inherited lock.
+//
+// Returns a readable FILE* (caller fcloses) and sets outPid for reaping,
+// or nullptr on failure.
+FILE *spawnReadPipe(char *const argv[], pid_t &outPid) {
+    int pipefd[2];
+    if (::pipe(pipefd) != 0) return nullptr;
+
+    posix_spawn_file_actions_t fa;
+    posix_spawn_file_actions_init(&fa);
+    // child stdout -> pipe write end; child stderr -> /dev/null
+    posix_spawn_file_actions_adddup2(&fa, pipefd[1], STDOUT_FILENO);
+    posix_spawn_file_actions_addopen(&fa, STDERR_FILENO, "/dev/null",
+                                     O_WRONLY, 0);
+    // close the inherited pipe fds in the child (write end is dup'd to 1)
+    posix_spawn_file_actions_addclose(&fa, pipefd[0]);
+    posix_spawn_file_actions_addclose(&fa, pipefd[1]);
+
+    pid_t pid = -1;
+    const int rc =
+        posix_spawn(&pid, argv[0], &fa, nullptr, argv, environ);
+    posix_spawn_file_actions_destroy(&fa);
+    ::close(pipefd[1]);  // parent keeps only the read end
+    if (rc != 0) {
+        ::close(pipefd[0]);
+        return nullptr;
+    }
+    outPid = pid;
+    return ::fdopen(pipefd[0], "r");
+}
+#endif  // !_WIN32
 
 }  // namespace
 
@@ -184,25 +239,32 @@ void DictionaryManager::flushDisassembly(Logger& logger,
                       bytes[2] == 'L' && bytes[3] == 'F' &&
                       (bytes[18] == 0xE0 && bytes[19] == 0x00));
 
-        char cmd[640];
+        // Launch the disassembler. POSIX uses posix_spawn (see
+        // spawnReadPipe) instead of popen — popen's fork() can deadlock on
+        // an inherited malloc lock in this multithreaded process, which is
+        // the Deep-mode hang. We exec the tool directly with an argv vector
+        // (no shell), so paths/args need no quoting and there's no /bin/sh.
+        FILE* pipe = nullptr;
+#ifndef _WIN32
+        pid_t childPid = -1;
+#endif
         if (isAmd) {
 #ifdef _WIN32
             // ROCm on Windows: not typical, skip AMD disassembly
             std::remove(tmpPathStr.c_str());
             continue;
 #else
-            // Discover llvm-objdump path
-            // Use -l to include DWARF source line info for source correlation
+            // llvm-objdump -d -l (-l adds DWARF source lines for correlation)
             const char* rocmPath = std::getenv("ROCM_PATH");
-            if (rocmPath && rocmPath[0]) {
-                std::snprintf(cmd, sizeof(cmd),
-                              "%s/llvm/bin/llvm-objdump -d -l %s 2>/dev/null",
-                              rocmPath, tmpPathStr.c_str());
-            } else {
-                std::snprintf(cmd, sizeof(cmd),
-                              "/opt/rocm/llvm/bin/llvm-objdump -d -l %s 2>/dev/null",
-                              tmpPathStr.c_str());
-            }
+            std::string objdump = (rocmPath && rocmPath[0])
+                ? std::string(rocmPath) + "/llvm/bin/llvm-objdump"
+                : std::string("/opt/rocm/llvm/bin/llvm-objdump");
+            std::vector<std::string> args = {objdump, "-d", "-l", tmpPathStr};
+            std::vector<char*> argv;
+            argv.reserve(args.size() + 1);
+            for (auto& a : args) argv.push_back(a.data());
+            argv.push_back(nullptr);
+            pipe = spawnReadPipe(argv.data(), childPid);
 #endif
         } else {
 #ifdef _WIN32
@@ -210,6 +272,7 @@ void DictionaryManager::flushDisassembly(Logger& logger,
             // Wrap entire command in outer quotes for cmd.exe /c — needed
             // when both the executable path and arguments contain spaces
             // (e.g., "C:\Program Files\...").
+            char cmd[640];
             const char* cudaPath = std::getenv("CUDA_PATH");
             if (cudaPath && cudaPath[0]) {
                 std::snprintf(cmd, sizeof(cmd),
@@ -220,21 +283,22 @@ void DictionaryManager::flushDisassembly(Logger& logger,
                               "\"nvdisasm.exe --print-code \"%s\"\"",
                               tmpPathStr.c_str());
             }
+            pipe = _popen(cmd, "r");
 #else
-            std::snprintf(cmd, sizeof(cmd),
-                          "/usr/local/cuda/bin/nvdisasm --print-code %s 2>/dev/null",
-                          tmpPathStr.c_str());
+            std::vector<std::string> args = {
+                "/usr/local/cuda/bin/nvdisasm", "--print-code", tmpPathStr};
+            std::vector<char*> argv;
+            argv.reserve(args.size() + 1);
+            for (auto& a : args) argv.push_back(a.data());
+            argv.push_back(nullptr);
+            pipe = spawnReadPipe(argv.data(), childPid);
 #endif
         }
 
-#ifdef _WIN32
-        FILE* pipe = _popen(cmd, "r");
-#else
-        FILE* pipe = ::popen(cmd, "r");
-#endif
         if (!pipe) {
             std::remove(tmpPathStr.c_str());
-            GFL_LOG_ERROR("[flushDisassembly] popen failed — disassembler unavailable?");
+            GFL_LOG_ERROR("[flushDisassembly] failed to launch disassembler "
+                          "— nvdisasm / llvm-objdump unavailable?");
             continue;
         }
 
@@ -334,7 +398,7 @@ void DictionaryManager::flushDisassembly(Logger& logger,
                 // NVIDIA nvdisasm format:
                 // Function: "_Z11vectorScalePiii:"
                 // Instruction: "/*XXXX*/   INSTR ;"
-                if (!std::isspace((unsigned char)raw[0]) && raw[0] != '.' &&
+                if (!std::isspace(static_cast<unsigned char>(raw[0])) && raw[0] != '.' &&
                     raw.back() == ':') {
                     currentFunc = raw.substr(0, raw.size() - 1);
                     if (!funcEntries.count(currentFunc))
@@ -368,7 +432,13 @@ void DictionaryManager::flushDisassembly(Logger& logger,
 #ifdef _WIN32
         _pclose(pipe);
 #else
-        ::pclose(pipe);
+        // We spawned with posix_spawn (not popen), so close the FILE*
+        // ourselves and reap the child explicitly to avoid a zombie.
+        ::fclose(pipe);
+        if (childPid > 0) {
+            int status = 0;
+            ::waitpid(childPid, &status, 0);
+        }
 #endif
         std::remove(tmpPathStr.c_str());
 

--- a/include/gpufl/core/events.hpp
+++ b/include/gpufl/core/events.hpp
@@ -83,9 +83,9 @@ struct InitEvent {
     //                    sessions ran with an engine?".
     // profiling_engine : vendor-namespaced detail like
     //                    "nvidia.pc_sampling" / "nvidia.sass_metrics"
-    //                    / "nvidia.none" (the latter is the explicit
-    //                    "user chose ProfilingEngine::None" sentinel).
-    //                    Stored verbatim by the backend.
+    //                    / "nvidia.none" (the latter is what
+    //                    ProfilingEngine::Monitor — telemetry only —
+    //                    emits). Stored verbatim by the backend.
     //                    The "nvidia.none" string lets the backend
     //                    distinguish "user explicitly disabled
     //                    profiling" from "pre-V40 client that omitted

--- a/include/gpufl/core/events.hpp
+++ b/include/gpufl/core/events.hpp
@@ -112,6 +112,23 @@ struct SassConfigEvent {
     std::vector<std::string> skipped_metrics;     // metrics CUPTI rejected for this GPU
 };
 
+struct CaptureCapability {
+    std::string feature;
+    bool requested = false;
+    std::string status;
+    std::string mode;
+    std::string reason_code;
+    std::string message;
+};
+
+struct CaptureCapabilitiesEvent {
+    std::string session_id;
+    int64_t ts_ns = 0;
+    std::string requested_engine;
+    std::string selected_engine;
+    std::vector<CaptureCapability> capabilities;
+};
+
 struct KernelEvent {
     int pid = 0;
     std::string app;

--- a/include/gpufl/core/gpufl.cpp
+++ b/include/gpufl/core/gpufl.cpp
@@ -363,31 +363,27 @@ bool init(const InitOptions& opts) {
     mOpts.profiling_engine = g_opts.profiling_engine;
 
     // Allow environment variable override: GPUFL_PROFILING_ENGINE.
-    // Accepts both technical names (PcSampling / PcSamplingWithSass /
-    // RangeProfiler) and friendly aliases (Continuous / Deep / Range)
-    // — same underlying enum values. Unrecognized values are logged but
-    // do not change the engine (it stays at whatever g_opts set above);
-    // previously such values fell through silently, which made
-    // `GPUFL_PROFILING_ENGINE=Deep` (documented in the manual) appear to
-    // work while actually doing nothing.
+    // Accepts exactly the six canonical engine names. Unrecognized
+    // values are logged and ignored (the engine stays at whatever
+    // g_opts set above) rather than silently doing nothing.
     if (const char* envEngine = std::getenv("GPUFL_PROFILING_ENGINE")) {
         const std::string val(envEngine);
         bool matched = true;
-        if (val == "None")                                       mOpts.profiling_engine = ProfilingEngine::None;
-        else if (val == "PcSampling" || val == "Continuous")     mOpts.profiling_engine = ProfilingEngine::PcSampling;
-        else if (val == "SassMetrics")                           mOpts.profiling_engine = ProfilingEngine::SassMetrics;
-        else if (val == "RangeProfiler" || val == "Range")       mOpts.profiling_engine = ProfilingEngine::RangeProfiler;
-        else if (val == "PcSamplingWithSass" || val == "Deep")   mOpts.profiling_engine = ProfilingEngine::PcSamplingWithSass;
+        if (val == "Monitor")                  mOpts.profiling_engine = ProfilingEngine::Monitor;
+        else if (val == "Trace")               mOpts.profiling_engine = ProfilingEngine::Trace;
+        else if (val == "PcSampling")          mOpts.profiling_engine = ProfilingEngine::PcSampling;
+        else if (val == "SassMetrics")         mOpts.profiling_engine = ProfilingEngine::SassMetrics;
+        else if (val == "RangeProfiler")       mOpts.profiling_engine = ProfilingEngine::RangeProfiler;
+        else if (val == "Deep")                mOpts.profiling_engine = ProfilingEngine::Deep;
         else matched = false;
         if (matched) {
             GFL_LOG_DEBUG("GPUFL_PROFILING_ENGINE override: ", val);
         } else {
             GFL_LOG_ERROR(
                 "GPUFL_PROFILING_ENGINE='", val, "' is not a recognized "
-                "engine name. Valid values: None, Continuous (alias "
-                "PcSampling), Deep (alias PcSamplingWithSass), Range "
-                "(alias RangeProfiler), SassMetrics. Keeping current "
-                "engine selection.");
+                "engine name. Valid values: Monitor, Trace, PcSampling, "
+                "SassMetrics, RangeProfiler, Deep. Keeping current engine "
+                "selection.");
         }
     }
     mOpts.kernel_sample_rate_ms = g_opts.kernel_sample_rate_ms;
@@ -402,6 +398,37 @@ bool init(const InitOptions& opts) {
     mOpts.enable_cuda_graphs_tracking = g_opts.enable_cuda_graphs_tracking;
     mOpts.backend_kind = ToMonitorBackendKind(g_opts.backend);
 
+    // EAGER module loading is OPT-IN. By default we leave CUDA on its normal
+    // LAZY loading; the per-architecture SASS exclusion gate
+    // (GPUFL_SASS_EXCLUDE_ARCHS, in SassMetricsEngine) is the default guard
+    // for the CUPTI lazy-patching deadlock — it disables SASS only on
+    // architectures confirmed to hang, rather than paying EAGER's
+    // whole-process startup/memory cost everywhere. EAGER remains available
+    // as a per-run alternative: GPUFL_EAGER_MODULE_LOADING=1 forces it (it
+    // finalizes every module up front, while the process is quiescent, so the
+    // concurrent-launch finalize that triggers the deadlock never happens).
+    //
+    // This MUST run before the first CUDA call below (cudaGetDevice creates
+    // the context, which reads CUDA_MODULE_LOADING). Honor a value the user
+    // already set. Python callers apply the same opt-in earlier in
+    // gpufl.init(); this covers the pure-C++ path.
+    if (mOpts.profiling_engine == ProfilingEngine::SassMetrics ||
+        mOpts.profiling_engine == ProfilingEngine::Deep) {
+        const char* knobEnv = std::getenv("GPUFL_EAGER_MODULE_LOADING");
+        const std::string knob = knobEnv ? knobEnv : "";
+        const bool optedIn = (knob == "1" || knob == "true" ||
+                              knob == "yes" || knob == "on");
+        if (optedIn && std::getenv("CUDA_MODULE_LOADING") == nullptr) {
+#if defined(_WIN32)
+            _putenv_s("CUDA_MODULE_LOADING", "EAGER");
+#else
+            setenv("CUDA_MODULE_LOADING", "EAGER", /*overwrite=*/0);
+#endif
+            GFL_LOG_DEBUG("[gpufl] CUDA_MODULE_LOADING=EAGER set "
+                          "(GPUFL_EAGER_MODULE_LOADING opt-in) for SASS/Deep.");
+        }
+    }
+
     // Auto-tune kernel_sample_rate_ms on older NVIDIA GPUs where SASS metric
     // overhead per kernel launch is much higher. A default 50ms on sm_86 can
     // lead to hundreds of captured kernels per second each carrying
@@ -411,7 +438,7 @@ bool init(const InitOptions& opts) {
 #if GPUFL_HAS_CUDA || defined(__CUDACC__)
     if (mOpts.kernel_sample_rate_ms > 0 && mOpts.kernel_sample_rate_ms < 200 &&
         (mOpts.profiling_engine == ProfilingEngine::SassMetrics ||
-         mOpts.profiling_engine == ProfilingEngine::PcSamplingWithSass)) {
+         mOpts.profiling_engine == ProfilingEngine::Deep)) {
         cudaDeviceProp prop{};
         int devId = 0;
         if (cudaGetDevice(&devId) == cudaSuccess &&
@@ -467,9 +494,21 @@ bool init(const InitOptions& opts) {
     ie.host = rt_ptr->host_collector->sample();
 
     switch (mOpts.profiling_engine) {
-        case ProfilingEngine::None:
+        case ProfilingEngine::Monitor:
+            // Telemetry-only. Reuse the legacy "nvidia.none" wire string
+            // so the dashboard keeps suppressing the engine badge for
+            // these sessions (SessionList.formatEngineBadge special-cases
+            // "nvidia.none"). session_kind stays "monitor".
             ie.session_kind = "monitor";
             ie.profiling_engine = "nvidia.none";
+            break;
+        case ProfilingEngine::Trace:
+            // Activity trace, no sampling. New wire string; the dashboard
+            // title-cases unknown values, so it renders a "Trace" badge
+            // and (correctly) does not show the Source/SASS tab
+            // (engineImpliesSamples only matches the sampling strings).
+            ie.session_kind = "monitor";
+            ie.profiling_engine = "nvidia.trace";
             break;
         case ProfilingEngine::PcSampling:
             ie.session_kind = "trace";
@@ -483,7 +522,7 @@ bool init(const InitOptions& opts) {
             ie.session_kind = "trace";
             ie.profiling_engine = "nvidia.range_profiler";
             break;
-        case ProfilingEngine::PcSamplingWithSass:
+        case ProfilingEngine::Deep:
             ie.session_kind = "trace";
             ie.profiling_engine = "nvidia.pc_sampling_with_sass";
             break;
@@ -735,7 +774,8 @@ void ScopedMonitor::init_(const ScopeMeta& meta) {
 
     // Scope callbacks are useful for both tracing and profiling backends.
     Monitor::BeginProfilerScope(name_.c_str());
-    if (g_opts.profiling_engine != ProfilingEngine::None) {
+    if (g_opts.profiling_engine != ProfilingEngine::Monitor &&
+        g_opts.profiling_engine != ProfilingEngine::Trace) {
         Monitor::BeginPerfScope(name_.c_str());
     }
 
@@ -785,7 +825,8 @@ ScopedMonitor::~ScopedMonitor() {
     Monitor::PushScopeRow(row);
 
     Monitor::EndProfilerScope(name_.c_str());
-    if (g_opts.profiling_engine != ProfilingEngine::None) {
+    if (g_opts.profiling_engine != ProfilingEngine::Monitor &&
+        g_opts.profiling_engine != ProfilingEngine::Trace) {
         Monitor::EndPerfScope(
             name_.c_str());  // triggers EndPerfPassAndDecode first
         if (IMonitorBackend* b = Monitor::GetBackend()) {

--- a/include/gpufl/core/gpufl.cpp
+++ b/include/gpufl/core/gpufl.cpp
@@ -203,6 +203,7 @@ static std::string defaultLogPath_(const std::string& app) {
 
 // Remembered after init() for use by generateReport() after shutdown()
 static std::string g_lastLogPath;
+static std::string g_lastSessionId;
 static std::string g_lastAppName;
 
 static std::atomic<uint64_t> g_nextScopeId{1};
@@ -315,6 +316,7 @@ bool init(const InitOptions& opts) {
     logOpts.flush_always = g_opts.flush_logs_always;
 
     g_lastLogPath = logPath;
+    g_lastSessionId = rt->session_id;
     g_lastAppName = rt->app_name;
 
     GFL_LOG_DEBUG("Opening log file: ", logPath);
@@ -493,40 +495,8 @@ bool init(const InitOptions& opts) {
     }
     ie.host = rt_ptr->host_collector->sample();
 
-    switch (mOpts.profiling_engine) {
-        case ProfilingEngine::Monitor:
-            // Telemetry-only. Reuse the legacy "nvidia.none" wire string
-            // so the dashboard keeps suppressing the engine badge for
-            // these sessions (SessionList.formatEngineBadge special-cases
-            // "nvidia.none"). session_kind stays "monitor".
-            ie.session_kind = "monitor";
-            ie.profiling_engine = "nvidia.none";
-            break;
-        case ProfilingEngine::Trace:
-            // Activity trace, no sampling. New wire string; the dashboard
-            // title-cases unknown values, so it renders a "Trace" badge
-            // and (correctly) does not show the Source/SASS tab
-            // (engineImpliesSamples only matches the sampling strings).
-            ie.session_kind = "monitor";
-            ie.profiling_engine = "nvidia.trace";
-            break;
-        case ProfilingEngine::PcSampling:
-            ie.session_kind = "trace";
-            ie.profiling_engine = "nvidia.pc_sampling";
-            break;
-        case ProfilingEngine::SassMetrics:
-            ie.session_kind = "trace";
-            ie.profiling_engine = "nvidia.sass_metrics";
-            break;
-        case ProfilingEngine::RangeProfiler:
-            ie.session_kind = "trace";
-            ie.profiling_engine = "nvidia.range_profiler";
-            break;
-        case ProfilingEngine::Deep:
-            ie.session_kind = "trace";
-            ie.profiling_engine = "nvidia.pc_sampling_with_sass";
-            break;
-    }
+    ie.session_kind = ProfilingEngineSessionKind(mOpts.profiling_engine);
+    ie.profiling_engine = ProfilingEngineWireName(mOpts.profiling_engine);
 
     rt_ptr->logger->write(model::InitEventModel(ie));
 
@@ -849,16 +819,21 @@ void generateReport(const std::string& output_path) {
     namespace fs = std::filesystem;
 
     fs::path p(g_lastLogPath);
-    std::string dir = p.parent_path().string();
-    if (dir.empty()) dir = ".";
-
-    std::string prefix = p.filename().string();
-    if (prefix.size() > 4 && prefix.substr(prefix.size() - 4) == ".log")
-        prefix = prefix.substr(0, prefix.size() - 4);
+    if (p.extension() == ".log") {
+        p.replace_extension();
+    }
 
     report::TextReport::Options opts;
-    opts.log_dir = dir;
-    opts.log_prefix = prefix;
+    const fs::path sessionDir = p / g_lastSessionId;
+    if (!g_lastSessionId.empty() && fs::exists(sessionDir)) {
+        opts.log_dir = sessionDir.string();
+        opts.log_prefix.clear();
+    } else {
+        std::string dir = p.parent_path().string();
+        if (dir.empty()) dir = ".";
+        opts.log_dir = dir;
+        opts.log_prefix = p.filename().string();
+    }
     std::string text = report::TextReport(opts).generate();
 
     if (output_path.empty()) {

--- a/include/gpufl/core/json/json.cpp
+++ b/include/gpufl/core/json/json.cpp
@@ -6,6 +6,9 @@
 #include <iomanip>
 #include <sstream>
 #include <stdexcept>
+#include <vector>
+
+#include <zlib.h>
 
 namespace gpufl {
 namespace json {
@@ -353,14 +356,41 @@ std::vector<JsonValue> loadJsonLines(const std::string& path) {
     std::vector<JsonValue> records;
     if (path.empty()) return records;
 
+    auto parseLine = [&](const std::string& line) {
+        if (line.empty() || line[0] != '{') return;
+        auto val = parseJson(line);
+        if (!val.is_null()) records.push_back(std::move(val));
+    };
+
+    if (path.size() > 3 && path.substr(path.size() - 3) == ".gz") {
+        gzFile file = gzopen(path.c_str(), "rb");
+        if (!file) return records;
+
+        std::vector<char> buf(65536);
+        std::string line;
+        while (gzgets(file, buf.data(), static_cast<int>(buf.size())) != nullptr) {
+            line += buf.data();
+            if (!line.empty() && line.back() == '\n') {
+                if (line.size() > 1 && line[line.size() - 2] == '\r') {
+                    line.erase(line.size() - 2);
+                } else {
+                    line.pop_back();
+                }
+                parseLine(line);
+                line.clear();
+            }
+        }
+        if (!line.empty()) parseLine(line);
+        gzclose(file);
+        return records;
+    }
+
     std::ifstream file(path);
     if (!file.is_open()) return records;
 
     std::string line;
     while (std::getline(file, line)) {
-        if (line.empty() || line[0] != '{') continue;
-        auto val = parseJson(line);
-        if (!val.is_null()) records.push_back(std::move(val));
+        parseLine(line);
     }
     return records;
 }

--- a/include/gpufl/core/model/lifecycle_model.cpp
+++ b/include/gpufl/core/model/lifecycle_model.cpp
@@ -72,4 +72,26 @@ std::string SassConfigModel::buildJson() const {
     return oss.str();
 }
 
+std::string CaptureCapabilitiesModel::buildJson() const {
+    std::ostringstream oss;
+    oss << "{\"version\":1,\"type\":\"capture_capabilities\""
+        << ",\"session_id\":\"" << jsonEscape(e_.session_id) << "\""
+        << ",\"ts_ns\":" << e_.ts_ns
+        << ",\"requested_engine\":\"" << jsonEscape(e_.requested_engine) << "\""
+        << ",\"selected_engine\":\"" << jsonEscape(e_.selected_engine) << "\""
+        << ",\"capabilities\":[";
+    for (size_t i = 0; i < e_.capabilities.size(); ++i) {
+        const auto& c = e_.capabilities[i];
+        if (i) oss << ',';
+        oss << "{\"feature\":\"" << jsonEscape(c.feature) << "\""
+            << ",\"requested\":" << (c.requested ? "true" : "false")
+            << ",\"status\":\"" << jsonEscape(c.status) << "\""
+            << ",\"mode\":\"" << jsonEscape(c.mode) << "\""
+            << ",\"reason_code\":\"" << jsonEscape(c.reason_code) << "\""
+            << ",\"message\":\"" << jsonEscape(c.message) << "\"}";
+    }
+    oss << "]}";
+    return oss.str();
+}
+
 }  // namespace gpufl::model

--- a/include/gpufl/core/model/lifecycle_model.hpp
+++ b/include/gpufl/core/model/lifecycle_model.hpp
@@ -29,4 +29,12 @@ private:
     const SassConfigEvent& e_;
 };
 
+struct CaptureCapabilitiesModel final : IJsonSerializable {
+    explicit CaptureCapabilitiesModel(const CaptureCapabilitiesEvent& e) : e_(e) {}
+    std::string buildJson() const override;
+    Channel channel() const override { return Channel::All; }
+private:
+    const CaptureCapabilitiesEvent& e_;
+};
+
 }  // namespace gpufl::model

--- a/include/gpufl/core/monitor.cpp
+++ b/include/gpufl/core/monitor.cpp
@@ -465,18 +465,23 @@ void Monitor::Initialize(const MonitorOptions& opts) {
 void Monitor::Shutdown() {
     if (!g_initialized.exchange(false)) return;
 
-    // Stop the backend BEFORE joining the collector thread.
+    // Stop and tear down the backend BEFORE joining the collector thread.
+    //
     // CuptiBackend::stop() calls cuptiActivityFlushAll(1), which fires
-    // BufferCompleted → pushes kernel activity records to the ring buffer.
-    // If we join the collector first and THEN call stop() (via shutdown()),
-    // those records arrive after the collector has drained and they are lost.
-    // Calling stop() here ensures all records land in the ring buffer while
-    // the collector thread is still running and will consume them.
+    // BufferCompleted -> pushes activity records to the ring buffer. Some
+    // engines also emit final profiling rows from shutdown(); SassMetrics
+    // deliberately defers cuptiSassMetricsFlushData until shutdown to avoid
+    // mid-run PyTorch deadlocks. If we join the collector first and only then
+    // call backend shutdown, those final PC_SAMPLE rows arrive after the
+    // collector has drained and never become profile_sample_batch records.
+    //
+    // Keeping the collector alive until after backend shutdown ensures every
+    // final activity/profiling record lands in the ring buffer and is consumed.
     if (g_adapter) g_adapter->stop();
+    if (g_adapter) g_adapter->shutdown();
 
     g_collectorRunning.store(false);
     if (g_collectorThread.joinable()) g_collectorThread.join();
-    if (g_adapter) g_adapter->shutdown();
     g_adapter.reset();
 }
 

--- a/include/gpufl/core/monitor.hpp
+++ b/include/gpufl/core/monitor.hpp
@@ -42,10 +42,10 @@ enum class MonitorBackendKind {
  *
  * Compatibility matrix (NVIDIA backend):
  *
- *   PcSampling   + SassMetrics   → PcSamplingWithSass (shipping; alias "Deep").
- *                                  PC sampling uses hardware counters; SASS
- *                                  metrics uses software lazy cubin patching —
- *                                  disjoint mechanisms, can coexist.
+ *   PcSampling   + SassMetrics   → Deep (shipping). PC sampling uses
+ *                                  hardware counters; SASS metrics uses
+ *                                  software lazy cubin patching — disjoint
+ *                                  mechanisms, can coexist.
  *
  *   SassMetrics  + RangeProfiler → Possible in principle (no resource
  *                                  conflict — SASS is software-patching,
@@ -63,19 +63,33 @@ enum class MonitorBackendKind {
  *                                  client-side fix — would require NVIDIA
  *                                  to expose a counter-multiplexing API.
  *
- *   By extension: PcSamplingWithSass + RangeProfiler is also impossible
- *   (the PC-sampling half conflicts; the SASS half would be fine).
+ *   By extension: Deep + RangeProfiler is also impossible (the
+ *   PC-sampling half conflicts; the SASS half would be fine).
  */
 enum class ProfilingEngine {
-    None,                // Monitoring only — no profiling overhead
-    PcSampling,          // PC-level stall-reason sampling
-    SassMetrics,         // SASS instruction-level metrics
-    RangeProfiler,       // Perfworks hardware counters (requires GPUFL_HAS_PERFWORKS)
-    PcSamplingWithSass,  // PC sampling + SASS metrics in a single run
-
-    Continuous = PcSampling,
-    Deep       = PcSamplingWithSass,
-    Range      = RangeProfiler,
+    // A monotonic ladder of increasing capture depth + cost. One name
+    // per level, no aliases — the names are chosen so the option list
+    // reads clearly to someone who isn't a CUPTI expert. The plain
+    // intent is in each comment; the precise CUPTI mechanism is named
+    // where it's the real, doc-searchable term (PC sampling, SASS).
+    Monitor,        // No CUPTI at all — GPU/host health metrics only
+                    // (util, mem, temp, power). Lowest overhead and immune
+                    // to every CUPTI kernel-path failure mode (per-launch
+                    // cost, the CUDA 13.1 symbolName segfault, activity
+                    // buffer leakage). "Just watch my GPU." The default.
+    Trace,          // + Activity trace: every kernel, memcpy/memset, and
+                    // sync — name, duration, stream, grid/block. NOT
+                    // kernel-exclusive (hence "Trace", not "KernelTrace").
+                    // "What ran and how long."
+    PcSampling,     // + PC stall-reason sampling: where in each kernel the
+                    // GPU stalls. "Why is this kernel slow." (CUPTI PC Sampling)
+    SassMetrics,    // + Per-instruction SASS counters: executed / divergent
+                    // instruction counts per source line. (CUPTI SASS Metrics)
+    RangeProfiler,  // + Hardware throughput counters: SM / memory / tensor
+                    // utilization, L1/L2 hit rates, DRAM bandwidth.
+                    // (CUPTI Range Profiler; requires GPUFL_HAS_PERFWORKS)
+    Deep,           // PcSampling + SassMetrics in a single run — the
+                    // deepest single-session profile. (Was PcSamplingWithSass.)
 };
 
 struct MonitorOptions {
@@ -110,7 +124,11 @@ struct MonitorOptions {
     // samples per hot range, not 10⁶. Users doing fine-grained stall
     // attribution can lower this back via InitOptions.
     uint32_t pc_sampling_period = 16;
-    ProfilingEngine profiling_engine = ProfilingEngine::None;
+    // Default Monitor: no CUPTI. The user-facing default lives on
+    // InitOptions (gpufl.hpp); this internal default matches it so a
+    // bare MonitorOptions (e.g. the system-monitor daemon, which only
+    // wants telemetry) doesn't accidentally subscribe CUPTI.
+    ProfilingEngine profiling_engine = ProfilingEngine::Monitor;
     MonitorBackendKind backend_kind = MonitorBackendKind::Auto;
 };
 

--- a/include/gpufl/core/monitor.hpp
+++ b/include/gpufl/core/monitor.hpp
@@ -149,7 +149,7 @@ struct MonitorOptions {
     // statistical signal for "which PCs dominate" needs maybe 10⁴
     // samples per hot range, not 10⁶. Users doing fine-grained stall
     // attribution can lower this back via InitOptions.
-    uint32_t pc_sampling_period = 16;
+    uint32_t pc_sampling_period = 10;
     // Default Monitor: no CUPTI. The user-facing default lives on
     // InitOptions (gpufl.hpp); this internal default matches it so a
     // bare MonitorOptions (e.g. the system-monitor daemon, which only

--- a/include/gpufl/core/monitor.hpp
+++ b/include/gpufl/core/monitor.hpp
@@ -92,6 +92,32 @@ enum class ProfilingEngine {
                     // deepest single-session profile. (Was PcSamplingWithSass.)
 };
 
+inline const char* ProfilingEngineWireName(const ProfilingEngine engine) {
+    switch (engine) {
+        case ProfilingEngine::Monitor:       return "nvidia.none";
+        case ProfilingEngine::Trace:         return "nvidia.trace";
+        case ProfilingEngine::PcSampling:    return "nvidia.pc_sampling";
+        case ProfilingEngine::SassMetrics:   return "nvidia.sass_metrics";
+        case ProfilingEngine::RangeProfiler: return "nvidia.range_profiler";
+        case ProfilingEngine::Deep:          return "nvidia.pc_sampling_with_sass";
+    }
+    return "nvidia.unknown";
+}
+
+inline const char* ProfilingEngineSessionKind(const ProfilingEngine engine) {
+    switch (engine) {
+        case ProfilingEngine::Monitor:
+        case ProfilingEngine::Trace:
+            return "monitor";
+        case ProfilingEngine::PcSampling:
+        case ProfilingEngine::SassMetrics:
+        case ProfilingEngine::RangeProfiler:
+        case ProfilingEngine::Deep:
+            return "trace";
+    }
+    return "monitor";
+}
+
 struct MonitorOptions {
     bool enable_debug_output = false;
     bool enable_stack_trace = false;

--- a/include/gpufl/core/monitor_adapter.cpp
+++ b/include/gpufl/core/monitor_adapter.cpp
@@ -11,6 +11,17 @@
 namespace gpufl {
 
 std::unique_ptr<IMonitorAdapter> CreateMonitorAdapter(const MonitorOptions& opts) {
+    // ProfilingEngine::Monitor means telemetry-only — no CUPTI at all.
+    // Return no adapter so Monitor never subscribes CUPTI callbacks or
+    // enables activity kinds. Monitor::Start/Stop/Shutdown are all
+    // null-adapter safe, and the collector thread + NVML telemetry
+    // sampler are created independently of the adapter, so scopes and
+    // GPU/host metrics still flow. This is the path that's immune to
+    // every CUPTI kernel-path failure mode (per-launch overhead,
+    // symbolName segfault, buffer leakage), which is why it's the default.
+    if (opts.profiling_engine == ProfilingEngine::Monitor) {
+        return nullptr;
+    }
     switch (opts.backend_kind) {
         case MonitorBackendKind::Nvidia:
 #if GPUFL_ENABLE_NVIDIA && GPUFL_HAS_CUDA

--- a/include/gpufl/gpufl.hpp
+++ b/include/gpufl/gpufl.hpp
@@ -93,14 +93,20 @@ struct InitOptions {
     // the kind. Cost when on: one record per cudaGraphLaunch (very
     // low volume).
     bool enable_cuda_graphs_tracking = false;
-    // Default: PC Sampling alone. The cubin-disassembly pipeline
-    // (ResourceHandler + nvdisasm) already provides SASS listings and
-    // source correlation, so PC Sampling gives users the full SASS view
-    // plus stall reasons. Opt into SassMetrics or PcSamplingWithSass only
-    // when per-instruction execution/divergence counters are needed —
-    // those paths use CUPTI kernel replay and are ~100× more expensive
-    // on pre-sm_120 GPUs.
-    ProfilingEngine profiling_engine = ProfilingEngine::PcSampling;
+    // Default: Monitor — telemetry only (GPU/host metrics), no CUPTI
+    // kernel capture. The safe, lowest-overhead default: it can't hit
+    // the CUPTI kernel-path overhead (PyTorch training saw +650% under
+    // PC Sampling) or the kernel-path crash/hang modes, and it's all a
+    // "just watch my GPU" user needs.
+    //
+    // Opt in explicitly for tracing/profiling, in order of cost:
+    //   Trace         — per-op timeline (kernels, memcpy, sync)
+    //   PcSampling    — + stall-reason sampling ("why is it slow")
+    //   SassMetrics   — + per-instruction counters (CUPTI replay,
+    //                   ~100× costlier on pre-sm_120 GPUs)
+    //   RangeProfiler — hardware throughput counters (SM/mem/tensor util)
+    //   Deep          — PcSampling + SassMetrics in one run
+    ProfilingEngine profiling_engine = ProfilingEngine::Monitor;
 
     // ── Configuration sources, in precedence order (low → high) ────────────
     //

--- a/include/gpufl/report/text_report.cpp
+++ b/include/gpufl/report/text_report.cpp
@@ -96,6 +96,7 @@ std::string capabilityStatusLabel(const std::string& status) {
     if (status == "fallback") return "fallback";
     if (status == "partial") return "partial";
     if (status == "skipped") return "skipped";
+    if (status == "enabled_no_data") return "on, no data";
     if (status == "not_requested") return "not requested";
     return status.empty() ? "unknown" : status;
 }

--- a/include/gpufl/report/text_report.cpp
+++ b/include/gpufl/report/text_report.cpp
@@ -1038,6 +1038,18 @@ void TextReport::writeProfileAnalysis(std::ostringstream& out) const {
     out << "\n" << SEP << "\n  Profile / SASS Analysis\n" << SEP << "\n";
     if (profile_samples_.empty()) { out << "  (No profile sample data)\n"; return; }
 
+    const bool hasNonZeroSample = std::any_of(
+        profile_samples_.begin(), profile_samples_.end(),
+        [](const ProfileSampleRecord& ps) { return ps.metric_value > 0; });
+    if (!hasNonZeroSample) {
+        out << "  (Profile sample rows were present, but every metric value was 0.)\n";
+        if (sass_active_) {
+            out << "  SASS instrumentation was configured, but CUPTI returned no "
+                   "non-zero SASS counter values for this session.\n";
+        }
+        return;
+    }
+
     // Convert a raw CUPTI stall metric name to a human-readable short name.
     // e.g. "smsp__pcsamp_warps_issue_stalled_wait_not_issued" → "Wait (not issued)"
     auto shortenStallName = [](const std::string& raw) -> std::string {

--- a/include/gpufl/report/text_report.cpp
+++ b/include/gpufl/report/text_report.cpp
@@ -77,6 +77,29 @@ std::string truncate(const std::string& s, size_t maxLen) {
     return (s.size() > maxLen) ? s.substr(0, maxLen - 3) + "..." : s;
 }
 
+std::string titleFromSnake(std::string s) {
+    bool capNext = true;
+    for (char& ch : s) {
+        if (ch == '_') {
+            ch = ' ';
+            capNext = true;
+        } else if (capNext) {
+            ch = static_cast<char>(std::toupper(static_cast<unsigned char>(ch)));
+            capNext = false;
+        }
+    }
+    return s;
+}
+
+std::string capabilityStatusLabel(const std::string& status) {
+    if (status == "collected") return "collected";
+    if (status == "fallback") return "fallback";
+    if (status == "partial") return "partial";
+    if (status == "skipped") return "skipped";
+    if (status == "not_requested") return "not requested";
+    return status.empty() ? "unknown" : status;
+}
+
 const std::map<int, std::string> kCopyKindNames = {
     {1, "HtoD"}, {2, "DtoH"}, {3, "HtoA"}, {4, "AtoH"},
     {5, "AtoA"}, {6, "AtoD"}, {7, "DtoA"}, {8, "DtoD"},
@@ -103,21 +126,33 @@ std::string resolveStallReason(int reason) {
     return (it != kStallNames.end()) ? it->second : "Stall_" + std::to_string(reason);
 }
 
-// Resolve log file path for a given channel
+// Resolve log file path for a given channel. Supports both the legacy
+// flat layout (<prefix>.<channel>.log) and the v1.2 session-directory layout
+// (<session>/<channel>.log.gz).
 std::string resolveLogPath(const std::string& dir, const std::string& prefix,
                            const std::string& channel) {
     std::string base = prefix;
     if (base.size() > 4 && base.substr(base.size() - 4) == ".log")
         base = base.substr(0, base.size() - 4);
 
-    fs::path active = fs::path(dir) / (base + "." + channel + ".log");
-    if (fs::exists(active)) return active.string();
+    const fs::path root(dir);
+    std::vector<fs::path> direct;
+    if (base.empty()) {
+        direct.push_back(root / (channel + ".log"));
+        direct.push_back(root / (channel + ".log.gz"));
+    } else {
+        direct.push_back(root / (base + "." + channel + ".log"));
+        direct.push_back(root / (base + "." + channel + ".log.gz"));
+    }
+    for (const auto& path : direct) {
+        if (fs::exists(path)) return path.string();
+    }
 
     std::vector<std::pair<int, std::string>> candidates;
     std::error_code ec;
-    for (auto& entry : fs::directory_iterator(dir, ec)) {
+    for (auto& entry : fs::directory_iterator(root, ec)) {
         const std::string name = entry.path().filename().string();
-        const std::string pat = base + "." + channel + ".";
+        const std::string pat = base.empty() ? (channel + ".") : (base + "." + channel + ".");
         if (name.rfind(pat, 0) == 0) {
             std::string rest = name.substr(pat.size());
             auto dotPos = rest.find(".log");
@@ -214,9 +249,33 @@ void TextReport::parseLogFiles(const Options& opts) {
         parseDictionaries(*recs, kernel_dict, scope_name_dict, function_dict, metric_dict);
 
     // Pass 2: typed records
+    for (const auto* recs : {&deviceRecords, &scopeRecords, &systemRecords})
+        parseCaptureCapabilities(*recs);
     parseDeviceLog(deviceRecords, kernel_dict);
     parseScopeLog(scopeRecords, scope_name_dict, function_dict, metric_dict);
     parseSystemLog(systemRecords);
+}
+
+void TextReport::parseCaptureCapabilities(const std::vector<JsonValue>& records) {
+    for (const auto& rec : records) {
+        if (rec.value<std::string>("type", "") != "capture_capabilities") continue;
+        if (!rec.contains("capabilities") || !rec["capabilities"].is_array()) continue;
+
+        requested_engine_ = rec.value<std::string>("requested_engine", requested_engine_);
+        selected_engine_ = rec.value<std::string>("selected_engine", selected_engine_);
+        capture_capabilities_.clear();
+        for (const auto& cap : rec["capabilities"].get_array()) {
+            if (!cap.is_object()) continue;
+            CaptureCapabilityRecord row;
+            row.feature = cap.value<std::string>("feature", "");
+            row.requested = cap.value<bool>("requested", false);
+            row.status = cap.value<std::string>("status", "");
+            row.mode = cap.value<std::string>("mode", "");
+            row.reason_code = cap.value<std::string>("reason_code", "");
+            row.message = cap.value<std::string>("message", "");
+            if (!row.feature.empty()) capture_capabilities_.push_back(std::move(row));
+        }
+    }
 }
 
 void TextReport::parseDictionaries(const std::vector<JsonValue>& records,
@@ -494,6 +553,32 @@ void TextReport::writeSessionSummary(std::ostringstream& out) const {
         if (info_.l2_cache_size > 0)
             out << "    L2 Cache:           " << fmtBytes(info_.l2_cache_size) << "\n";
     }
+
+    if (!capture_capabilities_.empty()) {
+        out << "\n  Capabilities:\n";
+        if (!requested_engine_.empty())
+            out << "    Requested Engine:   " << requested_engine_ << "\n";
+        if (!selected_engine_.empty())
+            out << "    Selected Engine:    " << selected_engine_ << "\n";
+        out << "    " << std::left << std::setw(24) << "Feature"
+            << std::setw(15) << "Status"
+            << std::setw(24) << "Mode"
+            << "Note" << std::right << "\n";
+        out << "    " << std::string(76, '-') << "\n";
+        for (const auto& cap : capture_capabilities_) {
+            std::string note;
+            if (!cap.reason_code.empty()) note = cap.reason_code;
+            else if (!cap.message.empty()) note = cap.message;
+            else if (!cap.requested) note = "not requested";
+
+            out << "    " << std::left
+                << std::setw(24) << truncate(titleFromSnake(cap.feature), 22)
+                << std::setw(15) << truncate(capabilityStatusLabel(cap.status), 13)
+                << std::setw(24) << truncate(cap.mode.empty() ? "-" : cap.mode, 22)
+                << truncate(note, 42)
+                << std::right << "\n";
+        }
+    }
 }
 
 void TextReport::writeKernelSummary(std::ostringstream& out) const {
@@ -506,7 +591,6 @@ void TextReport::writeKernelSummary(std::ostringstream& out) const {
                    [](const KernelRecord& k) { return k.duration_ms; });
 
     double totalMs = std::accumulate(durations.begin(), durations.end(), 0.0);
-    auto [minIt, maxIt] = std::minmax_element(durations.begin(), durations.end());
     std::sort(durations.begin(), durations.end());
 
     auto pctile = [&durations](double p) -> double {
@@ -539,8 +623,8 @@ void TextReport::writeKernelSummary(std::ostringstream& out) const {
     out << "  Median Duration:      " << fmtDuration(durations[durations.size() / 2]) << "\n";
     out << "  P90 Duration:         " << fmtDuration(pctile(0.90)) << "\n";
     out << "  P99 Duration:         " << fmtDuration(pctile(0.99)) << "\n";
-    out << "  Min Duration:         " << fmtDuration(*minIt) << "\n";
-    out << "  Max Duration:         " << fmtDuration(*maxIt) << "\n";
+    out << "  Min Duration:         " << fmtDuration(durations.front()) << "\n";
+    out << "  Max Duration:         " << fmtDuration(durations.back()) << "\n";
 
     if (sass_active_)
         out << "\n  Note: SASS metrics were active - kernel durations include "

--- a/include/gpufl/report/text_report.hpp
+++ b/include/gpufl/report/text_report.hpp
@@ -119,6 +119,15 @@ class TextReport {
         int l2_cache_size = 0;
     };
 
+    struct CaptureCapabilityRecord {
+        std::string feature;
+        bool requested = false;
+        std::string status;
+        std::string mode;
+        std::string reason_code;
+        std::string message;
+    };
+
     // Aggregation helper used by multiple sections
     struct AggStats {
         int count = 0;
@@ -137,6 +146,9 @@ class TextReport {
     std::vector<HostMetricRecord> host_metrics_;
     std::vector<ScopeEventRecord> scope_events_;
     std::vector<ProfileSampleRecord> profile_samples_;
+    std::vector<CaptureCapabilityRecord> capture_capabilities_;
+    std::string requested_engine_;
+    std::string selected_engine_;
     bool sass_active_ = false;
     int top_n_;
 
@@ -155,6 +167,7 @@ class TextReport {
                        const std::unordered_map<int, std::string>& function_dict,
                        const std::unordered_map<int, std::string>& metric_dict);
     void parseSystemLog(const std::vector<JsonValue>& records);
+    void parseCaptureCapabilities(const std::vector<JsonValue>& records);
     void mergeKernelDetails(std::unordered_map<unsigned, JsonValue>& details);
 
     static void parseJobStart(const JsonValue& record, SessionInfo& info);

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "gpufl"
-version = "1.1.0rc1"
+version = "1.1.0rc2"
 description = "GPU Monitoring Client"
 readme = "README.md"
 authors = [

--- a/python/bindings.cpp
+++ b/python/bindings.cpp
@@ -49,12 +49,13 @@ private:
 PYBIND11_MODULE(_gpufl_client, m) {
     m.doc() = "GPUFL Internal C++ Binding";
 
-    // BackendKind / ProfilingEngine both have a "None" value, which is a
-    // Python keyword — accessible as ProfilingEngine.__members__["None"]
-    // but ugly. Add a `None_` Python alias on each enum so users can write
-    // `gpufl.ProfilingEngine.None_` directly. The underscore-suffix is the
-    // standard Python convention for keyword-clashing names (mirrors
-    // pybind11's `class_`, `type_`, etc.).
+    // BackendKind has a "None" value, which is a Python keyword —
+    // accessible as BackendKind.__members__["None"] but ugly. Add a
+    // `None_` alias so users can write `gpufl.BackendKind.None_`. The
+    // underscore-suffix is the standard Python convention for
+    // keyword-clashing names (mirrors pybind11's `class_`, `type_`).
+    // (ProfilingEngine no longer has a "None" member — its floor is
+    // `Monitor` — so it needs no such alias.)
     auto backendKindEnum = py::enum_<gpufl::BackendKind>(m, "BackendKind")
         .value("Auto",   gpufl::BackendKind::Auto)
         .value("Nvidia", gpufl::BackendKind::Nvidia)
@@ -63,28 +64,17 @@ PYBIND11_MODULE(_gpufl_client, m) {
         .export_values();
     backendKindEnum.attr("None_") = backendKindEnum.attr("__members__")[py::str("None")];
 
-    auto profilingEngineEnum = py::enum_<gpufl::ProfilingEngine>(m, "ProfilingEngine")
-        .value("None",               gpufl::ProfilingEngine::None)
-        .value("PcSampling",         gpufl::ProfilingEngine::PcSampling)
-        .value("SassMetrics",        gpufl::ProfilingEngine::SassMetrics)
-        .value("RangeProfiler",      gpufl::ProfilingEngine::RangeProfiler)
-        .value("PcSamplingWithSass", gpufl::ProfilingEngine::PcSamplingWithSass)
+    // Six canonical names, one per level, no aliases — see the enum in
+    // monitor.hpp for the naming rationale (clarity-first, plain intent
+    // with the precise CUPTI term where it's the searchable one).
+    py::enum_<gpufl::ProfilingEngine>(m, "ProfilingEngine")
+        .value("Monitor",       gpufl::ProfilingEngine::Monitor)
+        .value("Trace",         gpufl::ProfilingEngine::Trace)
+        .value("PcSampling",    gpufl::ProfilingEngine::PcSampling)
+        .value("SassMetrics",   gpufl::ProfilingEngine::SassMetrics)
+        .value("RangeProfiler", gpufl::ProfilingEngine::RangeProfiler)
+        .value("Deep",          gpufl::ProfilingEngine::Deep)
         .export_values();
-    profilingEngineEnum.attr("None_") = profilingEngineEnum.attr("__members__")[py::str("None")];
-    // Friendly aliases — Phase 1 of mode renaming. Bound as class
-    // attributes pointing at the existing enum entries (not as
-    // additional `.value()` calls, which would either fight pybind11's
-    // deduplication or end up shadowing the canonical name in repr).
-    // gpufl.ProfilingEngine.Deep is the same value as
-    // gpufl.ProfilingEngine.PcSamplingWithSass, and repr() will still
-    // show the technical name. See
-    // gpufl-manual/client/mode-data-layers.html for naming rationale.
-    profilingEngineEnum.attr("Continuous") =
-        profilingEngineEnum.attr("__members__")[py::str("PcSampling")];
-    profilingEngineEnum.attr("Deep") =
-        profilingEngineEnum.attr("__members__")[py::str("PcSamplingWithSass")];
-    profilingEngineEnum.attr("Range") =
-        profilingEngineEnum.attr("__members__")[py::str("RangeProfiler")];
 
     py::class_<gpufl::InitOptions>(m, "InitOptions")
         .def(py::init<>())
@@ -185,7 +175,7 @@ PYBIND11_MODULE(_gpufl_client, m) {
        py::arg("enable_debug_output")         = false,
        py::arg("enable_stack_trace")          = false,
        py::arg("enable_source_collection")    = true,
-       py::arg("profiling_engine")            = gpufl::ProfilingEngine::PcSampling,
+       py::arg("profiling_engine")            = gpufl::ProfilingEngine::Monitor,
        py::arg("config_file")                 = "",
        py::arg("backend_url")                 = "",
        py::arg("api_key")                     = "",

--- a/python/gpufl/__init__.py
+++ b/python/gpufl/__init__.py
@@ -57,6 +57,127 @@ if os.name == 'nt':
                 if d not in os.environ.get('PATH', ''):
                     os.environ['PATH'] = d + os.pathsep + os.environ.get('PATH', '')
 
+
+# 1b. Linux: preload the MATCHING PerfWorks libraries before the C extension.
+#
+# gpufl's _gpufl_client.so links libnvperf_host.so / libnvperf_target.so
+# DIRECTLY (DT_NEEDED — see the NVPERF block in CMakeLists.txt), so the
+# dynamic loader resolves them the instant the extension is imported,
+# long before any of our initialize() code runs. In a PyTorch venv the
+# recommended import order is `torch` THEN `gpufl`; by the time gpufl
+# imports, torch has already loaded the pip `nvidia-cuXX` libcupti.so —
+# but NOT nvperf (torch doesn't touch PerfWorks at import). So our NEEDED
+# libnvperf_host.so has nothing resident to dedupe against, and the
+# loader finds the SYSTEM copy via ldconfig (/usr/local/cuda/.../
+# libnvperf_host.so). The result is venv CUPTI + system PerfWorks — a
+# split install that SEGFAULTS in NVPW_CUDA_LoadDriver the first time PC
+# sampling (PcSampling) or the Profiler API (SassMetrics / RangeProfiler
+# / Deep) runs. It "sometimes works" only when something happened to make
+# the matching nvperf resident first.
+#
+# `LD_LIBRARY_PATH=<venv>/nvidia/cuXX/lib` fixes it by winning that first
+# resolution. We do the same automatically and deterministically: find
+# the directory of the libcupti that's already mapped into the process
+# (torch loaded it; nvperf ships in the SAME wheel dir, so versions are
+# guaranteed to match) and preload its sibling PerfWorks libs with
+# RTLD_GLOBAL, in dependency order (target before host) so soname-dedup
+# binds our NEEDED entries to the matching copies. Best-effort and
+# silent; set GPUFL_DEBUG_PRELOAD=1 to trace what was preloaded.
+def _preload_matching_perfworks():
+    if not sys.platform.startswith('linux'):
+        return
+    import ctypes
+    import glob as _glob
+
+    # RTLD_LAZY|RTLD_GLOBAL — same flags the C++ side uses. GLOBAL so the
+    # symbols/soname win subsequent NEEDED resolutions; LAZY so we don't
+    # force-bind symbols that depend on libs not resident yet at import.
+    _mode = os.RTLD_LAZY | os.RTLD_GLOBAL
+
+    _debug = os.environ.get('GPUFL_DEBUG_PRELOAD', '').strip().lower() in (
+        '1', 'true', 'yes', 'on')
+
+    def _dbg(msg):
+        if _debug:
+            print(f"[gpufl] perfworks-preload: {msg}", file=sys.stderr)
+
+    candidate_dirs = []
+    # (1) Strongest signal: the directory of a libcupti already mapped
+    #     into this process. nvperf MUST match that CUPTI's CUDA version,
+    #     and it ships in the same wheel directory.
+    try:
+        with open('/proc/self/maps', 'r') as _maps:
+            for line in _maps:
+                slash = line.find('/')
+                if slash == -1:
+                    continue
+                path = line[slash:].rstrip()
+                if os.path.basename(path).startswith('libcupti.so'):
+                    d = os.path.dirname(path)
+                    if d and d not in candidate_dirs:
+                        candidate_dirs.append(d)
+    except OSError:
+        pass
+
+    # (2) Lower-priority fallback: nvidia CUDA wheels under site-packages.
+    #     Appended AFTER the libcupti dirs (which are preferred because
+    #     they're version-matched), so it covers (a) gpufl imported before
+    #     torch / pure-gpufl processes, and (b) torch bundling its libcupti
+    #     in a dir that has no sibling nvperf (e.g. torch/lib) — the loop
+    #     below skips dirs without the PerfWorks set and falls through here.
+    roots = []
+    try:
+        import importlib.util
+        spec = importlib.util.find_spec('nvidia')
+        if spec and spec.submodule_search_locations:
+            roots.extend(list(spec.submodule_search_locations))
+    except Exception:
+        pass
+    try:
+        _site = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        roots.append(os.path.join(_site, 'nvidia'))
+    except Exception:
+        pass
+    for root in roots:
+        for d in _glob.glob(os.path.join(root, '*', 'lib')):
+            if d not in candidate_dirs:
+                candidate_dirs.append(d)
+
+    # A heavy pipeline (torch + torchvision + other CUDA extensions) can
+    # have MORE THAN ONE libcupti resident — e.g. the pip venv copy AND a
+    # system /usr/local/cuda copy. /proc/self/maps order is by address, not
+    # load order, so "first seen" is arbitrary and could point at the
+    # system dir while gpufl actually binds the venv CUPTI (→ we'd preload
+    # the wrong, mismatched nvperf). gpufl is a pip wheel and binds the pip
+    # CUPTI, so prefer site-packages dirs. Stable sort keeps relative order
+    # within each group.
+    candidate_dirs.sort(key=lambda p: 0 if 'site-packages' in p else 1)
+
+    _dbg(f"candidate dirs: {candidate_dirs}")
+
+    # Preload from the FIRST directory that actually has the PerfWorks
+    # set. Loading a second CUDA version's nvperf would soname-collide
+    # with the first (identical SONAME, different ABI), so stop after one.
+    for d in candidate_dirs:
+        if not _glob.glob(os.path.join(d, 'libnvperf_host.so*')):
+            continue
+        loaded_any = False
+        for pattern in ('libnvperf_target.so*', 'libpcsamplingutil.so*',
+                        'libnvperf_host.so*'):
+            for so in sorted(_glob.glob(os.path.join(d, pattern))):
+                try:
+                    ctypes.CDLL(so, mode=_mode)
+                    loaded_any = True
+                    _dbg(f"loaded {so}")
+                except OSError as exc:
+                    _dbg(f"skip {so} ({exc})")
+        if loaded_any:
+            break
+
+
+_preload_matching_perfworks()
+
+
 # 2. Import C++ Core Bindings
 try:
     from ._gpufl_client import (
@@ -95,17 +216,13 @@ except ImportError as e:
         None_ = "None"
 
     class ProfilingEngine:
-        None_              = "None"
-        PcSampling         = "PcSampling"
-        SassMetrics        = "SassMetrics"
-        RangeProfiler      = "RangeProfiler"
-        PcSamplingWithSass = "PcSamplingWithSass"
-        # Friendly aliases — mirror the pybind11 ProfilingEngine attrs
-        # added in bindings.cpp. Identical string values so equality
-        # checks against the technical names still work in stub mode.
-        Continuous         = "PcSampling"
-        Deep               = "PcSamplingWithSass"
-        Range              = "RangeProfiler"
+        # Six canonical names, no aliases — mirrors the C++ enum.
+        Monitor       = "Monitor"
+        Trace         = "Trace"
+        PcSampling    = "PcSampling"
+        SassMetrics   = "SassMetrics"
+        RangeProfiler = "RangeProfiler"
+        Deep          = "Deep"
 
     class InitOptions:
         def __init__(self):
@@ -119,7 +236,7 @@ except ImportError as e:
             self.enable_stack_trace = False
             self.enable_source_collection = True
             self.flush_logs_always = False
-            self.profiling_engine = ProfilingEngine.PcSampling
+            self.profiling_engine = ProfilingEngine.Monitor
             self.config_file = ""
             self.backend_url = ""
             self.api_key = ""
@@ -174,7 +291,7 @@ except Exception as e:
     print(f"[FATAL] Unexpected error importing _gpufl_client: {e}", file=sys.stderr)
     raise e
 
-__version__ = "0.1.0.dev"
+__version__ = "1.1.0rc2"
 
 # ── Backend upload ────────────────────────────────────────────────────────────
 #
@@ -250,6 +367,64 @@ class _NoopUploadResult:
         return ("<UploadResult success=True events=0 bytes=0 files=0 "
                 "warnings=1 spool_ids=0 elapsed_ms=0 (disabled)>")
 
+def _apply_eager_module_loading(profiling_engine):
+    """Optionally set CUDA_MODULE_LOADING=EAGER — opt-in only.
+
+    EAGER is now OPT-IN. By default gpufl leaves CUDA on its normal LAZY
+    module loading. The per-architecture SASS exclusion gate
+    (GPUFL_SASS_EXCLUDE_ARCHS, read by the C++ SASS engine) is the default
+    mechanism for the lazy-patching deadlock: it disables SASS only on
+    architectures confirmed to hang (e.g. RTX 3090 / sm_86) instead of
+    paying EAGER's whole-process startup + memory cost on every machine.
+
+    EAGER stays available as an alternative per-run workaround. CUPTI's SASS
+    instrumentation + LAZY module loading can deadlock under concurrent
+    kernel launches (PyTorch): each kernel's module is finalized AND
+    SASS-patched on its first launch, and many such first-launches racing
+    across threads invert CUPTI/driver locks. EAGER finalizes every module
+    up front while the process is quiescent, closing that window.
+
+    Overrides:
+      * GPUFL_EAGER_MODULE_LOADING=1|true|yes|on → force EAGER for this run.
+      * Unset / anything else                    → leave CUDA on LAZY (default).
+      * An existing CUDA_MODULE_LOADING (set by the user) is always honored.
+
+    Must run before the CUDA context is created. In the recommended order
+    (`import torch` → `import gpufl` → `gpufl.init()` → train) the context
+    isn't created until the first CUDA op in the loop, so setting it at the
+    top of init() takes effect.
+    """
+    # Opt-in only: act solely when GPUFL_EAGER_MODULE_LOADING is truthy.
+    # (profiling_engine is kept for call-site compatibility / future use.)
+    knob = os.environ.get('GPUFL_EAGER_MODULE_LOADING', '').strip().lower()
+    if knob not in ('1', 'true', 'yes', 'on'):
+        return  # default: leave CUDA on LAZY module loading
+
+    if os.environ.get('CUDA_MODULE_LOADING'):
+        return  # respect a value the user set themselves
+
+    # If CUDA is already up, the env is read-at-context-creation, so setting
+    # it now is a no-op — warn instead of silently doing nothing. Only peek
+    # at torch if it's already imported (never import it here).
+    _torch = sys.modules.get('torch')
+    if _torch is not None:
+        try:
+            if _torch.cuda.is_initialized():
+                import warnings
+                warnings.warn(
+                    "[gpufl] CUDA is already initialized, so setting "
+                    "CUDA_MODULE_LOADING=EAGER now has no effect. SASS/Deep "
+                    "profiling can deadlock under CUDA's default lazy module "
+                    "loading; set CUDA_MODULE_LOADING=EAGER on the command "
+                    "line (before the process starts) to avoid it.",
+                    RuntimeWarning, stacklevel=3)
+                return
+        except Exception:
+            pass
+
+    os.environ['CUDA_MODULE_LOADING'] = 'EAGER'
+
+
 # Wrap the C++ init to apply env-var fallbacks for backend_url and
 # api_key, and to reject removed kwargs with a clear TypeError.
 _original_init = init
@@ -314,6 +489,14 @@ def init(*args, backend_url=None, api_key=None, remote_upload=None,
     # this process disabled it. Lets the same interpreter session run
     # disabled-then-enabled tests / notebooks without restarting.
     _disabled = False
+
+    # EAGER module loading is OPT-IN (default: CUDA's normal LAZY). The
+    # per-architecture SASS exclusion gate (GPUFL_SASS_EXCLUDE_ARCHS) is the
+    # default guard for the CUPTI lazy-patching deadlock. Set
+    # GPUFL_EAGER_MODULE_LOADING=1 to force EAGER for this run instead — must
+    # happen before the training loop creates the CUDA context, hence here.
+    _apply_eager_module_loading(kwargs.get('profiling_engine'))
+
     # Backward-compat shim: `sampling_auto_start` was renamed to
     # `continuous_system_sampling` because the old name only described
     # init-time auto-start and missed the new scope-bracketing behavior

--- a/python/gpufl/analyzer/analyzer.py
+++ b/python/gpufl/analyzer/analyzer.py
@@ -120,6 +120,28 @@ class GpuFlightSession:
             if not shut.empty and 'ts_ns' in shut.columns and self.session_end_ns is None:
                 self.session_end_ns = pd.to_numeric(shut.iloc[-1]['ts_ns'], errors='coerce')
 
+        # 2b. Capture capabilities — what was actually collected vs. enabled
+        # but empty vs. skipped. Emitted once at shutdown (type
+        # 'capture_capabilities'), routed to all channels.
+        self.requested_engine = None
+        self.selected_engine = None
+        self.capture_capabilities = []
+        for df in [device_df, scope_df, system_df]:
+            if df.empty or 'type' not in df.columns:
+                continue
+            caps = df[df['type'] == 'capture_capabilities']
+            if caps.empty:
+                continue
+            row = caps.iloc[-1]
+            if 'requested_engine' in caps.columns:
+                self.requested_engine = row.get('requested_engine')
+            if 'selected_engine' in caps.columns:
+                self.selected_engine = row.get('selected_engine')
+            cap_list = row.get('capabilities') if 'capabilities' in caps.columns else None
+            if isinstance(cap_list, list):
+                self.capture_capabilities = cap_list
+            break
+
         # 3. Detect format: batch (new) vs per-event (old)
         _BATCH_TYPES = {
             'kernel_event_batch', 'memcpy_event_batch', 'device_metric_batch',

--- a/python/gpufl/analyzer/analyzer.py
+++ b/python/gpufl/analyzer/analyzer.py
@@ -68,8 +68,14 @@ class GpuFlightSession:
         self.console = Console()
         self.max_stack_depth = max_stack_depth
         self.app_name = None
+        self._requested_session = session_id
 
-        # 1. Load raw DataFrames from JSONL
+        # 1. Load raw DataFrames from JSONL. Channel logs live either flat in
+        #    `log_dir` (legacy / demo layout) or nested under a per-run session
+        #    subdir written by the current client
+        #    (<log_dir>/<session_id>/<channel>.log[.gz]). Resolve which dir
+        #    actually holds this run's logs before loading.
+        self._read_dir = self._resolve_read_dir(session_id)
         device_df = self._load_log(self._resolve_log_path(log_prefix, "device"))
         scope_df  = self._load_log(self._resolve_log_path(log_prefix, "scope"))
         system_df = self._load_log(self._resolve_log_path(log_prefix, "system"))
@@ -246,30 +252,74 @@ class GpuFlightSession:
 
     # ── Log loading ───────────────────────────────────────────────────────────
 
-    def _resolve_log_path(self, log_prefix: str, channel: str) -> Path | None:
-        """Find a channel log path for current naming + rotation scheme.
+    def _resolve_read_dir(self, session_id: str = None) -> Path:
+        """Directory that actually holds this run's channel logs.
 
-        Preferred order:
-        1) <prefix>.<channel>.log
-        2) latest rotated file (<prefix>.<channel>.<N>.log[.gz], lowest N wins)
+        Two on-disk layouts are supported:
+          * flat (legacy / demo):    <log_dir>/[<prefix>.]<channel>.log[.gz]
+          * nested (current client): <log_dir>/<session_id>/<channel>.log[.gz]
+
+        If channel logs sit directly in `log_dir` we use it as-is; otherwise we
+        descend into a session subdir, preferring an exact `session_id` match
+        and falling back to the most-recently-written run.
+        """
+        if self._dir_has_any_channel(self.log_dir):
+            return self.log_dir
+        try:
+            subs = [p for p in self.log_dir.iterdir()
+                    if p.is_dir() and self._dir_has_any_channel(p)]
+        except (OSError, FileNotFoundError):
+            subs = []
+        if not subs:
+            return self.log_dir  # nothing found — _load_log() no-ops gracefully
+        if session_id:
+            exact = [p for p in subs if p.name == session_id]
+            if exact:
+                return exact[0]
+        return max(subs, key=lambda p: p.stat().st_mtime)
+
+    @staticmethod
+    def _dir_has_any_channel(d: Path) -> bool:
+        rx = re.compile(r"^(?:.+\.)?(?:device|scope|system)(?:\.\d+)?\.log(?:\.gz)?$")
+        try:
+            return any(rx.match(p.name) for p in d.iterdir() if p.is_file())
+        except (OSError, FileNotFoundError):
+            return False
+
+    def _resolve_log_path(self, log_prefix: str, channel: str) -> "Path | None":
+        """Find the best file for `channel` under the resolved read dir.
+
+        Handles current (bare `<channel>.log[.gz]`) and legacy
+        (`<prefix>.<channel>.log[.gz]`) names, active and rotated
+        (`...<channel>.<N>.log[.gz]`), compressed or not. Active wins over
+        rotated; among rotated the lowest index wins; uncompressed breaks ties.
         """
         base = log_prefix[:-4] if log_prefix.endswith(".log") else log_prefix
+        ch = re.escape(channel)
+        prefix = rf"(?:{re.escape(base)}\.)?" if base else ""
+        rx = re.compile(rf"^{prefix}{ch}(?:\.(\d+))?\.log(\.gz)?$")
 
-        active = self.log_dir / f"{base}.{channel}.log"
-        if active.exists():
-            return active
-
-        candidates = list(self.log_dir.glob(f"{base}.{channel}.*.log"))
-        candidates += list(self.log_dir.glob(f"{base}.{channel}.*.log.gz"))
-        indexed: list[tuple[int, Path]] = []
-        for p in candidates:
-            m = re.search(rf"\.{re.escape(channel)}\.(\d+)\.log(?:\.gz)?$", p.name)
-            if m:
-                indexed.append((int(m.group(1)), p))
-        if not indexed:
+        d = getattr(self, "_read_dir", self.log_dir)
+        try:
+            entries = list(d.iterdir())
+        except (OSError, FileNotFoundError):
             return None
-        indexed.sort(key=lambda t: t[0])
-        return indexed[0][1]
+
+        best = None  # (rank_tuple, Path)
+        for p in entries:
+            if not p.is_file():
+                continue
+            m = rx.match(p.name)
+            if not m:
+                continue
+            idx = int(m.group(1)) if m.group(1) else -1
+            compressed = 1 if m.group(2) else 0
+            # active (idx -1) before rotated; lowest rotated index next;
+            # uncompressed before compressed as a final tiebreak.
+            key = (0 if idx < 0 else 1, idx if idx >= 0 else 0, compressed)
+            if best is None or key < best[0]:
+                best = (key, p)
+        return best[1] if best else None
 
     def _load_log(self, path: Path | None):
         """Efficiently loads JSONL into Pandas"""
@@ -398,7 +448,8 @@ class GpuFlightSession:
                 ci   = {c: i for i, c in enumerate(cols)}
                 for row in (batch.get('rows') or []):
                     sk_int      = row[ci['sample_kind']]
-                    sample_kind = 'pc_sampling' if sk_int == 0 else 'sass_metric'
+                    sample_kind = {0: 'pc_sampling', 1: 'sass_metric',
+                                   2: 'isa_source_map'}.get(sk_int, 'sass_metric')
                     metric_id   = row[ci['metric_id']]
                     metric_name = dict_maps['metric'].get(metric_id) if metric_id else None
                     fn_id       = row[ci['function_id']]
@@ -1069,6 +1120,52 @@ class GpuFlightSession:
             for fn, value in by_func.items():
                 func_table.add_row(str(fn), str(int(value)))
             self.console.print(func_table)
+
+            # Per-function warp + memory efficiency (mirrors text_report.cpp /
+            # hint_engine.cpp so this matches the C++ report number-for-number).
+            eff_pivot = (
+                sass.groupby(['function_name', 'metric_name'])['metric_value']
+                .sum().unstack(fill_value=0)
+            )
+
+            def _ev(series, name):
+                return float(series[name]) if name in series.index else 0.0
+
+            eff_table = Table(title="SASS Efficiency — per function")
+            eff_table.add_column("Function", style="cyan")
+            eff_table.add_column("Warp Eff", justify="right")
+            eff_table.add_column("Mem Eff", justify="right")
+            eff_table.add_column("Hints", style="yellow")
+            order = eff_pivot.sum(axis=1).sort_values(ascending=False)
+            any_eff = False
+            for fn in order.index[:top_n]:
+                r        = eff_pivot.loc[fn]
+                warp     = _ev(r, "smsp__sass_inst_executed")
+                thread   = _ev(r, "smsp__sass_thread_inst_executed")
+                gsect    = _ev(r, "smsp__sass_sectors_mem_global")
+                ideal    = _ev(r, "smsp__sass_sectors_mem_global_ideal")
+                ideal_ld = _ev(r, "smsp__sass_sectors_mem_global_op_ld_ideal")
+                ideal_st = _ev(r, "smsp__sass_sectors_mem_global_op_st_ideal")
+                if warp <= 0 and thread <= 0 and gsect <= 0:
+                    continue
+                eff_ideal = ideal if ideal > 0 else (ideal_ld + ideal_st)
+                warp_pct = (thread / warp / 32.0 * 100) if (warp > 0 and thread > 0) else None
+                mem_pct  = (eff_ideal / gsect * 100) if (gsect > 0 and eff_ideal > 0) else None
+                warp_s = f"{warp_pct:.1f}%" if warp_pct is not None else "-"
+                mem_s  = (f"{mem_pct:.1f}%" if mem_pct is not None
+                          else ("n/a" if gsect > 0 else "-"))
+                tips = []
+                if warp_pct is not None and warp_pct < 90:
+                    tips.append("divergence")
+                if mem_pct is not None and mem_pct < 50:
+                    tips.append("coalescing")
+                fn_s = str(fn).split("@", 1)[0]
+                if len(fn_s) > 44:
+                    fn_s = fn_s[:41] + "..."
+                eff_table.add_row(fn_s, warp_s, mem_s, ", ".join(tips))
+                any_eff = True
+            if any_eff:
+                self.console.print(eff_table)
         else:
             self.console.print("[yellow]No sass_metric records found in profile_sample stream.[/yellow]")
 

--- a/python/gpufl/analyzer/analyzer.py
+++ b/python/gpufl/analyzer/analyzer.py
@@ -1162,7 +1162,7 @@ class GpuFlightSession:
             "    1. [bold]profiling_engine[/bold]: pass "
             "[cyan]ProfilingEngine.PcSampling[/cyan], "
             "[cyan]ProfilingEngine.SassMetrics[/cyan], or "
-            "[cyan]ProfilingEngine.PcSamplingWithSass[/cyan] to "
+            "[cyan]ProfilingEngine.Deep[/cyan] to "
             "[cyan]gpufl.init()[/cyan].\n"
             "    2. [bold]Scopes required[/bold]: wrap GPU work in "
             "[cyan]with gpufl.Scope(\"name\"):[/cyan] blocks — sample "

--- a/python/gpufl/report/text_report.py
+++ b/python/gpufl/report/text_report.py
@@ -501,48 +501,110 @@ class TextReport:
                         .head(self.top_n)
                     )
                     for fn, count in kern_stalls.items():
-                        short, _ = _shorten_kernel_name(str(fn))
+                        short, _ = _shorten_kernel_name(str(fn).split("@", 1)[0])
                         if len(short) > 50:
                             short = short[:47] + "..."
                         lines.append(f"    {short:<52}{int(count):>8} samples")
 
-        # SASS metrics summary
+        # SASS metrics — per-function instruction + memory efficiency.
+        # Mirrors include/gpufl/report/text_report.cpp + hint_engine.cpp so this
+        # Python report agrees number-for-number with the C++ generateReport():
+        #   warp efficiency   = thread_insts / warp_insts / 32
+        #   memory efficiency = ideal_sectors / global_sectors  (tiered ideal:
+        #     aggregate `_ideal` on sm_120+, op_ld + op_st on sm_86)
         if has_sass:
-            lines.append("")
-            lines.append("  SASS Metrics Summary:")
+            sass = samples[samples["metric_name"].notna()].copy()
+            sass["metric_value"] = pd.to_numeric(
+                sass["metric_value"], errors="coerce"
+            ).fillna(0)
+            if "function_name" not in sass.columns:
+                sass["function_name"] = "(unknown)"
+            sass["function_name"] = sass["function_name"].fillna("(unknown)")
 
-            sass = samples[samples["metric_name"].notna()]
-            metric_sums = (
-                sass.groupby("metric_name")["metric_value"]
+            per_func = (
+                sass.groupby(["function_name", "metric_name"])["metric_value"]
                 .sum()
-                .sort_values(ascending=False)
+                .unstack(fill_value=0)
             )
 
-            hdr = f"  {'Metric':<50}{'Total':>12}"
-            lines.append(hdr)
-            lines.append("  " + "-" * 62)
-            for metric, total in metric_sums.items():
-                mname = str(metric)
-                if len(mname) > 48:
-                    mname = mname[:45] + "..."
-                lines.append(f"  {mname:<50}{int(total):>12}")
+            def _metric(series, name):
+                return float(series[name]) if name in series.index else 0.0
 
-            # Divergence analysis: thread_inst / warp_inst ratio
-            warp_metric = "smsp__sass_inst_executed"
-            thread_metric = "smsp__sass_thread_inst_executed"
-            if warp_metric in metric_sums.index and thread_metric in metric_sums.index:
-                warp_total = metric_sums[warp_metric]
-                thread_total = metric_sums[thread_metric]
-                if warp_total > 0:
-                    # For a warp of 32 threads, thread/warp ratio should be 32 if no divergence
-                    ratio = thread_total / warp_total
-                    efficiency = ratio / 32.0 * 100
+            order = per_func.sum(axis=1).sort_values(ascending=False)
+            wrote_header = False
+            for fn in order.index[: self.top_n]:
+                row = per_func.loc[fn]
+                warp     = _metric(row, "smsp__sass_inst_executed")
+                thread   = _metric(row, "smsp__sass_thread_inst_executed")
+                gsect    = _metric(row, "smsp__sass_sectors_mem_global")
+                ideal    = _metric(row, "smsp__sass_sectors_mem_global_ideal")
+                ideal_ld = _metric(row, "smsp__sass_sectors_mem_global_op_ld_ideal")
+                ideal_st = _metric(row, "smsp__sass_sectors_mem_global_op_st_ideal")
+                if warp <= 0 and thread <= 0 and gsect <= 0:
+                    continue
+
+                if not wrote_header:
                     lines.append("")
-                    lines.append(f"  Thread Divergence Analysis:")
-                    lines.append(f"    Warp Instructions:    {int(warp_total)}")
-                    lines.append(f"    Thread Instructions:  {int(thread_total)}")
-                    lines.append(f"    Avg Threads/Warp:     {ratio:.1f} / 32")
-                    lines.append(f"    Warp Efficiency:      {efficiency:.1f}%")
+                    lines.append("  SASS Analysis (per function):")
+                    wrote_header = True
+
+                short, _ = _shorten_kernel_name(str(fn).split("@", 1)[0])
+                lines.append("")
+                lines.append(f"  {short}")
+                lines.append("  " + "-" * min(len(short) + 2, 60))
+
+                if warp > 0 or thread > 0:
+                    lines.append("    Instructions:")
+                    if warp > 0:
+                        lines.append(f"      Warp Insts:        {int(warp):>18,}")
+                    if thread > 0:
+                        lines.append(f"      Thread Insts:      {int(thread):>18,}")
+                    if warp > 0 and thread > 0:
+                        ratio = thread / warp
+                        eff = ratio / 32.0 * 100
+                        lines.append(
+                            f"      Warp Efficiency:   {ratio:>10.1f} / 32 ({eff:.1f}%)"
+                        )
+
+                if gsect > 0:
+                    eff_ideal = ideal if ideal > 0 else (ideal_ld + ideal_st)
+                    lines.append("    Memory:")
+                    lines.append(f"      Global Sectors:    {int(gsect):>18,}")
+                    if eff_ideal > 0:
+                        tag = " (ld+st)" if ideal == 0 else ""
+                        lines.append(
+                            f"      Ideal Sectors:     {int(eff_ideal):>18,}{tag}"
+                        )
+                        mem_eff = eff_ideal / gsect * 100
+                        lines.append(f"      Memory Efficiency: {mem_eff:>17.1f}%")
+                    else:
+                        lines.append(
+                            "      Memory Efficiency: (not available on this GPU)"
+                        )
+
+                # Interpretation hints — same thresholds as hint_engine.cpp
+                # (int-truncated percentages). Stall-based hints require PC
+                # sampling data, which the SASS path doesn't carry.
+                eff_ideal = ideal if ideal > 0 else (ideal_ld + ideal_st)
+                hints = []
+                if gsect > 0 and eff_ideal > 0:
+                    mem_eff = eff_ideal / gsect * 100
+                    if mem_eff < 50:
+                        hints.append(
+                            f"Low memory efficiency ({int(mem_eff)}%) - consider "
+                            "coalesced access patterns or shared memory tiling."
+                        )
+                if warp > 0 and thread > 0:
+                    eff = thread / warp / 32.0 * 100
+                    if eff < 90:
+                        hints.append(
+                            f"Low warp efficiency ({int(eff)}%) - reduce branch "
+                            "divergence within warps."
+                        )
+                if hints:
+                    lines.append("    Hints:")
+                    for h in hints:
+                        lines.append(f"      * {h}")
 
         return lines
 

--- a/python/gpufl/report/text_report.py
+++ b/python/gpufl/report/text_report.py
@@ -41,6 +41,24 @@ def _fmt_power(mw):
     return f"{mw:.0f} mW"
 
 
+def _title_from_snake(s: str) -> str:
+    return " ".join(w.capitalize() for w in s.split("_")) if s else s
+
+
+_CAP_STATUS_LABELS = {
+    "collected": "collected",
+    "fallback": "fallback",
+    "partial": "partial",
+    "skipped": "skipped",
+    "enabled_no_data": "on, no data",
+    "not_requested": "not requested",
+}
+
+
+def _capability_status_label(status: str) -> str:
+    return _CAP_STATUS_LABELS.get(status, status or "unknown")
+
+
 class TextReport:
     def __init__(self, session: GpuFlightSession, top_n: int = 10):
         self.session = session
@@ -50,6 +68,7 @@ class TextReport:
         sections = [
             self._section_header(),
             self._section_session_summary(),
+            self._section_capabilities(),
             self._section_kernel_summary(),
             self._section_top_kernels(),
             self._section_kernel_details(),
@@ -125,6 +144,33 @@ class TextReport:
                 if l2 is not None:
                     lines.append(f"    L2 Cache:           {_fmt_bytes(l2)}")
 
+        return lines
+
+    def _section_capabilities(self) -> list[str]:
+        caps = getattr(self.session, "capture_capabilities", None)
+        if not caps:
+            return []
+        lines = ["", _SEP, "  Capture Capabilities", _SEP]
+        req = getattr(self.session, "requested_engine", None)
+        sel = getattr(self.session, "selected_engine", None)
+        if req:
+            lines.append(f"  Requested Engine:     {req}")
+        if sel:
+            lines.append(f"  Selected Engine:      {sel}")
+        lines.append(f"  {'Feature':<22}{'Status':<14}Note")
+        lines.append("  " + "-" * 74)
+        for cap in caps:
+            if not isinstance(cap, dict):
+                continue
+            feature = _title_from_snake(str(cap.get("feature", "")))[:20]
+            status = _capability_status_label(str(cap.get("status", "")))[:12]
+            note = cap.get("reason_code") or cap.get("message") or ""
+            if not cap.get("requested", True) and not note:
+                note = "not requested"
+            note = str(note)
+            if len(note) > 40:
+                note = note[:37] + "..."
+            lines.append(f"  {feature:<22}{status:<14}{note}")
         return lines
 
     def _section_kernel_summary(self) -> list[str]:

--- a/python/gpufl/viz/reader.py
+++ b/python/gpufl/viz/reader.py
@@ -28,6 +28,7 @@ batch row — which is why the legacy `gpufl.viz` plots looked empty.
 """
 
 import glob
+import gzip
 import json
 import os
 from typing import Any, Dict, List
@@ -162,6 +163,35 @@ def _resolve_names(sample: Dict[str, Any],
         sample["name"] = dicts["kernel"].get(kid, f"#{kid}")
 
 
+def _gather_files(file_pattern: str) -> List[str]:
+    """Resolve a path / dir / glob into a concrete list of log files.
+
+    Understands the current client layout (gzipped, session-nested):
+      * a directory          -> all `<dir>/**/*.log[.gz]` (recursive)
+      * a `*.log` glob/path  -> that glob *plus* its `.gz` siblings
+      * an explicit `*.gz`   -> as given
+
+    so callers can pass `read_df("logs/")`, `read_df("logs/scope.*.log")`,
+    or `read_df("logs/run/scope.log.gz")` interchangeably.
+    """
+    if os.path.isdir(file_pattern):
+        pats = [os.path.join(file_pattern, "**", "*.log"),
+                os.path.join(file_pattern, "**", "*.log.gz")]
+    elif file_pattern.endswith(".gz"):
+        pats = [file_pattern]
+    else:
+        pats = [file_pattern, file_pattern + ".gz"]
+
+    out: List[str] = []
+    seen = set()
+    for pat in pats:
+        for f in glob.glob(pat, recursive=True):
+            if f not in seen and os.path.isfile(f):
+                seen.add(f)
+                out.append(f)
+    return out
+
+
 def read_events(file_pattern: str) -> List[dict]:
     """Read NDJSON files and return one dict per *expanded* event.
 
@@ -169,8 +199,11 @@ def read_events(file_pattern: str) -> List[dict]:
     `ts_ns` and resolved name fields where dictionary ids exist. Non-
     batch lines (lifecycle, dictionary_update, sass_config) pass through
     unchanged so downstream code can still see them if it needs to.
+
+    Accepts a file path, a directory, or a glob; gzipped (`.log.gz`) and
+    session-nested logs written by the current client are handled.
     """
-    files = glob.glob(file_pattern)
+    files = _gather_files(file_pattern)
 
     # Pass 1: parse every line. We have to buffer to do dictionary
     # resolution in pass 2 — `dictionary_update` events are usually
@@ -180,7 +213,8 @@ def read_events(file_pattern: str) -> List[dict]:
     for fpath in files:
         if not os.path.isfile(fpath):
             continue
-        with open(fpath, "r", encoding="utf-8") as f:
+        open_fn = gzip.open if fpath.endswith(".gz") else open
+        with open_fn(fpath, "rt", encoding="utf-8") as f:
             for line in f:
                 line = line.strip()
                 if not line or not line.startswith("{"):

--- a/python/gpufl/viz/visualizer.py
+++ b/python/gpufl/viz/visualizer.py
@@ -33,10 +33,10 @@ def init(log_pattern: Union[str, List[str]]):
         log_pattern: File path, directory, or glob pattern (e.g., "logs/*.log").
     """
     global _GLOBAL_DF
-    if isinstance(log_pattern, str) and os.path.isdir(log_pattern):
-        pattern = os.path.join(log_pattern, "*.log")
-    else:
-        pattern = log_pattern
+    # read_df / read_events expand a directory recursively and read both
+    # plain and gzipped (`.log.gz`) logs, so pass directories straight
+    # through rather than pinning to a non-recursive "<dir>/*.log".
+    pattern = log_pattern
 
     print(f"Loading logs from: {pattern} ...")
     df = read_df(pattern)

--- a/tests/backends/nvidia/test_engine_coverage.cpp
+++ b/tests/backends/nvidia/test_engine_coverage.cpp
@@ -123,11 +123,17 @@ TEST_P(EngineCoverageTest, EmitsExpectedEvents) {
         << "No job_start event in scope log for engine "
         << gpufl::test::EngineName(engine);
 
-    // Activity API is always on: kernel batches should appear for any engine
-    // once a kernel runs.
-    EXPECT_FALSE(gpufl::test::FilterByType(logs.device, "kernel_event_batch").empty())
-        << "No kernel_event_batch events for engine "
-        << gpufl::test::EngineName(engine);
+    // Activity API is on for every engine EXCEPT Off (which subscribes no
+    // CUPTI at all). So kernel batches must appear for the CUPTI engines
+    // and must be ABSENT for Off.
+    if (engine == gpufl::ProfilingEngine::Monitor) {
+        EXPECT_TRUE(gpufl::test::FilterByType(logs.device, "kernel_event_batch").empty())
+            << "Monitor engine must not capture kernel_event_batch (no CUPTI)";
+    } else {
+        EXPECT_FALSE(gpufl::test::FilterByType(logs.device, "kernel_event_batch").empty())
+            << "No kernel_event_batch events for engine "
+            << gpufl::test::EngineName(engine);
+    }
 
     // ── Engine-specific contracts ────────────────────────────────────────
     // profile_sample_batch events are emitted to the Scope channel.
@@ -149,15 +155,30 @@ TEST_P(EngineCoverageTest, EmitsExpectedEvents) {
               << " perf_events=" << perfEvents.size() << "\n";
 
     switch (engine) {
-        case gpufl::ProfilingEngine::None: {
+        case gpufl::ProfilingEngine::Monitor: {
+            // Telemetry-only: no CUPTI, so none of the CUPTI-derived
+            // event types appear. (kernel_event_batch absence is checked
+            // in the shared section above.)
             EXPECT_EQ(pcSamples, 0)
-                << "None engine must not produce pc_sampling rows";
+                << "Monitor engine must not produce pc_sampling rows";
             EXPECT_EQ(sassSamples, 0)
-                << "None engine must not produce sass_metric rows";
+                << "Monitor engine must not produce sass_metric rows";
             EXPECT_TRUE(sassConfigs.empty())
-                << "None engine must not emit sass_config";
+                << "Monitor engine must not emit sass_config";
             EXPECT_TRUE(perfEvents.empty())
-                << "None engine must not emit perf_metric_event";
+                << "Monitor engine must not emit perf_metric_event";
+            break;
+        }
+
+        case gpufl::ProfilingEngine::Trace: {
+            EXPECT_EQ(pcSamples, 0)
+                << "Trace engine must not produce pc_sampling rows";
+            EXPECT_EQ(sassSamples, 0)
+                << "Trace engine must not produce sass_metric rows";
+            EXPECT_TRUE(sassConfigs.empty())
+                << "Trace engine must not emit sass_config";
+            EXPECT_TRUE(perfEvents.empty())
+                << "Trace engine must not emit perf_metric_event";
             break;
         }
 
@@ -248,7 +269,7 @@ TEST_P(EngineCoverageTest, EmitsExpectedEvents) {
             break;
         }
 
-        case gpufl::ProfilingEngine::PcSamplingWithSass: {
+        case gpufl::ProfilingEngine::Deep: {
             if (samplesBestEffort) {
                 std::cerr << "[engine_coverage] sample collection best-effort "
                              "(PC sampling may be skipped due to Profiler API "
@@ -281,11 +302,12 @@ TEST_P(EngineCoverageTest, EmitsExpectedEvents) {
 
 INSTANTIATE_TEST_SUITE_P(
     AllEngines, EngineCoverageTest,
-    ::testing::Values(gpufl::ProfilingEngine::None,
+    ::testing::Values(gpufl::ProfilingEngine::Monitor,
+                      gpufl::ProfilingEngine::Trace,
                       gpufl::ProfilingEngine::PcSampling,
                       gpufl::ProfilingEngine::SassMetrics,
                       gpufl::ProfilingEngine::RangeProfiler,
-                      gpufl::ProfilingEngine::PcSamplingWithSass),
+                      gpufl::ProfilingEngine::Deep),
     [](const ::testing::TestParamInfo<gpufl::ProfilingEngine>& info) {
         return std::string(gpufl::test::EngineName(info.param));
     });

--- a/tests/common/log_utils.cpp
+++ b/tests/common/log_utils.cpp
@@ -205,11 +205,12 @@ std::vector<std::string> GetStringArrayField(
 
 const char* EngineName(gpufl::ProfilingEngine e) {
     switch (e) {
-        case gpufl::ProfilingEngine::None:               return "None";
-        case gpufl::ProfilingEngine::PcSampling:         return "PcSampling";
-        case gpufl::ProfilingEngine::SassMetrics:        return "SassMetrics";
-        case gpufl::ProfilingEngine::RangeProfiler:      return "RangeProfiler";
-        case gpufl::ProfilingEngine::PcSamplingWithSass: return "PcSamplingWithSass";
+        case gpufl::ProfilingEngine::Monitor:       return "Monitor";
+        case gpufl::ProfilingEngine::Trace:         return "Trace";
+        case gpufl::ProfilingEngine::PcSampling:    return "PcSampling";
+        case gpufl::ProfilingEngine::SassMetrics:   return "SassMetrics";
+        case gpufl::ProfilingEngine::RangeProfiler: return "RangeProfiler";
+        case gpufl::ProfilingEngine::Deep:          return "Deep";
     }
     return "Unknown";
 }

--- a/tests/core/test_analyzer.cpp
+++ b/tests/core/test_analyzer.cpp
@@ -6,7 +6,7 @@ TEST(CoreLogic, InitOptionsDefault) {
     gpufl::InitOptions opts;
     EXPECT_EQ(opts.app_name, "gpufl");
     EXPECT_FALSE(opts.continuous_system_sampling);
-    EXPECT_EQ(opts.profiling_engine, gpufl::ProfilingEngine::PcSampling);
+    EXPECT_EQ(opts.profiling_engine, gpufl::ProfilingEngine::Monitor);
 }
 
 TEST(CoreLogic, BackendKindEnum) {

--- a/tests/python/test_bindings.py
+++ b/tests/python/test_bindings.py
@@ -66,16 +66,12 @@ class TestInitOptions:
 # ---------------------------------------------------------------------------
 
 EXPECTED_PROFILING_ENGINES = [
+    "Monitor",       # no CUPTI — telemetry only (the safe default)
+    "Trace",         # activity trace (kernels + memcpy + sync), no sampling
     "PcSampling",
     "SassMetrics",
     "RangeProfiler",
-    "PcSamplingWithSass",
-    # Friendly aliases (Phase 1 of mode renaming). Same underlying enum
-    # values as their technical counterparts above; locked in here so
-    # the binding regression test catches a missing alias.
-    "Continuous",
-    "Deep",
-    "Range",
+    "Deep",          # PcSampling + SassMetrics
 ]
 
 EXPECTED_BACKEND_KINDS = [
@@ -93,9 +89,14 @@ class TestEnums:
                 f"Missing ProfilingEngine.{name}"
             )
 
-    def test_profiling_engine_none(self):
-        """ProfilingEngine.None_ exists (Python keyword workaround)."""
-        assert hasattr(gpufl.ProfilingEngine, "None_")
+    def test_profiling_engine_no_legacy_aliases(self):
+        """The pre-1.1 names are gone — clean six-value enum only."""
+        for gone in ("None_", "None", "Off", "KernelTrace",
+                     "Continuous", "Range", "PcSamplingWithSass"):
+            assert not hasattr(gpufl.ProfilingEngine, gone), (
+                f"ProfilingEngine.{gone} should have been removed in the "
+                f"1.1 rename"
+            )
 
     def test_backend_kind_values(self):
         """All C++ BackendKind enum values are accessible."""

--- a/tests/run_engine_coverage.ps1
+++ b/tests/run_engine_coverage.ps1
@@ -4,8 +4,8 @@
 
 .DESCRIPTION
     CUPTI does not reliably tolerate multiple init/shutdown cycles in a single
-    process, so each of the 5 profiling engines (None, PcSampling, SassMetrics,
-    RangeProfiler, PcSamplingWithSass) is exercised in its own invocation of
+    process, so each of the 6 profiling engines (Monitor, Trace, PcSampling,
+    SassMetrics, RangeProfiler, Deep) is exercised in its own invocation of
     gpufl_tests.exe. Per-engine pass/fail is reported; script exits 1 if any
     engine fails.
 
@@ -34,7 +34,7 @@ if (-not (Test-Path $TestExe)) {
     exit 2
 }
 
-$engines = @("None", "PcSampling", "SassMetrics", "RangeProfiler", "PcSamplingWithSass")
+$engines = @("Monitor", "Trace", "PcSampling", "SassMetrics", "RangeProfiler", "Deep")
 $failed = @()
 $passed = @()
 $skipped = @()

--- a/tests/run_engine_coverage.sh
+++ b/tests/run_engine_coverage.sh
@@ -2,8 +2,8 @@
 # Runs the engine-coverage test suite, one engine per fresh process.
 #
 # CUPTI does not reliably tolerate multiple init/shutdown cycles in a single
-# process, so each of the 5 profiling engines (None, PcSampling, SassMetrics,
-# RangeProfiler, PcSamplingWithSass) is exercised in its own invocation of
+# process, so each of the 6 profiling engines (Monitor, Trace, PcSampling,
+# SassMetrics, RangeProfiler, Deep) is exercised in its own invocation of
 # gpufl_tests. Per-engine pass/fail is reported; script exits 1 if any engine
 # fails.
 #
@@ -41,7 +41,7 @@ fi
 
 echo "Using test binary: $TEST_EXE"
 
-engines=(None PcSampling SassMetrics RangeProfiler PcSamplingWithSass)
+engines=(Monitor Trace PcSampling SassMetrics RangeProfiler Deep)
 passed=()
 failed=()
 

--- a/tests/verify_pipeline.py
+++ b/tests/verify_pipeline.py
@@ -16,11 +16,12 @@ def test_pipeline():
     keep = False
     try:
         print("2. Initializing GPUFL...")
-        # Passing 0 for interval. ProfilingEngine.None_ is the Python-
-        # keyword-safe alias for the "no profiling, monitor only" mode —
-        # equivalent to ProfilingEngine.__members__["None"] but readable.
+        # Trace = activity trace (kernels, memcpy, sync), no sampling. We
+        # exercise the CUPTI activity path here so the pipeline smoke test
+        # covers it; the no-CUPTI Monitor mode is covered by the
+        # engine-coverage suite.
         res = gfl.init("CI_Test_App", log_base_path, True, 50,
-                       profiling_engine=gfl.ProfilingEngine.None_)
+                       profiling_engine=gfl.ProfilingEngine.Trace)
         print(f"   Result: {res}")
         if res is False:
             print("\n[CI-INFO] GPUFL initialized in Stub Mode (No GPU detected).")


### PR DESCRIPTION
## Description
refactor: rephrase profiling engines; stabilize SASS/Deep/PerfWorks
Two threads of work on the NVIDIA profiling path.
1) Profiling-engine rephrase: clarify the engine taxonomy
   (Monitor -> Trace -> PcSampling -> SassMetrics -> RangeProfiler -> Deep)
   to remove naming confusion, propagated through the core, Python
   bindings/stub, examples, benchmarks, daemon, tests and docs.
2) SASS / Deep / PerfWorks stabilization: fix crashes, deadlocks and
   data-loss found running real PyTorch workloads on RTX 3090 / 5060, and
   re-base the SASS deadlock mitigation on a targeted per-architecture gate.
SASS / Deep / PerfWorks fixes:
- PerfWorks preload: match + preload the resident CUPTI's PerfWorks libs
  (libnvperf_target / libpcsamplingutil / libnvperf_host) in dependency
  order before the C extension imports, picking the dir matching the loaded
  libcupti. Fixes the NVPW_CUDA_LoadDriver segfault on CUPTI/PerfWorks
  mismatch.
- flushDisassembly: use posix_spawn instead of popen for nvdisasm to avoid
  a multithreaded-fork deadlock.
- Deep PC-sampling: forward the collector's periodic drainData() to the PC
  sampling sub-engine so its CONTINUOUS-mode buffer is drained mid-run
  (otherwise back-pressure froze a CUPTI helper thread).
- Kernel activity: collect CONCURRENT_KERNEL only, dropping the serializing
  CUPTI_ACTIVITY_KIND_KERNEL.
- SASS deadlock mitigation: the lazy-patching deadlock is an Ampere/sm_86
  (RTX 3090) limitation; Blackwell runs SASS fine under LAZY. So instead of
  globally forcing EAGER:
    * per-architecture exclusion gate GPUFL_SASS_EXCLUDE_ARCHS (runs before
      cuptiProfilerInitialize; covers standalone SASS and Deep->PC fallback);
    * CUDA_MODULE_LOADING=EAGER is now opt-in (GPUFL_EAGER_MODULE_LOADING=1);
    * Deep attempts SASS by default and falls back to PC if it can't arm.
- Experiment: GPUFL_DEEP_TRY_BOTH=1 arms SASS + PC sampling together in Deep
  to test coexistence (default stays one-or-the-other).
- Silence expected LEGACY_PROFILER_NOT_SUPPORTED / NOT_COMPATIBLE fallbacks;
  guard against init() being called mid-CUDA-program.
Env vars:
- GPUFL_SASS_EXCLUDE_ARCHS: disable SASS on listed compute caps (e.g. 86,
  8.6, 8). Default empty (attempt all).
- GPUFL_EAGER_MODULE_LOADING=1: opt into CUDA_MODULE_LOADING=EAGER. Default
  off (LAZY).
- GPUFL_DEEP_PC_ONLY=1: force Deep to PC-sampling only.
- GPUFL_DEEP_TRY_BOTH=1: experimental SASS + PC in Deep.
- GPUFL_DEBUG_PRELOAD=1: trace the PerfWorks preload.
Verified: RTX 5060 (sm_120) SASS/Deep work under both LAZY and EAGER; RTX
3090 (sm_86) is the confirmed-bad case and degrades cleanly to PC sampling.
Builds clean (MSVC, cp313 wheel) and imports.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

## Testing
## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas