### PR TITLE
Add NVAPI fallback for GPU/memory utilization on Windows WDDM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -119,6 +119,7 @@ target_sources(gpufl PRIVATE
 
 set(GPUFL_HAS_CUDA 0)
 set(GPUFL_HAS_NVML 0)
+set(GPUFL_HAS_NVAPI 0)
 set(GPUFL_HAS_ROCM 0)
 set(GPUFL_HAS_ROCM_SMI 0)
 set(GPUFL_HAS_HIP 0)
@@ -433,6 +434,59 @@ if(GPUFL_ENABLE_NVIDIA)
         target_link_libraries(gpufl PRIVATE dbghelp pdh psapi)
     endif()
 
+    # NVAPI capability (Windows only): the FB (frame-buffer) domain of
+    # NvAPI_GPU_GetDynamicPstatesInfoEx gives GPU memory-controller utilization
+    # on WDDM (consumer/GeForce), where NVML's util rates read 0% and PDH has no
+    # memory-utilization counter at all. The GPU domain also backstops gpu_util.
+    # NVAPI is open source under the MIT license (github.com/NVIDIA/nvapi), so by
+    # default we pull it via FetchContent (no binaries committed to this repo),
+    # pinned to a commit. A local copy (-DNVAPI_ROOT=... or a third_party/nvapi
+    # checkout) takes precedence for offline builds. See third_party/nvapi/README.md.
+    if(WIN32 AND GPUFL_HAS_NVML)
+        # 1) Prefer a local copy (offline / pinned snapshot) if present.
+        find_path(NVAPI_INCLUDE_DIR NAMES nvapi.h
+            HINTS "${NVAPI_ROOT}" "$ENV{NVAPI_ROOT}"
+                  "${CMAKE_SOURCE_DIR}/third_party/nvapi")
+        find_library(NVAPI_LIBRARY NAMES nvapi64 nvapi
+            HINTS "${NVAPI_ROOT}" "$ENV{NVAPI_ROOT}"
+                  "${CMAKE_SOURCE_DIR}/third_party/nvapi"
+            PATH_SUFFIXES amd64 x64 lib/x64)
+
+        # 2) Otherwise fetch the MIT-licensed open-source SDK (headers + the
+        #    prebuilt amd64/nvapi64.lib stub) into build/_deps. Pinned by SHA —
+        #    the repo publishes no tags.
+        if(NOT (NVAPI_INCLUDE_DIR AND NVAPI_LIBRARY))
+            include(FetchContent)
+            FetchContent_Declare(nvapi
+                GIT_REPOSITORY https://github.com/NVIDIA/nvapi.git
+                GIT_TAG        9b181ea572f680327fe01a14a0f1f41c78034104)  # R595, no tags -> pin SHA
+            # The repo ships no CMakeLists, so download only (no add_subdirectory).
+            # CMP0169 (CMake>=3.30) deprecates bare FetchContent_Populate; OLD
+            # keeps the download-only form usable.
+            if(POLICY CMP0169)
+                cmake_policy(SET CMP0169 OLD)
+            endif()
+            FetchContent_GetProperties(nvapi)
+            if(NOT nvapi_POPULATED)
+                FetchContent_Populate(nvapi)
+            endif()
+            find_path(NVAPI_INCLUDE_DIR NAMES nvapi.h HINTS "${nvapi_SOURCE_DIR}")
+            find_library(NVAPI_LIBRARY NAMES nvapi64 nvapi
+                HINTS "${nvapi_SOURCE_DIR}" PATH_SUFFIXES amd64 x64)
+        endif()
+
+        if(NVAPI_INCLUDE_DIR AND NVAPI_LIBRARY)
+            set(GPUFL_HAS_NVAPI 1)
+            target_include_directories(gpufl PRIVATE ${NVAPI_INCLUDE_DIR})
+            target_link_libraries(gpufl PRIVATE ${NVAPI_LIBRARY})
+            message(STATUS "Found NVAPI: ${NVAPI_LIBRARY} (mem_util/gpu_util on WDDM enabled)")
+        else()
+            message(STATUS
+                "NVAPI unavailable - GPUFL_HAS_NVAPI=0. mem_util will read 0 on "
+                "Windows WDDM (consumer GPUs). See third_party/nvapi/README.md.")
+        endif()
+    endif()
+
     #
     # Only compile NVML collector if NVML is actually available
     #
@@ -541,6 +595,7 @@ endif()
 target_compile_definitions(gpufl PUBLIC
     GPUFL_HAS_CUDA=${GPUFL_HAS_CUDA}
     GPUFL_HAS_NVML=${GPUFL_HAS_NVML}
+    GPUFL_HAS_NVAPI=${GPUFL_HAS_NVAPI}
     GPUFL_HAS_CUPTI=${GPUFL_HAS_CUPTI}
     GPUFL_HAS_PERFWORKS=${GPUFL_HAS_PERFWORKS}
     GPUFL_HAS_ROCM=${GPUFL_HAS_ROCM}

--- a/include/gpufl/backends/nvidia/nvml_collector.cpp
+++ b/include/gpufl/backends/nvidia/nvml_collector.cpp
@@ -15,6 +15,7 @@
 #include <windows.h>
 #include <pdh.h>
 #include <pdhmsg.h>
+#include <cwchar>  // wcsstr — PDH engine-instance name filtering
 #pragma comment(lib, "pdh.lib")
 #endif
 
@@ -56,11 +57,17 @@ NvmlCollector::NvmlCollector() {
 #ifdef _WIN32
     initPdh_();
 #endif
+#if defined(_WIN32) && GPUFL_HAS_NVAPI
+    initNvapi_();
+#endif
 }
 
 NvmlCollector::~NvmlCollector() {
 #ifdef _WIN32
     cleanupPdh_();
+#endif
+#if defined(_WIN32) && GPUFL_HAS_NVAPI
+    cleanupNvapi_();
 #endif
     if (initialized_) {
         // Skip nvmlShutdown() during Windows injection process-exit teardown:
@@ -117,10 +124,25 @@ std::vector<gpufl::DeviceSample> NvmlCollector::sampleAll() {
             s.gpu_util = static_cast<int>(util.gpu);
             s.mem_util = static_cast<int>(util.memory);
         }
+#if defined(_WIN32) && GPUFL_HAS_NVAPI
+        // On Windows WDDM, NVML's util rates read 0% for CUDA workloads (both
+        // gpu and memory). NVAPI's dynamic-pstates GPU/FB domains report
+        // correctly on WDDM — and FB (memory-controller) util has no PDH
+        // equivalent, so NVAPI is the only source for mem_util here. Only
+        // backfill fields NVML left at 0, so correct TCC/datacenter values
+        // (where NVML works) stay intact.
+        if ((s.gpu_util == 0 || s.mem_util == 0) && nvapi_available_) {
+            unsigned int nvapiGpu = 0, nvapiMem = 0;
+            if (sampleUtilNvapi_(s.pci_bus_id, nvapiGpu, nvapiMem)) {
+                if (s.gpu_util == 0) s.gpu_util = nvapiGpu;
+                if (s.mem_util == 0) s.mem_util = nvapiMem;
+            }
+        }
+#endif
 #ifdef _WIN32
-        // On Windows WDDM, NVML returns 0% for CUDA compute workloads.
-        // Fall back to the Windows PDH performance counter for GPU engine
-        // utilization which reports correctly on WDDM.
+        // Last-resort gpu_util fallback: the Windows PDH GPU-engine counter
+        // (reports correctly on WDDM). There is no PDH path for mem_util — no
+        // such counter exists on Windows.
         if (s.gpu_util == 0 && pdh_available_) {
             s.gpu_util = sampleGpuUtilPdh_();
         }
@@ -319,8 +341,9 @@ unsigned int NvmlCollector::sampleGpuUtilPdh_() {
 
     if (PdhCollectQueryData(query) != ERROR_SUCCESS) return 0;
 
-    // The wildcard counter returns multiple instances (one per GPU engine).
-    // Sum the 3D/Compute engine utilization across all instances.
+    // The wildcard counter returns one instance per (process, GPU engine).
+    // We take the max utilization across the 3D/Compute engine instances
+    // (the per-instance engine-type filtering happens in the loop below).
     DWORD bufSize = 0, itemCount = 0;
     PDH_STATUS st = PdhGetFormattedCounterArrayW(
         counter, PDH_FMT_DOUBLE, &bufSize, &itemCount, nullptr);
@@ -334,15 +357,91 @@ unsigned int NvmlCollector::sampleGpuUtilPdh_() {
 
     double maxUtil = 0.0;
     for (DWORD i = 0; i < itemCount; ++i) {
-        if (items[i].FmtValue.CStatus == PDH_CSTATUS_VALID_DATA) {
-            if (items[i].FmtValue.doubleValue > maxUtil)
-                maxUtil = items[i].FmtValue.doubleValue;
-        }
+        if (items[i].FmtValue.CStatus != PDH_CSTATUS_VALID_DATA) continue;
+        // Count only the 3D/Compute engines — CUDA runs there. Skipping the
+        // Copy/Video/Encode/Decode instances stops background video playback
+        // from inflating gpu_util. Instance names look like
+        // "pid_1234_..._engtype_3D" / "..._engtype_Compute".
+        const wchar_t* name = items[i].szName;
+        if (!name ||
+            (!wcsstr(name, L"engtype_3D") && !wcsstr(name, L"engtype_Compute")))
+            continue;
+        if (items[i].FmtValue.doubleValue > maxUtil)
+            maxUtil = items[i].FmtValue.doubleValue;
     }
 
     // PDH returns 0-100 as double; clamp and convert.
     if (maxUtil > 100.0) maxUtil = 100.0;
     return static_cast<unsigned int>(maxUtil);
+}
+#endif
+
+#if defined(_WIN32) && GPUFL_HAS_NVAPI
+void NvmlCollector::initNvapi_() {
+    if (NvAPI_Initialize() != NVAPI_OK) return;
+
+    NvPhysicalGpuHandle handles[NVAPI_MAX_PHYSICAL_GPUS] = {};
+    NvU32 count = 0;
+    if (NvAPI_EnumPhysicalGPUs(handles, &count) != NVAPI_OK) {
+        NvAPI_Unload();
+        return;
+    }
+    // Map each physical GPU by PCI bus id so we can line NVAPI handles up with
+    // NVML's DeviceSample.pci_bus_id (NVAPI enum order != NVML index order).
+    for (NvU32 i = 0; i < count; ++i) {
+        NvU32 busId = 0;
+        if (NvAPI_GPU_GetBusId(handles[i], &busId) == NVAPI_OK)
+            nvapi_by_bus_[static_cast<unsigned int>(busId)] = handles[i];
+    }
+    nvapi_available_ = !nvapi_by_bus_.empty();
+    if (nvapi_available_)
+        GFL_LOG_DEBUG("[NVML] NVAPI dynamic-pstates utilization initialized");
+    else
+        NvAPI_Unload();
+}
+
+void NvmlCollector::cleanupNvapi_() {
+    if (!nvapi_available_) return;
+    nvapi_by_bus_.clear();
+    nvapi_available_ = false;
+    // Mirror the nvmlShutdown teardown guard: during Windows injection
+    // process-exit the driver is being torn down and NvAPI_Unload can hang;
+    // the OS reclaims everything at exit anyway. See teardown_flag.hpp.
+    if (!gpufl::detail::isProcessExitTeardown()) {
+        NvAPI_Unload();
+    }
+}
+
+bool NvmlCollector::sampleUtilNvapi_(int pciBus, unsigned int& gpu,
+                                     unsigned int& mem) {
+    if (!nvapi_available_) return false;
+    auto it = nvapi_by_bus_.find(static_cast<unsigned int>(pciBus));
+    if (it == nvapi_by_bus_.end()) return false;
+
+    NV_GPU_DYNAMIC_PSTATES_INFO_EX info{};
+    info.version = NV_GPU_DYNAMIC_PSTATES_INFO_EX_VER;
+    if (NvAPI_GPU_GetDynamicPstatesInfoEx(it->second, &info) != NVAPI_OK)
+        return false;
+
+    // NVAPI's public header doesn't define named domain constants; the
+    // utilization[] array is indexed by domain in a fixed order (see the
+    // NvAPI_GPU_GetDynamicPstatesInfoEx docs in nvapi.h): 0=GPU (graphics
+    // engine), 1=FB (frame buffer = graphics-memory bandwidth), 2=VID, 3=BUS.
+    constexpr int kDomainGpu = 0;
+    constexpr int kDomainFb  = 1;
+
+    bool any = false;
+    const auto& g = info.utilization[kDomainGpu];
+    const auto& f = info.utilization[kDomainFb];
+    if (g.bIsPresent) {
+        gpu = g.percentage > 100u ? 100u : g.percentage;
+        any = true;
+    }
+    if (f.bIsPresent) {  // FB = frame buffer = graphics-memory bandwidth util
+        mem = f.percentage > 100u ? 100u : f.percentage;
+        any = true;
+    }
+    return any;
 }
 #endif
 

--- a/include/gpufl/backends/nvidia/nvml_collector.hpp
+++ b/include/gpufl/backends/nvidia/nvml_collector.hpp
@@ -8,6 +8,11 @@
 #if GPUFL_ENABLE_NVIDIA && GPUFL_HAS_NVML
 #include <nvml.h>
 
+#if defined(_WIN32) && GPUFL_HAS_NVAPI
+#include <nvapi.h>
+#include <unordered_map>
+#endif
+
 namespace gpufl::nvidia {
 struct NvLinkState {
     unsigned long long lastRxTotal = 0;
@@ -38,6 +43,19 @@ class NvmlCollector : public ISystemCollector<DeviceSample> {
     void  initPdh_();
     void  cleanupPdh_();
     unsigned int sampleGpuUtilPdh_();
+#endif
+
+#if defined(_WIN32) && GPUFL_HAS_NVAPI
+    // NVAPI fallback for GPU + memory(FB) utilization on WDDM, where NVML's
+    // util rates read 0%. FB (memory-controller) util has no PDH counter, so
+    // NVAPI is the only source for mem_util on Windows consumer GPUs.
+    bool nvapi_available_ = false;
+    std::unordered_map<unsigned int, NvPhysicalGpuHandle> nvapi_by_bus_;  // PCI bus -> handle
+    void initNvapi_();
+    void cleanupNvapi_();
+    // Fills gpu/mem (0-100) for the GPU at pciBus via NVAPI dynamic pstates.
+    // Returns false if NVAPI has no data for that bus.
+    bool sampleUtilNvapi_(int pciBus, unsigned int& gpu, unsigned int& mem);
 #endif
 };
 }  // namespace gpufl::nvidia

--- a/third_party/nvapi/README.md
+++ b/third_party/nvapi/README.md
@@ -1,0 +1,51 @@
+# NVAPI (Windows-only, fetched via FetchContent)
+
+`gpufl` uses NVIDIA's **NVAPI** to read GPU and memory-controller utilization on
+Windows **WDDM** (consumer / GeForce) GPUs. There, NVML's
+`nvmlDeviceGetUtilizationRates` returns 0% for CUDA workloads, and the Windows
+PDH performance counters expose **no** memory-utilization counter at all. The
+`FB` (frame-buffer) domain of `NvAPI_GPU_GetDynamicPstatesInfoEx` is the only
+source for `mem_util` on those GPUs; its `GPU` domain also backstops `gpu_util`.
+
+NVAPI is **open source under the MIT license** (<https://github.com/NVIDIA/nvapi>),
+including the prebuilt `amd64/nvapi64.lib` import stub. We therefore **do not
+commit it here** — the build pulls it via CMake `FetchContent` (same mechanism as
+zlib), pinned to a commit.
+
+## How it's sourced (default)
+
+On a Windows build with NVIDIA enabled, CMake clones the repo into
+`build/_deps/nvapi-src/` and links `amd64/nvapi64.lib` from there. Pinned to:
+
+```
+github.com/NVIDIA/nvapi @ 9b181ea572f680327fe01a14a0f1f41c78034104   # R595
+```
+
+The repo ships no tags, so the pin is a commit SHA. **To update**: bump
+`GIT_TAG` in the NVAPI block of the top-level `CMakeLists.txt`. Linux / non-Windows
+builds never fetch it (`GPUFL_HAS_NVAPI=0`; the NVAPI code in
+`nvml_collector.{hpp,cpp}` is compiled out via `#if defined(_WIN32) && GPUFL_HAS_NVAPI`).
+
+## Offline / local override (optional)
+
+To build without the network, point CMake at a local copy instead — it takes
+precedence over FetchContent:
+
+- `cmake -DNVAPI_ROOT=C:/path/to/nvapi ...`, **or** set `NVAPI_ROOT` in the env,
+  **or** drop the SDK into this folder so the layout is:
+  ```
+  third_party/nvapi/
+    nvapi.h
+    nvapi_lite_*.h        (and the other NVAPI headers)
+    amd64/nvapi64.lib
+  ```
+
+On success you'll see: `-- Found NVAPI: .../nvapi64.lib (mem_util/gpu_util on WDDM enabled)`.
+
+## License compliance
+
+NVAPI is MIT (`SPDX-License-Identifier: MIT`, © NVIDIA). MIT permits commercial
+use and redistribution; the only obligation is to **include the copyright +
+permission notice** with the distributed product. Since the shipped `gpufl`
+binary statically links the `nvapi64.lib` stub, add NVAPI's MIT notice (its
+`License.txt`) to the product's third-party license/NOTICE file.


### PR DESCRIPTION
NVML's util rates return 0% for CUDA workloads on WDDM (consumer/GeForce) GPUs, and Windows PDH has no memory-controller utilization counter at all. Fall back per-field to NVAPI dynamic-pstates when NVML reads 0: GPU domain -> gpu_util, FB domain -> mem_util. Order is NVML -> NVAPI -> PDH for gpu_util (PDH filtered to 3D/Compute engines); NVML -> NVAPI for mem_util (no PDH counter exists). No wire/schema change - fills the existing mem_util/gpu_util columns.

NVAPI (MIT, github.com/NVIDIA/nvapi) is pulled via FetchContent pinned to the R595 commit; a local copy via -DNVAPI_ROOT or third_party/nvapi takes precedence. Windows-only; Linux builds set GPUFL_HAS_NVAPI=0 and compile the NVAPI paths out.

Verified: builds with GPUFL_HAS_NVAPI 0 and 1 (VS2022/CUDA 13.2); runtime on RTX 5060 Laptop (WDDM) shows NVAPI FB mem_util=98%, gpu_util=100% under real ~310 GB/s memory load, matching PDH 3D/Compute.

## Description
## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Documentation update

## Testing
## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas