### PR TITLE
Fix Windows Deep SASS deadlock defaults and build scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,83 @@ git clone https://github.com/gpu-flight/gpufl-client.git
 CMAKE_ARGS="-DBUILD_TESTING=OFF" pip install "./gpufl-client[analyzer,viz]"
 ```
 
+### Build Scripts
+
+The repository includes platform-specific helper scripts for local source
+builds. Use these scripts when you need to build against a specific CUDA
+Toolkit, Python virtual environment, or wheel ABI.
+
+#### Ubuntu / Linux
+
+`build.sh` is the Linux entrypoint. It delegates to `build-ubuntu.sh`.
+
+```bash
+# Install into the active Python environment
+./build.sh
+
+# Build a wheel into ./dist
+./build.sh --wheel
+
+# Use an explicit Python and CUDA Toolkit
+./build-ubuntu.sh --wheel \
+  --python .venv/bin/python \
+  --cuda-root /usr/local/cuda-13.2
+```
+
+Useful options:
+
+| Option | Meaning |
+|---|---|
+| `--install` | Install the package into the selected Python environment. This is the default. |
+| `--wheel` | Build a wheel into `./dist` or `--wheel-dir`. |
+| `--python PATH` | Python executable to use. Use your target virtual environment's Python when building wheels. |
+| `--cuda-root PATH` | CUDA Toolkit root, for example `/usr/local/cuda-13.2`. |
+| `--wheel-dir PATH` | Output directory for built wheels. |
+
+#### Windows
+
+Use `build-windows.ps1` from PowerShell. The script imports the Visual Studio
+2022 `vcvars64.bat` environment when it can find it, then sets the CUDA and
+CMake generator variables for the build.
+
+```powershell
+# Install into the active Python environment
+powershell -ExecutionPolicy Bypass -File .\build-windows.ps1
+
+# Build a wheel into .\dist
+powershell -ExecutionPolicy Bypass -File .\build-windows.ps1 -Mode wheel
+
+# Build a wheel for a specific Python venv and CUDA Toolkit
+powershell -ExecutionPolicy Bypass -File .\build-windows.ps1 `
+  -Mode wheel `
+  -Python "C:\path\to\.venv\Scripts\python.exe" `
+  -CudaPath "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.2"
+```
+
+Useful parameters:
+
+| Parameter | Meaning |
+|---|---|
+| `-Mode install` | Install the package into the selected Python environment. This is the default. |
+| `-Mode wheel` | Build a wheel into `.\dist` or `-WheelDir`. |
+| `-Python PATH` | Python executable to use. Use the target virtual environment's Python so the wheel tag matches that environment, for example `cp313`. |
+| `-CudaPath PATH` | CUDA Toolkit root. If omitted, the script checks `CUDA_PATH`, `CUDA_HOME`, then common CUDA 13.x install paths. |
+| `-WheelDir PATH` | Output directory for built wheels. |
+| `-NoVcVars` | Skip importing `vcvars64.bat` and use the current shell environment. |
+
+Both platform scripts pass the current CMake options:
+
+```text
+BUILD_PYTHON=ON
+BUILD_GPUFL_EXAMPLE=OFF
+BUILD_TESTING=OFF
+PYBIND11_FINDPYTHON=ON
+GPUFL_ENABLE_NVIDIA=ON
+GPUFL_ENABLE_AMD=OFF
+CUDAToolkit_ROOT=<selected CUDA Toolkit>
+CMAKE_CUDA_COMPILER=<selected nvcc>
+```
+
 ### C++ (CMake FetchContent)
 ```cmake
 cmake_minimum_required(VERSION 3.31)

--- a/build-ubuntu.sh
+++ b/build-ubuntu.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PYTHON_BIN="${PYTHON:-python3}"
+CUDA_ROOT="${CUDA_ROOT:-${CUDA_PATH:-${CUDA_HOME:-/usr/local/cuda}}}"
+MODE="install"
+WHEEL_DIR="$ROOT_DIR/dist"
+
+usage() {
+  cat <<'EOF'
+Usage: ./build-ubuntu.sh [--install|--wheel] [--python PATH] [--cuda-root PATH] [--wheel-dir PATH]
+
+Defaults:
+  --install
+  --python    ${PYTHON:-python3}
+  --cuda-root ${CUDA_ROOT:-${CUDA_PATH:-${CUDA_HOME:-/usr/local/cuda}}}
+  --wheel-dir ./dist
+
+Examples:
+  ./build-ubuntu.sh
+  ./build-ubuntu.sh --wheel
+  ./build-ubuntu.sh --python .venv/bin/python --cuda-root /usr/local/cuda-13.2
+EOF
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --install)
+      MODE="install"
+      shift
+      ;;
+    --wheel)
+      MODE="wheel"
+      shift
+      ;;
+    --python)
+      PYTHON_BIN="$2"
+      shift 2
+      ;;
+    --cuda-root)
+      CUDA_ROOT="$2"
+      shift 2
+      ;;
+    --wheel-dir)
+      WHEEL_DIR="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+if [[ ! -x "$CUDA_ROOT/bin/nvcc" ]]; then
+  for candidate in /usr/local/cuda /usr/local/cuda-13.2 /usr/local/cuda-13.1 /usr/local/cuda-13.0; do
+    if [[ -x "$candidate/bin/nvcc" ]]; then
+      CUDA_ROOT="$candidate"
+      break
+    fi
+  done
+fi
+
+if [[ ! -x "$CUDA_ROOT/bin/nvcc" ]]; then
+  echo "CUDA nvcc was not found under: $CUDA_ROOT" >&2
+  echo "Pass --cuda-root PATH or set CUDA_ROOT/CUDA_PATH/CUDA_HOME." >&2
+  exit 1
+fi
+
+export CUDA_ROOT
+export CUDA_PATH="$CUDA_ROOT"
+export CUDA_HOME="$CUDA_ROOT"
+export CUDACXX="$CUDA_ROOT/bin/nvcc"
+export PATH="$CUDA_ROOT/bin:$CUDA_ROOT/extras/CUPTI/lib64:$PATH"
+export LD_LIBRARY_PATH="$CUDA_ROOT/lib64:$CUDA_ROOT/extras/CUPTI/lib64:${LD_LIBRARY_PATH:-}"
+
+COMMON_CONFIG=(
+  -C cmake.define.BUILD_PYTHON=ON
+  -C cmake.define.BUILD_GPUFL_EXAMPLE=OFF
+  -C cmake.define.BUILD_TESTING=OFF
+  -C cmake.define.PYBIND11_FINDPYTHON=ON
+  -C cmake.define.GPUFL_ENABLE_NVIDIA=ON
+  -C cmake.define.GPUFL_ENABLE_AMD=OFF
+  -C "cmake.define.CUDAToolkit_ROOT=$CUDA_ROOT"
+  -C "cmake.define.CMAKE_CUDA_COMPILER=$CUDA_ROOT/bin/nvcc"
+)
+
+echo "GPUFlight build"
+echo "  mode:      $MODE"
+echo "  python:    $PYTHON_BIN"
+echo "  cuda root: $CUDA_ROOT"
+
+if [[ "$MODE" == "wheel" ]]; then
+  mkdir -p "$WHEEL_DIR"
+  "$PYTHON_BIN" -m pip wheel "$ROOT_DIR" -w "$WHEEL_DIR" --no-deps -v "${COMMON_CONFIG[@]}"
+else
+  "$PYTHON_BIN" -m pip install "$ROOT_DIR" -v "${COMMON_CONFIG[@]}"
+fi

--- a/build-windows.ps1
+++ b/build-windows.ps1
@@ -1,0 +1,105 @@
+param(
+    [ValidateSet("install", "wheel")]
+    [string]$Mode = "install",
+
+    [string]$Python = $env:PYTHON,
+
+    [string]$CudaPath = $env:CUDA_PATH,
+
+    [string]$WheelDir,
+
+    [switch]$NoVcVars
+)
+
+$ErrorActionPreference = "Stop"
+
+$RootDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+if ([string]::IsNullOrWhiteSpace($Python)) {
+    $Python = "python"
+}
+if ([string]::IsNullOrWhiteSpace($WheelDir)) {
+    $WheelDir = Join-Path $RootDir "dist"
+}
+
+function Resolve-CudaPath {
+    param([string]$RequestedPath)
+
+    $candidates = @(
+        $RequestedPath,
+        $env:CUDA_HOME,
+        "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.2",
+        "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.1",
+        "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.0"
+    ) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+
+    foreach ($candidate in $candidates) {
+        $nvcc = Join-Path $candidate "bin\nvcc.exe"
+        if (Test-Path -LiteralPath $nvcc) {
+            return (Resolve-Path -LiteralPath $candidate).Path
+        }
+    }
+
+    throw "CUDA nvcc was not found. Pass -CudaPath or set CUDA_PATH/CUDA_HOME."
+}
+
+function Import-VcVars64 {
+    $programFiles = ${env:ProgramFiles}
+    $candidates = @(
+        "$programFiles\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat",
+        "$programFiles\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvars64.bat",
+        "$programFiles\Microsoft Visual Studio\2022\Professional\VC\Auxiliary\Build\vcvars64.bat",
+        "$programFiles\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+    )
+
+    $vcvars = $candidates | Where-Object { Test-Path -LiteralPath $_ } | Select-Object -First 1
+    if (-not $vcvars) {
+        Write-Warning "vcvars64.bat was not found. Continuing with the current shell environment."
+        return
+    }
+
+    Write-Host "Importing MSVC environment from: $vcvars"
+    cmd /d /s /c "call `"$vcvars`" >nul 2>&1 && set" | ForEach-Object {
+        $idx = $_.IndexOf("=")
+        if ($idx -gt 0) {
+            $name = $_.Substring(0, $idx)
+            $value = $_.Substring($idx + 1)
+            [Environment]::SetEnvironmentVariable($name, $value, "Process")
+        }
+    }
+}
+
+$CudaPath = Resolve-CudaPath -RequestedPath $CudaPath
+if (-not $NoVcVars) {
+    Import-VcVars64
+}
+
+$env:CUDA_PATH = $CudaPath
+$env:CUDA_HOME = $CudaPath
+$env:CUDACXX = Join-Path $CudaPath "bin\nvcc.exe"
+$env:CMAKE_GENERATOR = "Visual Studio 17 2022"
+$env:CMAKE_GENERATOR_PLATFORM = "x64"
+$env:CMAKE_GENERATOR_TOOLSET = "cuda=$CudaPath"
+$env:Path = "$CudaPath\bin;$CudaPath\extras\CUPTI\lib64;$env:Path"
+
+$commonConfig = @(
+    "-C", "cmake.define.BUILD_PYTHON=ON",
+    "-C", "cmake.define.BUILD_GPUFL_EXAMPLE=OFF",
+    "-C", "cmake.define.BUILD_TESTING=OFF",
+    "-C", "cmake.define.PYBIND11_FINDPYTHON=ON",
+    "-C", "cmake.define.GPUFL_ENABLE_NVIDIA=ON",
+    "-C", "cmake.define.GPUFL_ENABLE_AMD=OFF",
+    "-C", "cmake.define.CUDAToolkit_ROOT=$CudaPath",
+    "-C", "cmake.define.CMAKE_CUDA_COMPILER=$env:CUDACXX"
+)
+
+Write-Host "GPUFlight build"
+Write-Host "  mode:      $Mode"
+Write-Host "  python:    $Python"
+Write-Host "  cuda path: $CudaPath"
+
+if ($Mode -eq "wheel") {
+    New-Item -ItemType Directory -Force -Path $WheelDir | Out-Null
+    & $Python -m pip wheel $RootDir -w $WheelDir --no-deps -v @commonConfig
+} else {
+    & $Python -m pip install $RootDir -v @commonConfig
+}

--- a/build.sh
+++ b/build.sh
@@ -1,1 +1,23 @@
-python -m pip install . -v -C cmake.define.BUILD_PYTHON=ON -C cmake.define.GPUFL_ENABLE_CUDA=ON -C cmake.define.GPUFL_ENABLE_NVML=ON
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+UNAME="$(uname -s 2>/dev/null || echo unknown)"
+
+case "$UNAME" in
+  Linux*)
+    exec "$ROOT_DIR/build-ubuntu.sh" "$@"
+    ;;
+  *)
+    cat >&2 <<'EOF'
+build.sh is the Ubuntu/Linux entrypoint.
+
+On Windows, use:
+  powershell -ExecutionPolicy Bypass -File .\build-windows.ps1
+
+For wheel packaging on Windows, use:
+  powershell -ExecutionPolicy Bypass -File .\build-windows.ps1 -Mode wheel
+EOF
+    exit 1
+    ;;
+esac

--- a/daemon/monitor/CMakeLists.txt
+++ b/daemon/monitor/CMakeLists.txt
@@ -9,7 +9,13 @@ if(GPUFL_HAS_CUDA)
 endif()
 
 if(GPUFL_HAS_NVML)
-    target_link_libraries(gpufl-monitor PRIVATE CUDA::nvml)
+    if(TARGET CUDA::nvml)
+        target_link_libraries(gpufl-monitor PRIVATE CUDA::nvml)
+    elseif(NVML_LIBRARY)
+        target_link_libraries(gpufl-monitor PRIVATE ${NVML_LIBRARY})
+    else()
+        message(WARNING "GPUFL_HAS_NVML is true, but no NVML import target or library is available for gpufl-monitor")
+    endif()
 endif()
 
 install(TARGETS gpufl-monitor

--- a/docs/compatibility/nvidia-deep-mode-matrix.md
+++ b/docs/compatibility/nvidia-deep-mode-matrix.md
@@ -1,0 +1,181 @@
+# NVIDIA Deep Mode Compatibility Matrix
+
+This document records NVIDIA Deep mode test results, the hardware/software
+environment used for each run, and the feature set each Deep mode combination is
+expected to collect.
+
+Deep mode is a decision pipeline, not a fixed "enable every CUPTI feature"
+switch:
+
+1. Deep decides whether to attempt SASS metrics.
+2. If SASS does not arm, Deep falls back to PC sampling.
+3. If SASS arms, Deep applies the SASS activity policy.
+4. The product default is SASS-safe activity, not the legacy full CUPTI activity
+   bundle.
+
+The purpose of this document is to keep the runtime policy tied to observed
+device behavior.
+
+## Current Policy
+
+| Policy | Default | Reason |
+| --- | --- | --- |
+| Deep attempts SASS first | Yes | Deep's most differentiated value is per-instruction SASS metrics and disassembly. |
+| Deep falls back to PC sampling | Yes | If SASS is disabled, excluded, unavailable, or fails to arm, Deep should still produce stall/hot-PC data. |
+| SASS-safe activity policy | Yes | SASS plus the full CUPTI activity bundle reproduced a scoped PyTorch hang on Windows/CUDA 13.2. |
+| Full activity bundle | Opt-in only | Available for diagnostics through `GPUFL_SASS_ALLOW_FULL_ACTIVITY=1`, but not safe as a default. |
+| SASS + PC sampling together | Experimental only | Controlled by `GPUFL_DEEP_TRY_BOTH=1`; current assumption is mutual exclusion. |
+
+## Test Environment: 2026-06-02 Windows PyTorch Run
+
+| Field | Value |
+| --- | --- |
+| Date | 2026-06-02 |
+| OS | Microsoft Windows 11, NT version 10.0.26200.8457 |
+| GPU | NVIDIA GeForce RTX 5060 Laptop GPU |
+| Compute capability | 12.0 |
+| NVIDIA driver | 592.01 |
+| CUDA Toolkit | 13.2, `nvcc` 13.2.51 |
+| Toolkit CUPTI DLL | `cupti64_2026.1.0.dll` |
+| PyTorch bundled CUPTI DLL | `cupti64_2026.1.1.dll` |
+| Python | 3.13.5, 64-bit |
+| PyTorch | 2.12.0+cu132 |
+| PyTorch CUDA | 13.2 |
+| Client package | `gpufl-1.1.0rc2-cp313-cp313-win_amd64.whl` |
+| Workload | `C1M2_Assignment.py`, EMNIST one-epoch training workload |
+| Init options | `ProfilingEngine.Deep`, `enable_stack_trace=True`, `enable_memory_tracking=True`, `enable_cuda_graphs_tracking=False`, `enable_debug_output=False` |
+| Scope setup | One outer `gpufl.Scope("train_epoch")` unless otherwise noted |
+| Timeout threshold | 240 seconds |
+
+## Observed Results
+
+| Run | Scope | Flags / policy | Result | Marker progress | Interpretation |
+| --- | --- | --- | --- | --- | --- |
+| `baseline_outer_scope_20260602_145825` | Outer `train_epoch` | Pre-patch default full SASS activity | Timeout | Not instrumented | Reproduced hang with Deep + SASS + full activity bundle. |
+| `defer_scope_flush_20260602_150305` | Outer `train_epoch` | `GPUFL_SASS_DEFER_SCOPE_FLUSH=1` | Timeout | Not instrumented | Deferring scope-stop SASS flush did not fix the hang. |
+| `defer_no_cubin_capture_20260602_150815` | Outer `train_epoch` | `GPUFL_SASS_DEFER_SCOPE_FLUSH=1`, `GPUFL_SASS_DISABLE_CUBIN_CAPTURE=1` | Timeout | Not instrumented | CUBIN capture alone was not the root cause. |
+| `instrumented_outer_scope_20260602_151945` | Outer `train_epoch` | Pre-patch default full SASS activity | Timeout | Reached `entered train_epoch scope`; did not return from `train_epoch` | Hang occurs inside scoped training after SASS is armed, not only at shutdown or scope exit. |
+| `instrumented_no_scope_20260602_152434` | No scope | Pre-patch default full SASS activity | Exit | Reached `after gpufl.shutdown` | Removing the scope avoided SASS arming during the training loop, so the workload completed. |
+| `instrumented_outer_sass_metrics_only_20260602_153557` | Outer `train_epoch` | `GPUFL_SASS_METRICS_ONLY=1` | Exit | Reached `after gpufl.shutdown` | SASS itself can run. The failing condition is SASS combined with other CUPTI activity/callback layers. |
+| `instrumented_outer_sass_safe_activity_20260602_153829` | Outer `train_epoch` | `GPUFL_SASS_FORCE_SAFE_ACTIVITY=1` | Exit | Reached `after gpufl.shutdown` | Safe SASS activity policy avoids the hang. |
+| `instrumented_outer_default_after_safe_patch_20260602_154729` | Outer `train_epoch` | Post-patch default safe SASS activity | Exit | Reached `after gpufl.shutdown` | The new default policy preserved Deep/SASS while avoiding the reproduced hang. |
+
+`GPUFL_SASS_ALLOW_KERNEL_ACTIVITY=1` was not tested in this run because the
+approval prompt for that diagnostic run was declined. The current evidence
+therefore proves the unsafe bundle-level condition, not the exact individual
+CUPTI activity kind that triggers the hang.
+
+## Deep Mode Feature Collection Semantics
+
+| Combination | Selection | Expected collected data | Expected missing or degraded data | Stability status |
+| --- | --- | --- | --- | --- |
+| Default Deep, SASS wins | `ProfilingEngine.Deep`, no activity override flags | SASS metrics, CUBIN capture, SASS disassembly, callback-based synthetic kernel rows, launch API timestamps, scope path, launch grid/block parameters when available, host metrics, NVML device metrics, MEMORY2 rows if `enable_memory_tracking=True` and not blocked by policy | CUPTI kernel activity GPU start/end records are skipped; kernel duration and occupancy can be partial; PC sampling is skipped | Recommended default |
+| Deep PC-only fallback | `GPUFL_DEEP_PC_ONLY=1`, SASS excluded, or SASS fails to arm | PC samples, stall reasons, hot PCs, source/function correlation when emitted, callback-based kernel rows, launch metadata, host metrics, NVML device metrics | SASS metrics and SASS replay counters are not collected | Recommended fallback |
+| SASS metrics only | `GPUFL_SASS_METRICS_ONLY=1` | SASS metric rows and CUBIN/SASS disassembly unless CUBIN capture is disabled | Kernel rows, kernel names/details, memory activity, sync activity, marker activity, graph activity, external correlation, and PC sampling are skipped | Diagnostic safe mode |
+| Safe SASS + kernel activity | `GPUFL_SASS_ALLOW_KERNEL_ACTIVITY=1` | Default SASS data plus CUPTI `KERNEL` and `CONCURRENT_KERNEL` activity records, GPU start/end timing, richer kernel names/details | PC sampling remains skipped when SASS wins | Experimental; needs per-workload validation |
+| Safe SASS + memcpy activity | `GPUFL_SASS_ALLOW_MEM_TRANSFER_ACTIVITY=1` | Default SASS data plus CUPTI memcpy/memset timing, bytes, and direction | MEMORY2 allocation tracking is disabled by default when mem-transfer activity is explicitly enabled, unless `GPUFL_SASS_ALLOW_MEMORY2_ACTIVITY=1` is also set | Experimental |
+| Safe SASS + memory allocation activity | `enable_memory_tracking=True`; optional `GPUFL_SASS_ALLOW_MEMORY2_ACTIVITY=1` | CUPTI `MEMORY2` allocation/free rows with address, size, and memory kind | Memcpy/memset activity remains off unless separately enabled | Default-safe when mem-transfer activity is not enabled |
+| Safe SASS + synchronization activity | `GPUFL_SASS_ALLOW_SYNC_ACTIVITY=1`, `enable_synchronization=True` | CUPTI synchronization timing records | Synchronization callback stack attribution remains disabled in SASS profiler mode | Experimental |
+| Safe SASS + marker activity | `GPUFL_SASS_ALLOW_MARKER_ACTIVITY=1` | CUPTI marker/NVTX records | Does not enable kernel/memory/sync activity by itself | Experimental |
+| Safe SASS + graph activity | `GPUFL_SASS_ALLOW_GRAPH_ACTIVITY=1`, `enable_cuda_graphs_tracking=True` | CUPTI graph launch activity | Per-node graph timing is not implied; kernel activity still requires its own flag | Experimental |
+| Safe SASS + external correlation | `GPUFL_SASS_ALLOW_EXTERNAL_CORRELATION=1`, `enable_external_correlation=True` | Framework external correlation IDs when emitted; runtime/driver anchors are enabled internally | No rows if the framework does not emit external IDs | Experimental, potentially high volume |
+| Legacy SASS + full activity bundle | `GPUFL_SASS_ALLOW_FULL_ACTIVITY=1` | SASS metrics, CUBIN/SASS disassembly, and all requested CUPTI activity layers | PC sampling is still skipped unless `GPUFL_DEEP_TRY_BOTH=1` is also used | Diagnostic only; reproduced hang risk |
+| SASS + PC sampling try-both | `GPUFL_DEEP_TRY_BOTH=1` | If both APIs arm, potentially SASS metrics and PC sampling in one session | Expected to fail or degrade on currently tested drivers because SASS and PC sampling are treated as mutually exclusive | Research-only |
+| CUBIN capture disabled | `GPUFL_SASS_DISABLE_CUBIN_CAPTURE=1` or `GPUFL_DISABLE_CUBIN_CAPTURE=1` | Selected engine can still run | Source/SASS disassembly and CUBIN-backed instruction mapping are unavailable or degraded | Diagnostic only |
+
+## Flag Reference
+
+| Flag | Effect |
+| --- | --- |
+| `GPUFL_DEEP_PC_ONLY=1` | Forces Deep to skip SASS and run PC sampling only. |
+| `GPUFL_SASS_EXCLUDE_ARCHS=86,120` | Skips SASS on listed compute capabilities and lets Deep fall back to PC sampling. |
+| `GPUFL_SASS_METRICS_ONLY=1` | Runs SASS in isolation by disabling activity/callback tracing around SASS. |
+| `GPUFL_SASS_FORCE_SAFE_ACTIVITY=1` | Forces safe SASS activity policy. Equivalent to the current default unless full activity is explicitly allowed. |
+| `GPUFL_SASS_ALLOW_FULL_ACTIVITY=1` | Restores legacy full CUPTI activity behavior in SASS profiler mode. Diagnostic only. |
+| `GPUFL_SASS_ALLOW_KERNEL_ACTIVITY=1` | Enables CUPTI kernel activity in safe SASS mode. |
+| `GPUFL_SASS_ALLOW_MEM_TRANSFER_ACTIVITY=1` | Enables CUPTI memcpy/memset activity in safe SASS mode. |
+| `GPUFL_SASS_ALLOW_MEMORY2_ACTIVITY=1` | Explicitly enables CUPTI `MEMORY2` allocation/free activity in safe SASS mode. |
+| `GPUFL_SASS_ALLOW_MEMORY_ACTIVITY=1` | Alias accepted by the memory activity policy. |
+| `GPUFL_SASS_ALLOW_SYNC_ACTIVITY=1` | Enables CUPTI synchronization activity in safe SASS mode. |
+| `GPUFL_SASS_ALLOW_MARKER_ACTIVITY=1` | Enables CUPTI marker activity in safe SASS mode. |
+| `GPUFL_SASS_ALLOW_GRAPH_ACTIVITY=1` | Enables CUPTI graph launch activity in safe SASS mode. |
+| `GPUFL_SASS_ALLOW_EXTERNAL_CORRELATION=1` | Enables CUPTI external correlation records and runtime/driver anchors in safe SASS mode. |
+| `GPUFL_DEEP_TRY_BOTH=1` | Attempts PC sampling after SASS. Research-only. |
+| `GPUFL_SASS_DISABLE_CUBIN_CAPTURE=1` | Disables CUBIN capture only in SASS profiler modes. |
+| `GPUFL_DISABLE_CUBIN_CAPTURE=1` | Disables CUBIN capture globally. |
+| `GPUFL_SASS_DEFER_SCOPE_FLUSH=1` | Diagnostic mode that keeps SASS armed across scope stop and flushes later. |
+
+## Decision Tree
+
+```text
+ProfilingEngine.Deep
+  |
+  +-- GPUFL_DEEP_PC_ONLY=1?
+  |     |
+  |     +-- yes -> PC sampling only
+  |     |
+  |     +-- no
+  |          |
+  |          +-- GPU architecture excluded by GPUFL_SASS_EXCLUDE_ARCHS?
+  |          |     |
+  |          |     +-- yes -> PC sampling only
+  |          |     |
+  |          |     +-- no
+  |          |          |
+  |          |          +-- Attempt SASS
+  |          |                |
+  |          |                +-- SASS failed to arm -> PC sampling only
+  |          |                |
+  |          |                +-- SASS armed
+  |          |                      |
+  |          |                      +-- GPUFL_SASS_METRICS_ONLY=1?
+  |          |                      |     |
+  |          |                      |     +-- yes -> SASS metrics only
+  |          |                      |
+  |          |                      +-- GPUFL_SASS_ALLOW_FULL_ACTIVITY=1?
+  |          |                      |     |
+  |          |                      |     +-- yes -> SASS + full CUPTI activity bundle
+  |          |                      |              (diagnostic only; observed hang risk)
+  |          |                      |
+  |          |                      +-- default -> Safe SASS Deep
+  |          |                              |
+  |          |                              +-- optional per-kind flags add activity layers:
+  |          |                                  GPUFL_SASS_ALLOW_KERNEL_ACTIVITY
+  |          |                                  GPUFL_SASS_ALLOW_MEM_TRANSFER_ACTIVITY
+  |          |                                  GPUFL_SASS_ALLOW_MEMORY2_ACTIVITY
+  |          |                                  GPUFL_SASS_ALLOW_SYNC_ACTIVITY
+  |          |                                  GPUFL_SASS_ALLOW_MARKER_ACTIVITY
+  |          |                                  GPUFL_SASS_ALLOW_GRAPH_ACTIVITY
+  |          |                                  GPUFL_SASS_ALLOW_EXTERNAL_CORRELATION
+```
+
+## How to Add a New Device Result
+
+Add a new environment section and append rows to the observed results table.
+Record at least:
+
+| Required field | Example |
+| --- | --- |
+| Date | `2026-06-02` |
+| GPU | `NVIDIA GeForce RTX 5060 Laptop GPU` |
+| Compute capability | `12.0` |
+| Driver | `592.01` |
+| CUDA Toolkit | `13.2` |
+| Toolkit CUPTI DLL | `cupti64_2026.1.0.dll` |
+| Framework | `PyTorch 2.12.0+cu132` |
+| Workload | `C1M2_Assignment.py`, one epoch |
+| Scope setup | Outer `train_epoch`, nested scopes, or no scope |
+| Flags | Exact `GPUFL_*` environment variables |
+| Result | `Exit`, `Timeout`, crash, or degraded output |
+| Collected data | Which capture capabilities produced rows |
+| Decision impact | Whether the result changes the default policy |
+
+## Code References
+
+| File | Role |
+| --- | --- |
+| `include/gpufl/backends/nvidia/cupti_backend.hpp` | SASS safe/full activity policy and CUBIN capture gates. |
+| `include/gpufl/backends/nvidia/cupti_backend.cpp` | CUPTI activity enable/disable logic and capture capability reporting. |
+| `include/gpufl/backends/nvidia/kernel_launch_handler.cpp` | Launch callbacks, synthetic kernel rows, and CUPTI kernel activity handling. |
+| `include/gpufl/backends/nvidia/engine/pc_sampling_with_sass_engine.cpp` | Deep mode selection between SASS and PC sampling. |
+| `include/gpufl/backends/nvidia/engine/sass_metrics_engine.cpp` | SASS arm/flush/disable behavior and diagnostic scope flush controls. |

--- a/include/gpufl/backends/nvidia/cupti_backend.hpp
+++ b/include/gpufl/backends/nvidia/cupti_backend.hpp
@@ -54,15 +54,16 @@ class CuptiBackend : public IMonitorBackend {
     }
     bool SassMetricsOnlyMode() const {
         if (!IsSassProfilerMode()) return false;
-        // Isolation mode only. By default match main: allow normal CUPTI
-        // activity/callback tracing to coexist with SASS metrics.
+        // Isolation mode: disable CUPTI activity/callback tracing around SASS
+        // metrics while keeping SASS itself enabled.
         return EnvFlagEnabled_("GPUFL_SASS_METRICS_ONLY");
     }
     bool UseSafeSassActivityDefaults() const {
         if (!IsSassProfilerMode()) return false;
         if (SassMetricsOnlyMode()) return true;
         if (EnvFlagEnabled_("GPUFL_SASS_FORCE_SAFE_ACTIVITY")) return true;
-        return false;
+        if (EnvFlagEnabled_("GPUFL_SASS_ALLOW_FULL_ACTIVITY")) return false;
+        return true;
     }
     bool AllowSassKernelActivity() const {
         if (SassMetricsOnlyMode()) return false;
@@ -130,6 +131,10 @@ class CuptiBackend : public IMonitorBackend {
     // to. (ProfilingEngine::Monitor never constructs a CuptiBackend at
     // all, so it doesn't reach this method.)
     bool NeedsCubinCapture() const {
+        if (EnvFlagEnabled_("GPUFL_DISABLE_CUBIN_CAPTURE")) return false;
+        if (IsSassProfilerMode() &&
+            EnvFlagEnabled_("GPUFL_SASS_DISABLE_CUBIN_CAPTURE"))
+            return false;
         return opts_.profiling_engine == ProfilingEngine::PcSampling ||
                opts_.profiling_engine == ProfilingEngine::SassMetrics ||
                opts_.profiling_engine == ProfilingEngine::Deep;

--- a/include/gpufl/backends/nvidia/engine/sass_metrics_engine.cpp
+++ b/include/gpufl/backends/nvidia/engine/sass_metrics_engine.cpp
@@ -162,6 +162,13 @@ bool ShouldUseLazyPatching() {
     // the all-zero SASS counter behavior.
     return EnvFlagEnabled("GPUFL_SASS_LAZY_PATCHING");
 }
+
+bool ShouldDeferScopeFlush() {
+    // Diagnostic mode: keep SASS armed across scope boundaries and flush only
+    // at session stop/shutdown. This separates "SASS + activity" issues from
+    // "disable/flush raced a concurrent framework launch" issues.
+    return EnvFlagEnabled("GPUFL_SASS_DEFER_SCOPE_FLUSH");
+}
 }  // namespace
 
 bool SassMetricsEngine::initialize(const MonitorOptions& opts,
@@ -332,6 +339,15 @@ void SassMetricsEngine::onScopeStart(const char* name) {
 
 void SassMetricsEngine::onScopeStop(const char* name) {
     if (!enabled_ || !ctx_.cuda_ctx) return;
+
+    if (ShouldDeferScopeFlush()) {
+        GFL_LOG_DEBUG(
+            "[SassMetricsEngine] deferring SASS metrics flush/disable for "
+            "scope: ",
+            name ? name : "<unnamed>",
+            " (GPUFL_SASS_DEFER_SCOPE_FLUSH=1)");
+        return;
+    }
 
     GFL_LOG_DEBUG("[SassMetricsEngine] flushing SASS metrics for scope: ",
                   name ? name : "<unnamed>");

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,7 +79,7 @@ all = [
 
 [tool.scikit-build]
 cmake.args = ["-DCMAKE_BUILD_TYPE=Release", "--log-level=STATUS"]
-cmake.define = { BUILD_PYTHON = "ON", BUILD_GPUFL_EXAMPLE = "OFF" }
+cmake.define = { BUILD_PYTHON = "ON", BUILD_GPUFL_EXAMPLE = "OFF", BUILD_TESTING = "OFF", PYBIND11_FINDPYTHON = "ON" }
 cmake.build-type = "Release"
 cmake.verbose = true
 logging.level = "INFO"

--- a/python/bindings.cpp
+++ b/python/bindings.cpp
@@ -1,4 +1,5 @@
 #include <stdexcept>
+#include <sstream>
 #include <pybind11/pybind11.h>
 #include <pybind11/stl.h>
 #include "gpufl/gpufl.hpp"


### PR DESCRIPTION
## Description
On windows,
- default NVIDIA Deep/SASS mode to safe CUPTI activity policy
- keep full SASS + CUPTI activity bundle behind explicit opt-in flag
- add diagnostic flags for CUBIN capture and deferred SASS scope flush
- fix Windows CUDA/NVML build issues and Python binding include
- add Windows and Ubuntu build helper scripts
- document build script usage and NVIDIA Deep mode compatibility results
## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

## Testing
## Checklist
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas