### PR TITLE
Refactor async

### DIFF
--- a/example/cuda/deep_deadlock_repro.cu
+++ b/example/cuda/deep_deadlock_repro.cu
@@ -220,6 +220,12 @@ int main(int argc, char** argv) {
     const int steps      = intArg(argc, argv, "steps", 40);
     const int timeoutSec = intArg(argc, argv, "timeout", 60);
     const bool useScope  = !hasFlag(argc, argv, "noscope");
+    // Experiment knob: serially first-launch every distinct kernel inside the
+    // SASS-armed scope BEFORE releasing the concurrent threads. Tests the
+    // hypothesis that the hang is CUPTI's lazy SASS patching of modules loaded
+    // after arm — done serially (no concurrency) it should patch each module
+    // without the launch-rwlock ↔ CUPTI-lock AB-BA.
+    const bool prewarm   = hasFlag(argc, argv, "prewarm");
     const gpufl::ProfilingEngine engine = engineArg(argc, argv);
 
     const char* fullActivity = std::getenv("GPUFL_SASS_ALLOW_FULL_ACTIVITY");
@@ -233,6 +239,7 @@ int main(int argc, char** argv) {
               << "  steps/thread    : " << steps << "\n"
               << "  distinct kernels: " << kNumDistinctKernels << "\n"
               << "  scope-wrapped   : " << (useScope ? "yes" : "no (control)") << "\n"
+              << "  prewarm modules : " << (prewarm ? "yes (serial first-launch before concurrency)" : "no") << "\n"
               << "  CUPTI activity  : "
               << (unsafeMode ? "FULL (GPUFL_SASS_ALLOW_FULL_ACTIVITY=1 — UNSAFE, may hang)"
                             : "safe (default defense)")
@@ -298,6 +305,28 @@ int main(int argc, char** argv) {
     launchers.reserve(numThreads);
 
     auto runWorkload = [&]() {
+        if (prewarm) {
+            // Serially first-launch every distinct kernel BEFORE releasing the
+            // concurrent threads. Runs inside the SASS-armed scope, so if the
+            // deadlock is CUPTI lazily patching modules loaded after arm, this
+            // patches each module one-at-a-time (no concurrency → no AB-BA),
+            // leaving the concurrent loop below to only re-launch already-
+            // patched modules.
+            std::cout << "[prewarm] serially launching " << kNumDistinctKernels
+                      << " distinct kernels before concurrency...\n" << std::flush;
+            const int n = 1 << 18;
+            float* d = nullptr;
+            if (cudaMalloc(&d, n * sizeof(float)) == cudaSuccess) {
+                cudaMemset(d, 0, n * sizeof(float));
+                const dim3 block(256), grid((n + block.x - 1) / block.x);
+                for (int k = 0; k < kNumDistinctKernels; ++k) {
+                    kDistinctKernels[k]<<<grid, block>>>(d, n);
+                    cudaDeviceSynchronize();  // one module patched at a time
+                }
+                cudaFree(d);
+            }
+            std::cout << "[prewarm] done — modules patched serially.\n" << std::flush;
+        }
         for (int t = 0; t < numThreads; ++t)
             launchers.emplace_back(launcherThread, t, steps, std::ref(go),
                                    std::ref(liveCount));

--- a/example/cuda/deep_deadlock_repro.cu
+++ b/example/cuda/deep_deadlock_repro.cu
@@ -77,6 +77,7 @@
 #include <cstdlib>
 #include <cstring>
 #include <iostream>
+#include <mutex>
 #include <string>
 #include <thread>
 #include <vector>
@@ -127,6 +128,16 @@ static KernelFn kDistinctKernels[] = {
 };
 static constexpr int kNumDistinctKernels =
     sizeof(kDistinctKernels) / sizeof(kDistinctKernels[0]);
+
+// Experiment knob: when set (via the `serialize` flag), every launcher thread
+// takes this global mutex around its kernel <<<>>> launch, so only one thread
+// is inside the driver's launch enqueue at a time. Tests the "SASS Safe-Lock"
+// mitigation: if the hang is concurrent cuLaunchKernel threads tangling the
+// driver launch rwlock, serializing the host-side enqueue should break it
+// (GPU execution still overlaps — only the dispatch is serialized). Set in
+// main() before any launcher thread is spawned, then read-only.
+static std::mutex g_launchSerializeMu;
+static bool g_serializeLaunches = false;
 
 // ── CLI parsing helpers ─────────────────────────────────────────────────────
 
@@ -203,7 +214,15 @@ static void launcherThread(int threadId, int steps,
             // Offset by threadId so threads hit *different* distinct symbols
             // first → maximal distinct-first-launch concurrency.
             int idx = (k + threadId) % kNumDistinctKernels;
-            kDistinctKernels[idx]<<<grid, block, 0, stream>>>(d_buf, n);
+            if (g_serializeLaunches) {
+                // SASS Safe-Lock: only one thread in the driver launch enqueue
+                // at a time. The lock spans just the host-side dispatch; the
+                // kernel still executes async on the stream after we release.
+                std::lock_guard<std::mutex> lk(g_launchSerializeMu);
+                kDistinctKernels[idx]<<<grid, block, 0, stream>>>(d_buf, n);
+            } else {
+                kDistinctKernels[idx]<<<grid, block, 0, stream>>>(d_buf, n);
+            }
         }
         // Periodic sync mimics a training step boundary and forces the
         // activity/callback path to flush under contention.
@@ -226,6 +245,8 @@ int main(int argc, char** argv) {
     // after arm — done serially (no concurrency) it should patch each module
     // without the launch-rwlock ↔ CUPTI-lock AB-BA.
     const bool prewarm   = hasFlag(argc, argv, "prewarm");
+    // SASS Safe-Lock experiment: serialize host-side kernel-launch enqueue.
+    g_serializeLaunches  = hasFlag(argc, argv, "serialize");
     const gpufl::ProfilingEngine engine = engineArg(argc, argv);
 
     const char* fullActivity = std::getenv("GPUFL_SASS_ALLOW_FULL_ACTIVITY");
@@ -240,6 +261,7 @@ int main(int argc, char** argv) {
               << "  distinct kernels: " << kNumDistinctKernels << "\n"
               << "  scope-wrapped   : " << (useScope ? "yes" : "no (control)") << "\n"
               << "  prewarm modules : " << (prewarm ? "yes (serial first-launch before concurrency)" : "no") << "\n"
+              << "  serialize launch: " << (g_serializeLaunches ? "yes (global launch mutex — SASS Safe-Lock)" : "no") << "\n"
               << "  CUPTI activity  : "
               << (unsafeMode ? "FULL (GPUFL_SASS_ALLOW_FULL_ACTIVITY=1 — UNSAFE, may hang)"
                             : "safe (default defense)")

--- a/include/gpufl/backends/nvidia/cupti_backend.cpp
+++ b/include/gpufl/backends/nvidia/cupti_backend.cpp
@@ -495,6 +495,14 @@ void CuptiBackend::start() {
     function_record_seen_.store(0, std::memory_order_relaxed);
     capture_capabilities_emitted_.store(false, std::memory_order_relaxed);
 
+    // Capture the per-session CUPTI->wall clock anchor before enabling any
+    // activity kind, so every activity record converts against a consistent,
+    // per-session-fresh base. Replaces the old function-static anchor in
+    // BufferCompleted (which leaked across init/shutdown cycles).
+    base_cpu_ns_ = detail::GetTimestampNs();
+    base_cupti_ts_ = 0;
+    cuptiGetTimestamp(&base_cupti_ts_);
+
     // Resolve CUDA context/device before asking handlers for activity kinds.
     // SASS safe-mode policy is device dependent, and the policy log should
     // report the real SM version. Querying requiredActivityKinds() before this
@@ -1312,9 +1320,14 @@ void CUPTIAPI CuptiBackend::BufferCompleted(CUcontext context,
         return;
     }
 
-    static int64_t baseCpuNs = detail::GetTimestampNs();
-    static uint64_t baseCuptiTs = 0;
-    if (baseCuptiTs == 0) cuptiGetTimestamp(&baseCuptiTs);
+    // Per-session clock anchor, captured in start(). Defensive lazy-init in
+    // case an activity record somehow arrives before start() set it.
+    if (backend->base_cupti_ts_ == 0) {
+        backend->base_cpu_ns_ = detail::GetTimestampNs();
+        cuptiGetTimestamp(&backend->base_cupti_ts_);
+    }
+    const int64_t baseCpuNs = backend->base_cpu_ns_;
+    const uint64_t baseCuptiTs = backend->base_cupti_ts_;
 
     std::vector<std::shared_ptr<ICuptiHandler>> handlers;
     {

--- a/include/gpufl/backends/nvidia/cupti_backend.cpp
+++ b/include/gpufl/backends/nvidia/cupti_backend.cpp
@@ -495,6 +495,29 @@ void CuptiBackend::start() {
     function_record_seen_.store(0, std::memory_order_relaxed);
     capture_capabilities_emitted_.store(false, std::memory_order_relaxed);
 
+    // Reset the BufferCompleted companion maps for a clean per-session slate
+    // (Step 5). These persist across BufferCompleted calls *within* a session
+    // but were never cleared *between* sessions — across an init/shutdown cycle
+    // CUPTI reuses sourceLocator / function / marker ids, so a stale entry from
+    // a prior session could mis-attribute a PC sample or NVTX range. Safe to do
+    // here: start() runs before any activity kind is enabled below, so no
+    // BufferCompleted can be in flight yet (the mutexes are belt-and-suspenders).
+    // g_extCorrMap is also cleared at stop(); clearing here too makes the slate
+    // robust no matter how the previous session ended.
+    {
+        std::lock_guard lk(g_sourceLocatorMu);
+        g_sourceLocatorMap.clear();
+        g_functionNameMap.clear();
+    }
+    {
+        std::lock_guard lk(g_nvtxMu);
+        g_nvtxOpen.clear();
+    }
+    {
+        std::lock_guard lk(g_extCorrMu);
+        g_extCorrMap.clear();
+    }
+
     // Capture the per-session CUPTI->wall clock anchor before enabling any
     // activity kind, so every activity record converts against a consistent,
     // per-session-fresh base. Replaces the old function-static anchor in

--- a/include/gpufl/backends/nvidia/cupti_backend.cpp
+++ b/include/gpufl/backends/nvidia/cupti_backend.cpp
@@ -1543,23 +1543,11 @@ void CUPTIAPI CuptiBackend::BufferCompleted(CUcontext context,
                         out.sync_type     = static_cast<uint8_t>(s->type);
                         out.sync_event_id = s->cudaEventId;
                         out.context_id    = s->contextId;
-                        // Join the user call stack captured by
-                        // SynchronizationHandler on API_ENTER. Erasing
-                        // after lookup keeps sync_meta_by_corr_ bounded
-                        // — sync activity records are 1:1 with the
-                        // API call, unlike kernel correlations that
-                        // can span multiple activity records.
-                        // (BufferCompleted is a static method, so we
-                        // access non-static state through the backend
-                        // pointer captured at line 851.)
-                        {
-                            std::lock_guard lk(backend->sync_meta_mu_);
-                            auto smIt = backend->sync_meta_by_corr_.find(s->correlationId);
-                            if (smIt != backend->sync_meta_by_corr_.end()) {
-                                out.stack_id = smIt->second.stack_id;
-                                backend->sync_meta_by_corr_.erase(smIt);
-                            }
-                        }
+                        // The user call stack captured by SynchronizationHandler
+                        // at API_ENTER is joined on the collector thread now
+                        // (g_syncStackByCorr in monitor.cpp, keyed by corr_id) —
+                        // no sync_meta_mu_ here. out.stack_id stays 0; the
+                        // collector fills it. (Step 4c.)
                         g_monitorBuffer.Push(out);
                     }
                     // (EXTERNAL_CORRELATION handled in pass 1 above —

--- a/include/gpufl/backends/nvidia/cupti_backend.cpp
+++ b/include/gpufl/backends/nvidia/cupti_backend.cpp
@@ -413,12 +413,10 @@ void CuptiBackend::initialize(const MonitorOptions& opts) {
 
     std::set<CUpti_CallbackDomain> domains;
     std::set<std::pair<CUpti_CallbackDomain, CUpti_CallbackId>> callbacks;
-    {
-        std::lock_guard<std::mutex> lk(handler_mu_);
-        for (const auto& h : handlers_) {
-            for (auto d : h->requiredDomains()) domains.insert(d);
-            for (auto cb : h->requiredCallbacks()) callbacks.insert(cb);
-        }
+    // handlers_ just registered above on this thread; read lock-free.
+    for (const auto& h : handlers_) {
+        for (auto d : h->requiredDomains()) domains.insert(d);
+        for (auto cb : h->requiredCallbacks()) callbacks.insert(cb);
     }
     for (auto d : domains) CUPTI_CHECK(cuptiEnableDomain(1, subscriber_, d));
     for (auto& [domain, cbid] : callbacks)
@@ -707,14 +705,12 @@ void CuptiBackend::start() {
         }
     }
 
-    // Enable activity kinds required by registered handlers (always on)
+    // Enable activity kinds required by registered handlers (always on).
+    // handlers_ is immutable after initialize() → read lock-free.
     {
         std::set<CUpti_ActivityKind> kinds;
-        {
-            std::lock_guard<std::mutex> lk(handler_mu_);
-            for (const auto& h : handlers_)
-                for (auto k : h->requiredActivityKinds()) kinds.insert(k);
-        }
+        for (const auto& h : handlers_)
+            for (auto k : h->requiredActivityKinds()) kinds.insert(k);
         for (auto k : kinds) CUPTI_CHECK(cuptiActivityEnable(k));
     }
 
@@ -734,11 +730,8 @@ void CuptiBackend::start() {
     // kernel activity records are produced regardless of engine type.
     {
         std::set<CUpti_ActivityKind> kinds;
-        {
-            std::lock_guard lk(handler_mu_);
-            for (const auto& h : handlers_)
-                for (auto k : h->requiredActivityKinds()) kinds.insert(k);
-        }
+        for (const auto& h : handlers_)
+            for (auto k : h->requiredActivityKinds()) kinds.insert(k);
         for (auto k : kinds) cuptiActivityEnable(k);
     }
 
@@ -1110,11 +1103,8 @@ void CuptiBackend::stop() {
     // below. So we don't lose any data by disabling first.
     {
         std::set<CUpti_ActivityKind> kinds;
-        {
-            std::lock_guard lk(handler_mu_);
-            for (const auto& h : handlers_)
-                for (auto k : h->requiredActivityKinds()) kinds.insert(k);
-        }
+        for (const auto& h : handlers_)
+            for (auto k : h->requiredActivityKinds()) kinds.insert(k);
         for (auto k : kinds) cuptiActivityDisable(k);
     }
 
@@ -1178,7 +1168,8 @@ void CuptiBackend::stop() {
 void CuptiBackend::RegisterHandler(
     const std::shared_ptr<ICuptiHandler>& handler) {
     if (!handler) return;
-    std::lock_guard lk(handler_mu_);
+    // No lock: called only from initialize() before CUPTI callbacks are enabled
+    // (single-threaded setup). handlers_ is immutable once callbacks can fire.
     handlers_.push_back(handler);
 }
 
@@ -1257,11 +1248,9 @@ void CUPTIAPI CuptiBackend::BufferCompleted(CUcontext context,
     const int64_t baseCpuNs = backend->base_cpu_ns_;
     const uint64_t baseCuptiTs = backend->base_cupti_ts_;
 
-    std::vector<std::shared_ptr<ICuptiHandler>> handlers;
-    {
-        std::lock_guard lk(backend->handler_mu_);
-        handlers = backend->handlers_;
-    }
+    // handlers_ is immutable after initialize() (see its declaration) — iterate
+    // it directly: no handler_mu_, no per-buffer vector copy.
+    const auto& handlers = backend->handlers_;
 
     if (validSize > 0) {
         // ----------------------------------------------------------------
@@ -1598,11 +1587,9 @@ void CuptiBackend::GflCallback(void* userdata, CUpti_CallbackDomain domain,
     auto* backend = static_cast<CuptiBackend*>(userdata);
     if (!backend) return;
 
-    std::vector<std::shared_ptr<ICuptiHandler>> handlers;
-    {
-        std::lock_guard<std::mutex> lk(backend->handler_mu_);
-        handlers = backend->handlers_;
-    }
+    // handlers_ is immutable after initialize() (see its declaration) — iterate
+    // it directly on this per-callback hot path: no handler_mu_, no copy/alloc.
+    const auto& handlers = backend->handlers_;
 
     bool apiHandled = false;
 

--- a/include/gpufl/backends/nvidia/cupti_backend.cpp
+++ b/include/gpufl/backends/nvidia/cupti_backend.cpp
@@ -1131,7 +1131,13 @@ void CuptiBackend::stop() {
         LogCuptiIfUnexpected("Perfworks", "cuptiActivityFlushAll",
                              cuptiActivityFlushAll(1));
     }
-    FlushPendingKernels();
+    // Synthetic kernels (launches CUPTI delivered no activity record for) are
+    // now flushed by the collector thread from its worker-local meta map once
+    // the ring is fully drained (drainSyntheticKernels in monitor.cpp, invoked
+    // at CollectorLoop teardown + Monitor::Shutdown's post-join drain) — see
+    // Step 4b-2. This used to call FlushPendingKernels() here on the stop
+    // thread. The summary counters below therefore now reflect real activity
+    // records only; synthetic rows are counted/emitted later by the collector.
     {
         std::lock_guard lk(g_extCorrMu);
         g_extCorrMap.clear();
@@ -1196,107 +1202,6 @@ void CuptiBackend::FlushOnContextDestroy() {
                          cuptiActivityFlushAll(1));
 
     context_destroy_flushing_.store(false, std::memory_order_release);
-}
-
-void CuptiBackend::FlushPendingKernels() {
-    const int64_t flushNs = detail::GetTimestampNs();
-    std::unordered_map<uint64_t, LaunchMeta> pending;
-    {
-        std::lock_guard lk(meta_mu_);
-        pending = std::move(meta_by_corr_);
-    }
-    GFL_LOG_DEBUG("[FlushPendingKernels] draining ", pending.size(),
-                  " synthetic kernel(s) at flushNs=", flushNs);
-
-    // Build an order-by-api-enter index so we can approximate per-kernel
-    // GPU time as the interval between this kernel's dispatch and the
-    // next kernel's dispatch (or the scope flush time for the last one).
-    //
-    // CUPTI did NOT deliver activity records for these kernels (common on
-    // Blackwell with PC Sampling SamplingAPI: PC Sampling captures the
-    // kernel stream, so KERNEL activity kinds stay dormant). Without GPU
-    // timestamps we fall back to host-side dispatch intervals — an
-    // imperfect proxy that nonetheless reflects the actual sequential
-    // execution pattern for typical single-stream workloads and is
-    // strictly better than reporting 0.
-    std::vector<uint64_t> orderedCorr;
-    orderedCorr.reserve(pending.size());
-    for (const auto& [corr, _] : pending) orderedCorr.push_back(corr);
-    std::sort(orderedCorr.begin(), orderedCorr.end(),
-              [&](uint64_t a, uint64_t b) {
-                  return pending[a].api_enter_ns < pending[b].api_enter_ns;
-              });
-
-    for (size_t i = 0; i < orderedCorr.size(); ++i) {
-        const uint64_t corr = orderedCorr[i];
-        auto& m = pending[corr];
-        ActivityRecord out{};
-        out.device_id = device_id_;
-        out.stream = 0;
-        out.type = TraceType::KERNEL;
-        std::snprintf(out.name, sizeof(out.name), "%s", m.name);
-        out.cpu_start_ns = m.api_enter_ns;
-
-        // Synthetic duration: interval until the next kernel's dispatch
-        // (they run sequentially on the default stream of single-stream
-        // workloads, so one's completion roughly aligns with the next
-        // one's dispatch return) — or flushNs for the last kernel
-        // (it completed between its dispatch and our post-sync flush).
-        const int64_t nextEnterNs = (i + 1 < orderedCorr.size())
-            ? pending[orderedCorr[i + 1]].api_enter_ns
-            : flushNs;
-        int64_t synthDur = nextEnterNs - m.api_enter_ns;
-        if (synthDur < 0) synthDur = 0;  // clock skew guard
-        out.duration_ns = synthDur;
-        out.corr_id = static_cast<unsigned>(corr);
-        out.api_start_ns = m.api_enter_ns;
-        out.api_exit_ns = m.api_exit_ns > 0 ? m.api_exit_ns : flushNs;
-        out.scope_depth = m.scope_depth;
-        out.stack_id = m.stack_id;
-        std::copy(std::begin(m.user_scope), std::end(m.user_scope),
-                  std::begin(out.user_scope));
-        if (m.has_details) {
-            out.has_details = true;
-            out.grid_x = m.grid_x;
-            out.grid_y = m.grid_y;
-            out.grid_z = m.grid_z;
-            out.block_x = m.block_x;
-            out.block_y = m.block_y;
-            out.block_z = m.block_z;
-            out.dyn_shared = m.dyn_shared;
-
-            SmProps props = GetSMProps(out.device_id);
-            int threadsPerBlock =
-                out.block_x * out.block_y * out.block_z;
-            int warpsPerBlock =
-                (threadsPerBlock + props.warpSize - 1) / props.warpSize;
-            int maxWarpsPerSM = props.maxThreadsPerSM / props.warpSize;
-            int warpBlocks = (warpsPerBlock > 0)
-                                 ? (maxWarpsPerSM / warpsPerBlock) : 0;
-            int blockBlocks = props.maxBlocksPerSM;
-            out.max_active_blocks = std::min(warpBlocks, blockBlocks);
-            auto toOcc = [&](int blocks) -> float {
-                return (maxWarpsPerSM > 0 && warpsPerBlock > 0)
-                           ? std::min(1.0f,
-                                      static_cast<float>(
-                                          blocks * warpsPerBlock) /
-                                          maxWarpsPerSM)
-                           : 0.0f;
-            };
-            out.warp_occupancy = toOcc(warpBlocks);
-            out.block_occupancy = toOcc(blockBlocks);
-            out.occupancy = out.warp_occupancy;
-            std::snprintf(out.limiting_resource,
-                          sizeof(out.limiting_resource), "%s", "warps");
-        }
-        GFL_LOG_DEBUG("[FlushPendingKernels] synth corr=", corr,
-                      " name=", out.name,
-                      " scope=", out.user_scope,
-                      " dur=", out.duration_ns, "ns");
-        g_monitorBuffer.Push(out);
-        kernel_activity_seen_.fetch_add(1, std::memory_order_relaxed);
-        kernel_activity_emitted_.fetch_add(1, std::memory_order_relaxed);
-    }
 }
 
 // ---- Static callbacks ------------------------------------------------------

--- a/include/gpufl/backends/nvidia/cupti_backend.hpp
+++ b/include/gpufl/backends/nvidia/cupti_backend.hpp
@@ -217,8 +217,15 @@ class CuptiBackend : public IMonitorBackend {
     std::unordered_map<uint64_t, CubinInfo> cubin_by_crc_;
     std::unordered_set<const void*> seen_cubin_ptrs_;
 
+    // Registered once in initialize() via RegisterHandler — BEFORE the CUPTI
+    // subscriber + activity callbacks are enabled — and never modified for the
+    // rest of the backend's lifetime (a fresh CuptiBackend is created per
+    // session; see Monitor::Shutdown's adapter.reset() + Initialize). It is
+    // therefore IMMUTABLE while any callback can run, so GflCallback /
+    // BufferCompleted (and start()/stop()) read it lock-free — no handler_mu_,
+    // and the per-callback vector copy is gone (zero-alloc dispatch). Do NOT
+    // call RegisterHandler after initialize() has enabled callbacks.
     std::vector<std::shared_ptr<ICuptiHandler>> handlers_;
-    std::mutex handler_mu_;
 
     std::atomic<uint64_t> last_kernel_end_ts_{0};
     std::atomic<uint64_t> kernel_activity_seen_{0};

--- a/include/gpufl/backends/nvidia/cupti_backend.hpp
+++ b/include/gpufl/backends/nvidia/cupti_backend.hpp
@@ -197,6 +197,18 @@ class CuptiBackend : public IMonitorBackend {
     std::mutex sync_meta_mu_;
     std::unordered_map<uint64_t, SyncMeta> sync_meta_by_corr_;
 
+    // Per-session clock anchor mapping CUPTI activity timestamps
+    // (cuptiGetTimestamp domain) to wall-clock ns. Captured fresh in start()
+    // so re-init sessions re-anchor — the previous function-static anchor in
+    // BufferCompleted persisted process-wide and skewed timestamps across
+    // init/shutdown cycles. Written once in start() before any activity record
+    // can arrive; read on the (serial) BufferCompleted thread.
+    int64_t base_cpu_ns_ = 0;
+    uint64_t base_cupti_ts_ = 0;
+    int64_t toWallNs(uint64_t cuptiTs) const {
+        return base_cpu_ns_ + static_cast<int64_t>(cuptiTs - base_cupti_ts_);
+    }
+
     std::string cached_device_name_ = "Unknown Device";
     CUcontext ctx_ = nullptr;
 

--- a/include/gpufl/backends/nvidia/cupti_backend.hpp
+++ b/include/gpufl/backends/nvidia/cupti_backend.hpp
@@ -55,6 +55,17 @@ class CuptiBackend : public IMonitorBackend {
     bool AllowSassKernelActivity() const {
         return resolved_plan_.allow_sass_kernel_activity;
     }
+    // True when CUPTI kernel ACTIVITY records won't be collected, so every
+    // launch must be reported from its callback as a synthetic kernel (PC
+    // Sampling, or SASS profiler safe mode without GPUFL_SASS_ALLOW_KERNEL_
+    // ACTIVITY). Mirrors KernelLaunchHandler::requiredActivityKinds() returning
+    // {}. In these modes the launch callback precomputes the simplified kernel
+    // occupancy (the activity record that would otherwise carry it never
+    // arrives); see KernelLaunchHandler::handle + drainSyntheticKernels.
+    bool WillEmitSyntheticKernels() const {
+        return opts_.profiling_engine == ProfilingEngine::PcSampling ||
+               !AllowSassKernelActivity();
+    }
     bool AllowSassMarkerActivity() const {
         return resolved_plan_.allow_sass_marker_activity;
     }
@@ -99,11 +110,6 @@ class CuptiBackend : public IMonitorBackend {
 
     bool IsActive() const { return active_.load(); }
     const MonitorOptions& GetOptions() const { return opts_; }
-
-    // Flush any pending kernel metadata as synthetic activity records.
-    // Called from scope stop after cudaDeviceSynchronize() so durations
-    // reflect actual GPU execution time.
-    void FlushPendingKernels();
 
     // Drain CUPTI activity buffers from the CUPTI_CBID_RESOURCE_CONTEXT_
     // DESTROY_STARTING callback — i.e. while the context is still alive, just
@@ -182,14 +188,17 @@ class CuptiBackend : public IMonitorBackend {
     DeviceFacts device_facts_;
     ResolvedProfilingPlan resolved_plan_;
 
-    std::mutex meta_mu_;
-    std::unordered_map<uint64_t, LaunchMeta> meta_by_corr_;
+    // NOTE (Step 4b-2): the launch-meta join map + its mutex are GONE. The
+    // corr->meta join (kernel AND memcpy/memset) now runs lock-free on the
+    // single collector thread (g_launchMetaByCorr / joinLaunchMeta in
+    // monitor.cpp); the launch callbacks push KERNEL_LAUNCH_META /
+    // KERNEL_API_EXIT records to the ring instead of locking meta_mu_.
 
     // Sync metadata captured by SynchronizationHandler on API_ENTER and
     // joined to the SYNCHRONIZATION activity record by correlationId in
-    // BufferCompleted. Separate mutex from meta_mu_ so sync API_ENTER
-    // doesn't contend with kernel-launch metadata writes during bursty
-    // workloads (PyTorch eager mode interleaves both heavily).
+    // BufferCompleted. Still mutex-guarded (the kernel/mem join went lock-free
+    // in 4b-2; this sync join follows in 4c — same pattern: push SYNC_META to
+    // the ring and join on the collector thread, then this mutex too is gone).
     struct SyncMeta {
         size_t stack_id = 0;
         int64_t api_enter_ns = 0;

--- a/include/gpufl/backends/nvidia/cupti_backend.hpp
+++ b/include/gpufl/backends/nvidia/cupti_backend.hpp
@@ -188,23 +188,12 @@ class CuptiBackend : public IMonitorBackend {
     DeviceFacts device_facts_;
     ResolvedProfilingPlan resolved_plan_;
 
-    // NOTE (Step 4b-2): the launch-meta join map + its mutex are GONE. The
-    // corr->meta join (kernel AND memcpy/memset) now runs lock-free on the
-    // single collector thread (g_launchMetaByCorr / joinLaunchMeta in
-    // monitor.cpp); the launch callbacks push KERNEL_LAUNCH_META /
-    // KERNEL_API_EXIT records to the ring instead of locking meta_mu_.
-
-    // Sync metadata captured by SynchronizationHandler on API_ENTER and
-    // joined to the SYNCHRONIZATION activity record by correlationId in
-    // BufferCompleted. Still mutex-guarded (the kernel/mem join went lock-free
-    // in 4b-2; this sync join follows in 4c — same pattern: push SYNC_META to
-    // the ring and join on the collector thread, then this mutex too is gone).
-    struct SyncMeta {
-        size_t stack_id = 0;
-        int64_t api_enter_ns = 0;
-    };
-    std::mutex sync_meta_mu_;
-    std::unordered_map<uint64_t, SyncMeta> sync_meta_by_corr_;
+    // NOTE (Steps 4b-2 + 4c): the launch-meta AND sync-meta join maps + their
+    // mutexes are GONE. All corr-keyed joins (kernel, memcpy/memset, and sync)
+    // now run lock-free on the single collector thread (g_launchMetaByCorr /
+    // g_syncStackByCorr in monitor.cpp); the callbacks push KERNEL_LAUNCH_META /
+    // KERNEL_API_EXIT / SYNC_META records to the ring instead of taking a lock.
+    // The CUPTI launch + sync callbacks are now zero-lock.
 
     // Per-session clock anchor mapping CUPTI activity timestamps
     // (cuptiGetTimestamp domain) to wall-clock ns. Captured fresh in start()

--- a/include/gpufl/backends/nvidia/cupti_common.hpp
+++ b/include/gpufl/backends/nvidia/cupti_common.hpp
@@ -78,7 +78,7 @@ struct LaunchMeta {
         num_regs = 0;
     float occupancy = 0.0f;
     int max_active_blocks = 0;
-    char name[128]{};
+    char name[256]{};  // RAW (mangled) name; demangled on the collector thread
     char user_scope[256]{};
     int scope_depth{};
     size_t stack_id{};

--- a/include/gpufl/backends/nvidia/kernel_launch_handler.cpp
+++ b/include/gpufl/backends/nvidia/kernel_launch_handler.cpp
@@ -454,7 +454,6 @@ bool KernelLaunchHandler::handleActivityRecord(const CUpti_Activity* record,
     out.dyn_shared = k->dynamicSharedMemory;
     out.static_shared = k->staticSharedMemory;
     out.num_regs = k->registersPerThread;
-    out.has_details = false;
 
     // Phase 1a: always-on fields from CUpti_ActivityKernel11
     out.local_mem_total = k->localMemoryTotal;
@@ -499,15 +498,86 @@ bool KernelLaunchHandler::handleActivityRecord(const CUpti_Activity* record,
         }
     }
 
+    out.corr_id = k->correlationId;
+
+    // Launch dims + occupancy come straight from the activity record:
+    // CUpti_ActivityKernel11 carries the ACTUAL launched grid/block/regs/
+    // shared-mem, so they're computed with NO lock and for every kernel —
+    // independent of whether the launch-callback metadata is present. (Step 4b)
+    out.has_details = true;
+    out.grid_x = k->gridX;
+    out.grid_y = k->gridY;
+    out.grid_z = k->gridZ;
+    out.block_x = k->blockX;
+    out.block_y = k->blockY;
+    out.block_z = k->blockZ;
+    out.local_bytes = static_cast<int>(k->localMemoryPerThread);
+    {
+        // Per-resource occupancy from launch config + SM properties.
+        SmProps props = GetSMProps(out.device_id);
+        int threadsPerBlock = out.block_x * out.block_y * out.block_z;
+        int warpsPerBlock =
+            (threadsPerBlock + props.warpSize - 1) / props.warpSize;
+        int maxWarpsPerSM = props.maxThreadsPerSM / props.warpSize;
+        int warpBlocks =
+            (warpsPerBlock > 0) ? (maxWarpsPerSM / warpsPerBlock) : 0;
+        int blockBlocks = props.maxBlocksPerSM;
+        // Registers are allocated per-warp in multiples of 256 on sm_6x+.
+        constexpr int kRegAllocGranularity = 256;
+        int regsPerWarp = (warpsPerBlock > 0 && out.num_regs > 0)
+                              ? (((out.num_regs * props.warpSize) +
+                                  kRegAllocGranularity - 1) /
+                                 kRegAllocGranularity) *
+                                    kRegAllocGranularity
+                              : 0;
+        int regsPerBlock = regsPerWarp * warpsPerBlock;
+        int regBlocks =
+            regsPerBlock > 0 ? props.regsPerSM / regsPerBlock : warpBlocks;
+        int smemPerBlock = out.static_shared + out.dyn_shared;
+        int smemBlocks = (smemPerBlock > 0)
+                             ? (props.sharedMemPerSM / smemPerBlock)
+                             : warpBlocks;
+        out.max_active_blocks =
+            std::min({warpBlocks, regBlocks, blockBlocks, smemBlocks});
+        auto toOcc = [&](const int blocks) -> float {
+            return maxWarpsPerSM > 0 && warpsPerBlock > 0
+                       ? std::min(1.0f, static_cast<float>(blocks *
+                                                           warpsPerBlock) /
+                                            maxWarpsPerSM)
+                       : 0.0f;
+        };
+        out.warp_occupancy = toOcc(warpBlocks);
+        out.reg_occupancy = toOcc(regBlocks);
+        out.smem_occupancy = toOcc(smemBlocks);
+        out.block_occupancy = toOcc(blockBlocks);
+        out.occupancy = toOcc(out.max_active_blocks);
+        struct {
+            float occ;
+            const char* name;
+        } limiters[] = {
+            {out.warp_occupancy, "warps"},
+            {out.reg_occupancy, "registers"},
+            {out.smem_occupancy, "shared_mem"},
+            {out.block_occupancy, "blocks"},
+        };
+        auto limiting = "warps";
+        float minOcc = out.warp_occupancy;
+        for (auto& [occ, name] : limiters) {
+            if (occ < minOcc) {
+                minOcc = occ;
+                limiting = name;
+            }
+        }
+        std::snprintf(out.limiting_resource, sizeof(out.limiting_resource),
+                      "%s", limiting);
+    }
+
+    // Join the launch-callback metadata: scope path, stack id, API timestamps,
+    // and const-bank size (the only fields NOT in the activity record). The
+    // critical section is just find + copy + erase. (Step 4b-2 moves this join
+    // onto the collector thread to drop meta_mu_ from the callback entirely.)
     {
         const uint64_t corr = k->correlationId;
-        out.corr_id = corr;
-
-        // Copy the launch metadata out under the lock, then release it
-        // immediately. The occupancy math below touches no shared state, so
-        // holding meta_mu_ across it (previously ~80 lines incl. GetSMProps +
-        // snprintf) needlessly blocked the app launch threads writing new
-        // metadata. Keep the critical section to find + copy + erase.
         LaunchMeta meta;
         bool found = false;
         {
@@ -516,13 +586,9 @@ bool KernelLaunchHandler::handleActivityRecord(const CUpti_Activity* record,
                 it != backend_->meta_by_corr_.end()) {
                 meta = it->second;
                 found = true;
-                // Always erase after processing — launches without grid/block
-                // metadata used to leave stale entries that FlushPendingKernels
-                // then resurrected as synthetic duplicates at session stop().
                 backend_->meta_by_corr_.erase(it);
             }
         }
-
         if (found) {
             out.scope_depth = meta.scope_depth;
             out.stack_id = meta.stack_id;
@@ -530,88 +596,7 @@ bool KernelLaunchHandler::handleActivityRecord(const CUpti_Activity* record,
                       std::begin(out.user_scope));
             out.api_start_ns = meta.api_enter_ns;
             out.api_exit_ns = meta.api_exit_ns;
-            if (meta.has_details) {
-                out.has_details = true;
-                out.grid_x = meta.grid_x;
-                out.grid_y = meta.grid_y;
-                out.grid_z = meta.grid_z;
-                out.block_x = meta.block_x;
-                out.block_y = meta.block_y;
-                out.block_z = meta.block_z;
-                out.local_bytes = static_cast<int>(k->localMemoryPerThread);
-                out.const_bytes = meta.const_bytes;
-
-                // Compute per-resource occupancy from activity record data
-                // (registers, shared memory) and SM properties.
-                SmProps props = GetSMProps(out.device_id);
-                int threadsPerBlock = out.block_x * out.block_y * out.block_z;
-                int warpsPerBlock =
-                    (threadsPerBlock + props.warpSize - 1) / props.warpSize;
-                int maxWarpsPerSM = props.maxThreadsPerSM / props.warpSize;
-
-                // Warp limit
-                int warpBlocks =
-                    (warpsPerBlock > 0) ? (maxWarpsPerSM / warpsPerBlock) : 0;
-
-                // Hardware block count limit
-                int blockBlocks = props.maxBlocksPerSM;
-
-                // Register limit — registers are allocated per-warp in
-                // multiples of 256 on modern NVIDIA architectures (sm_6x+).
-                constexpr int kRegAllocGranularity = 256;
-                int regsPerWarp = (warpsPerBlock > 0 && out.num_regs > 0)
-                                      ? (((out.num_regs * props.warpSize) +
-                                          kRegAllocGranularity - 1) /
-                                         kRegAllocGranularity) *
-                                            kRegAllocGranularity
-                                      : 0;
-                int regsPerBlock = regsPerWarp * warpsPerBlock;
-                int regBlocks = regsPerBlock > 0
-                                    ? props.regsPerSM / regsPerBlock
-                                    : warpBlocks;
-
-                // Shared memory limit
-                int smemPerBlock = out.static_shared + out.dyn_shared;
-                int smemBlocks =
-                    (smemPerBlock > 0) ? (props.sharedMemPerSM / smemPerBlock)
-                                       : warpBlocks;
-
-                out.max_active_blocks =
-                    std::min({warpBlocks, regBlocks, blockBlocks, smemBlocks});
-
-                auto toOcc = [&](const int blocks) -> float {
-                    return maxWarpsPerSM > 0 && warpsPerBlock > 0
-                               ? std::min(1.0f, static_cast<float>(
-                                                    blocks * warpsPerBlock) /
-                                                    maxWarpsPerSM)
-                               : 0.0f;
-                };
-                out.warp_occupancy = toOcc(warpBlocks);
-                out.reg_occupancy = toOcc(regBlocks);
-                out.smem_occupancy = toOcc(smemBlocks);
-                out.block_occupancy = toOcc(blockBlocks);
-                out.occupancy = toOcc(out.max_active_blocks);
-
-                struct {
-                    float occ;
-                    const char* name;
-                } limiters[] = {
-                    {out.warp_occupancy, "warps"},
-                    {out.reg_occupancy, "registers"},
-                    {out.smem_occupancy, "shared_mem"},
-                    {out.block_occupancy, "blocks"},
-                };
-                auto limiting = "warps";
-                float minOcc = out.warp_occupancy;
-                for (auto& [occ, name] : limiters) {
-                    if (occ < minOcc) {
-                        minOcc = occ;
-                        limiting = name;
-                    }
-                }
-                std::snprintf(out.limiting_resource,
-                              sizeof(out.limiting_resource), "%s", limiting);
-            }
+            out.const_bytes = meta.const_bytes;
         }
     }
 

--- a/include/gpufl/backends/nvidia/kernel_launch_handler.cpp
+++ b/include/gpufl/backends/nvidia/kernel_launch_handler.cpp
@@ -96,43 +96,6 @@ bool CopyReadableCString(const char* src, std::string* out) {
 KernelLaunchHandler::KernelLaunchHandler(CuptiBackend* backend)
     : backend_(backend) {}
 
-const std::string& KernelLaunchHandler::cachedDemangle(const char* mangled) {
-    static const std::string kFallback = "kernel_launch";
-    if (!mangled) return kFallback;
-
-    // Defensive bounded read. On CUDA 13.1 + PyTorch autograd's backward
-    // worker threads, a SEGV was observed deep inside cachedDemangle on
-    // an RTX 3090 — no DemangleName frame on the stack, which means the
-    // implicit `std::string(mangled)` construction in find()/emplace()
-    // crashed. That can happen if `cbInfo->symbolName` (or the activity
-    // record's `name` field) points to a buffer that isn't reliably
-    // null-terminated under some CUPTI codepath. strnlen short-circuits
-    // at kMaxNameLen so a non-null-terminated pointer reads at most one
-    // page of bogus memory instead of running off the end of mapping —
-    // and if it never finds a terminator we fall back to a known-safe
-    // string rather than letting std::string crash. PyTorch's longest
-    // mangled cuBLAS / cutlass names top out around 350 chars in
-    // practice; 4 KiB gives generous headroom.
-    constexpr size_t kMaxNameLen = 4096;
-    if (const size_t len = strnlen(mangled, kMaxNameLen);
-        len == 0 || len == kMaxNameLen) return kFallback;
-
-    std::lock_guard lk(demangle_mu_);
-    if (const auto it = demangle_cache_.find(mangled); it != demangle_cache_.end()) return it->second;
-    // Try-catch around the insert as belt-and-suspenders. If DemangleName
-    // itself throws (it shouldn't — abi::__cxa_demangle returns a status
-    // code and we check it — but defensive on platforms with unusual
-    // allocator behavior), we return the fallback rather than letting
-    // the exception unwind across a CUPTI callback boundary, which is
-    // undefined behavior in CUPTI's callback contract.
-    try {
-        auto [inserted, _] = demangle_cache_.emplace(mangled, DemangleName(mangled));
-        return inserted->second;
-    } catch (...) {
-        return kFallback;
-    }
-}
-
 std::vector<std::pair<CUpti_CallbackDomain, CUpti_CallbackId>>
 KernelLaunchHandler::requiredCallbacks() const {
     if (backend_ && backend_->SassMetricsOnlyMode()) {
@@ -284,16 +247,18 @@ void KernelLaunchHandler::handle(CUpti_CallbackDomain domain,
         // values in symbolName, so never dereference it directly; copy through
         // process_vm_readv first and fall back to the stable API function name
         // (cudaLaunchKernel / cuLaunchKernelEx) if the probe fails.
+        // Store the RAW name; demangling is deferred to the collector thread
+        // (DemangleKernelNameCached in monitor.cpp). %.*s bounds the source
+        // read so a non-null-terminated CUPTI name pointer can't overrun.
         std::string copiedSymbol;
         if (CopyReadableCString(cbInfo->symbolName, &copiedSymbol)) {
-            const std::string demangledName = DemangleName(copiedSymbol.c_str());
-            std::snprintf(meta.name, sizeof(meta.name), "%s",
-                          demangledName.c_str());
+            std::snprintf(meta.name, sizeof(meta.name), "%.*s",
+                          static_cast<int>(sizeof(meta.name) - 1),
+                          copiedSymbol.c_str());
         } else {
-            const char* nm = cbInfo->functionName;
-            const std::string& demangledName = cachedDemangle(nm);
-            std::snprintf(meta.name, sizeof(meta.name), "%s",
-                          demangledName.c_str());
+            const char* nm = cbInfo->functionName ? cbInfo->functionName : "";
+            std::snprintf(meta.name, sizeof(meta.name), "%.*s",
+                          static_cast<int>(sizeof(meta.name) - 1), nm);
         }
 
         if (backend_->GetOptions().enable_stack_trace) {
@@ -479,8 +444,11 @@ bool KernelLaunchHandler::handleActivityRecord(const CUpti_Activity* record,
     out.device_id = k->deviceId;
     out.stream = static_cast<StreamHandle>(k->streamId);
     out.type = TraceType::KERNEL;
-    const std::string& demangledKernelName = cachedDemangle(k->name);
-    std::snprintf(out.name, sizeof(out.name), "%s", demangledKernelName.c_str());
+    // Store the RAW (mangled) name; demangle is deferred to the collector
+    // thread. %.*s bounds the source read against a non-terminated name.
+    std::snprintf(out.name, sizeof(out.name), "%.*s",
+                  static_cast<int>(sizeof(out.name) - 1),
+                  k->name ? k->name : "");
     out.cpu_start_ns = baseCpuNs + static_cast<int64_t>(k->start - baseCuptiTs);
     out.duration_ns = static_cast<int64_t>(k->end - k->start);
     out.dyn_shared = k->dynamicSharedMemory;

--- a/include/gpufl/backends/nvidia/kernel_launch_handler.cpp
+++ b/include/gpufl/backends/nvidia/kernel_launch_handler.cpp
@@ -91,6 +91,37 @@ bool CopyReadableCString(const char* src, std::string* out) {
 #endif
 }
 
+// Precompute the SIMPLIFIED occupancy carried on a synthetic kernel's launch-
+// meta record. Only grid/block + dynamic shared memory are known at launch time
+// (per-thread registers and static shared memory live on the activity record,
+// which by definition never arrives for a synthetic kernel), so occupancy is
+// bounded by warps + blocks only — byte-for-byte the math the old
+// CuptiBackend::FlushPendingKernels ran at stop(). Runs here on the launch
+// callback (the nvidia layer, where GetSMProps lives) so the core collector TU
+// can stay free of CUDA headers; drainSyntheticKernels in monitor.cpp just
+// copies these fields. Only called in synthetic-kernel modes (see
+// CuptiBackend::WillEmitSyntheticKernels), so normal/Deep launches pay nothing.
+void ComputeSyntheticOccupancy(ActivityRecord& rec, uint32_t device_id) {
+    SmProps props = GetSMProps(static_cast<int>(device_id));
+    int threadsPerBlock = rec.block_x * rec.block_y * rec.block_z;
+    int warpsPerBlock = (threadsPerBlock + props.warpSize - 1) / props.warpSize;
+    int maxWarpsPerSM = props.maxThreadsPerSM / props.warpSize;
+    int warpBlocks = (warpsPerBlock > 0) ? (maxWarpsPerSM / warpsPerBlock) : 0;
+    int blockBlocks = props.maxBlocksPerSM;
+    rec.max_active_blocks = std::min(warpBlocks, blockBlocks);
+    auto toOcc = [&](int blocks) -> float {
+        return (maxWarpsPerSM > 0 && warpsPerBlock > 0)
+                   ? std::min(1.0f, static_cast<float>(blocks * warpsPerBlock) /
+                                        maxWarpsPerSM)
+                   : 0.0f;
+    };
+    rec.warp_occupancy = toOcc(warpBlocks);
+    rec.block_occupancy = toOcc(blockBlocks);
+    rec.occupancy = rec.warp_occupancy;
+    std::snprintf(rec.limiting_resource, sizeof(rec.limiting_resource), "%s",
+                  "warps");
+}
+
 }  // namespace
 
 KernelLaunchHandler::KernelLaunchHandler(CuptiBackend* backend)
@@ -239,8 +270,20 @@ void KernelLaunchHandler::handle(CUpti_CallbackDomain domain,
 
     if (cbInfo->callbackSite == CUPTI_API_ENTER) {
         backend_->NoteKernelLaunchForCleanupFlush();
-        LaunchMeta meta{};
-        meta.api_enter_ns = detail::GetTimestampNs();
+
+        // Build a KERNEL_LAUNCH_META record and push it to the lock-free ring
+        // (Step 4b-2). The corr->meta join that used to run here under meta_mu_
+        // now happens on the single collector thread (joinLaunchMeta in
+        // monitor.cpp) — this callback takes NO lock. Push is heap-free: the
+        // ring slot is preallocated and Push copies the POD into it.
+        ActivityRecord metaRec{};
+        metaRec.type = TraceType::KERNEL_LAUNCH_META;
+        metaRec.corr_id = cbInfo->correlationId;
+        // device_id is consumed only by the synthetic-kernel path (real kernels
+        // take k->deviceId from the activity record); matches the old
+        // FlushPendingKernels `out.device_id = device_id_`.
+        metaRec.device_id = backend_->device_id_;
+        metaRec.api_start_ns = detail::GetTimestampNs();  // API_ENTER ns
 
         // Prefer cbInfo->symbolName so callback-only SASS safe mode can still
         // group kernels by real symbol. CUDA 13.1 sometimes puts invalid tagged
@@ -252,23 +295,23 @@ void KernelLaunchHandler::handle(CUpti_CallbackDomain domain,
         // read so a non-null-terminated CUPTI name pointer can't overrun.
         std::string copiedSymbol;
         if (CopyReadableCString(cbInfo->symbolName, &copiedSymbol)) {
-            std::snprintf(meta.name, sizeof(meta.name), "%.*s",
-                          static_cast<int>(sizeof(meta.name) - 1),
+            std::snprintf(metaRec.name, sizeof(metaRec.name), "%.*s",
+                          static_cast<int>(sizeof(metaRec.name) - 1),
                           copiedSymbol.c_str());
         } else {
             const char* nm = cbInfo->functionName ? cbInfo->functionName : "";
-            std::snprintf(meta.name, sizeof(meta.name), "%.*s",
-                          static_cast<int>(sizeof(meta.name) - 1), nm);
+            std::snprintf(metaRec.name, sizeof(metaRec.name), "%.*s",
+                          static_cast<int>(sizeof(metaRec.name) - 1), nm);
         }
 
         if (backend_->GetOptions().enable_stack_trace) {
             // Capture raw return addresses only (cheap); symbol resolution is
             // deferred to the collector thread via StackRegistry::get(),
             // keeping dbghelp/SymFromAddr off this per-launch CUPTI callback.
-            meta.stack_id = StackRegistry::instance().getOrRegister(
+            metaRec.stack_id = StackRegistry::instance().getOrRegister(
                 core::CaptureCallStackRaw(2));
         } else {
-            meta.stack_id = 0;
+            metaRec.stack_id = 0;
         }
 
         auto& stack = getThreadScopeStack();
@@ -278,39 +321,39 @@ void KernelLaunchHandler::handle(CUpti_CallbackDomain domain,
                 if (i > 0) fullPath += "|";
                 fullPath += stack[i];
             }
-            std::snprintf(meta.user_scope, sizeof(meta.user_scope), "%s",
+            std::snprintf(metaRec.user_scope, sizeof(metaRec.user_scope), "%s",
                           fullPath.c_str());
-            meta.scope_depth = stack.size();
+            metaRec.scope_depth = stack.size();
         } else if (const char* injectedApp = std::getenv("GPUFL_APP_NAME")) {
             if (std::getenv("GPUFL_INJECT") && injectedApp[0] != '\0') {
                 std::string processScope = "process:";
                 processScope += injectedApp;
-                std::snprintf(meta.user_scope, sizeof(meta.user_scope), "%s",
-                              processScope.c_str());
+                std::snprintf(metaRec.user_scope, sizeof(metaRec.user_scope),
+                              "%s", processScope.c_str());
             } else {
-                std::snprintf(meta.user_scope, sizeof(meta.user_scope), "%s",
-                              "global");
+                std::snprintf(metaRec.user_scope, sizeof(metaRec.user_scope),
+                              "%s", "global");
             }
-            meta.scope_depth = 0;
+            metaRec.scope_depth = 0;
         } else {
-            std::snprintf(meta.user_scope, sizeof(meta.user_scope), "%s",
+            std::snprintf(metaRec.user_scope, sizeof(metaRec.user_scope), "%s",
                           "global");
-            meta.scope_depth = 0;
+            metaRec.scope_depth = 0;
         }
 
-        auto setLaunchDims = [&meta](const unsigned int gx,
-                                     const unsigned int gy,
+        auto setLaunchDims = [&metaRec](const unsigned int gx,
+                                        const unsigned int gy,
                     const unsigned int gz, const unsigned int bx,
                     const unsigned int by, const unsigned int bz,
-                                     size_t dyn_smem) {
-            meta.has_details = true;
-            meta.grid_x = static_cast<int>(gx);
-            meta.grid_y = static_cast<int>(gy);
-            meta.grid_z = static_cast<int>(gz);
-            meta.block_x = static_cast<int>(bx);
-            meta.block_y = static_cast<int>(by);
-            meta.block_z = static_cast<int>(bz);
-            meta.dyn_shared = static_cast<int>(dyn_smem);
+                                        size_t dyn_smem) {
+            metaRec.has_details = true;
+            metaRec.grid_x = static_cast<int>(gx);
+            metaRec.grid_y = static_cast<int>(gy);
+            metaRec.grid_z = static_cast<int>(gz);
+            metaRec.block_x = static_cast<int>(bx);
+            metaRec.block_y = static_cast<int>(by);
+            metaRec.block_z = static_cast<int>(bz);
+            metaRec.dyn_shared = static_cast<int>(dyn_smem);
         };
 
         if (cbInfo->functionParams != nullptr) {
@@ -367,42 +410,35 @@ void KernelLaunchHandler::handle(CUpti_CallbackDomain domain,
 #endif
         }
 
-        // Store metadata — emit later from scope stop (PC Sampling path)
-        // or handleActivityRecord (normal path). Runtime and driver launch
-        // callbacks can share one correlation id, so keep the richest metadata
-        // and avoid duplicate diagnostic lines for the same logical launch.
-        bool shouldLogLaunch = false;
-        {
-            std::lock_guard lk(backend_->meta_mu_);
-            auto it = backend_->meta_by_corr_.find(cbInfo->correlationId);
-            if (it == backend_->meta_by_corr_.end()) {
-                backend_->meta_by_corr_.emplace(cbInfo->correlationId, meta);
-                shouldLogLaunch = true;
-            } else if (it->second.has_details && !meta.has_details) {
-                GFL_LOG_DEBUG(
-                    "[DEBUG-CALLBACK] Skipping overwrite of rich metadata "
-                    "for CorrID ",
-                    cbInfo->correlationId, " by Driver API.");
-            } else if (!it->second.has_details && meta.has_details) {
-                it->second = meta;
-                shouldLogLaunch = true;
-            }
+        // Synthetic-kernel modes (PC Sampling / SASS safe): no CUPTI activity
+        // record will arrive, so precompute the simplified occupancy now — the
+        // only place with the nvidia SM properties — and carry it on the meta
+        // record for drainSyntheticKernels to copy. Skipped in normal / Deep
+        // mode (the activity record supplies full occupancy), keeping this
+        // callback thin. NOTE: a rare leftover meta orphaned at stop() in normal
+        // mode (its activity record dropped/in-flight) now ships occupancy 0
+        // instead of the old simplified value — acceptable for a degraded
+        // best-effort row whose duration is already a host-dispatch estimate.
+        if (metaRec.has_details && backend_->WillEmitSyntheticKernels()) {
+            ComputeSyntheticOccupancy(metaRec, metaRec.device_id);
         }
+
+        g_monitorBuffer.Push(metaRec);
+
         // Diagnostic: confirm every logical kernel launch fires this callback.
-        // If "GPU Time by Scope" shows only N kernels but this logs M>N,
-        // the loss is downstream (activity records / FlushPendingKernels).
-        if (shouldLogLaunch) {
-            GFL_LOG_DEBUG("[KernelLaunchHandler] API_ENTER corr=",
-                          cbInfo->correlationId, " name=", meta.name,
-                          " scope=", meta.user_scope);
-        }
+        // Runtime+driver share a corr so this can log twice per launch; the
+        // collector's keep-first merge dedups the actual join.
+        GFL_LOG_DEBUG("[KernelLaunchHandler] API_ENTER corr=", metaRec.corr_id,
+                      " name=", metaRec.name, " scope=", metaRec.user_scope);
     } else if (cbInfo->callbackSite == CUPTI_API_EXIT) {
-        const int64_t exitNs = detail::GetTimestampNs();
-        std::lock_guard lk(backend_->meta_mu_);
-        auto it = backend_->meta_by_corr_.find(cbInfo->correlationId);
-        if (it != backend_->meta_by_corr_.end()) {
-            it->second.api_exit_ns = exitNs;
-        }
+        // Push the API-exit timestamp as its own record; the collector patches
+        // it onto the matching launch meta. Same thread as API_ENTER, so it
+        // enters the ring after the ENTER record (FIFO by push order).
+        ActivityRecord exitRec{};
+        exitRec.type = TraceType::KERNEL_API_EXIT;
+        exitRec.corr_id = cbInfo->correlationId;
+        exitRec.api_exit_ns = detail::GetTimestampNs();
+        g_monitorBuffer.Push(exitRec);
     }
 }
 
@@ -572,34 +608,12 @@ bool KernelLaunchHandler::handleActivityRecord(const CUpti_Activity* record,
                       "%s", limiting);
     }
 
-    // Join the launch-callback metadata: scope path, stack id, API timestamps,
-    // and const-bank size (the only fields NOT in the activity record). The
-    // critical section is just find + copy + erase. (Step 4b-2 moves this join
-    // onto the collector thread to drop meta_mu_ from the callback entirely.)
-    {
-        const uint64_t corr = k->correlationId;
-        LaunchMeta meta;
-        bool found = false;
-        {
-            std::lock_guard lk(backend_->meta_mu_);
-            if (auto it = backend_->meta_by_corr_.find(corr);
-                it != backend_->meta_by_corr_.end()) {
-                meta = it->second;
-                found = true;
-                backend_->meta_by_corr_.erase(it);
-            }
-        }
-        if (found) {
-            out.scope_depth = meta.scope_depth;
-            out.stack_id = meta.stack_id;
-            std::copy(std::begin(meta.user_scope), std::end(meta.user_scope),
-                      std::begin(out.user_scope));
-            out.api_start_ns = meta.api_enter_ns;
-            out.api_exit_ns = meta.api_exit_ns;
-            out.const_bytes = meta.const_bytes;
-        }
-    }
-
+    // Launch-callback metadata (scope path, stack id, API timestamps, const-
+    // bank size — the only fields NOT in the activity record) is joined on the
+    // collector thread now (joinLaunchMeta in monitor.cpp), keyed by corr_id.
+    // This callback takes NO meta_mu_ — it pushes the raw activity record and
+    // returns. (Step 4b-2: the join moved off the CUPTI threads to drop the
+    // mutex; the matching KERNEL_LAUNCH_META was pushed by handle() at ENTER.)
     g_monitorBuffer.Push(out);
     backend_->kernel_activity_emitted_.fetch_add(1, std::memory_order_relaxed);
     return true;

--- a/include/gpufl/backends/nvidia/kernel_launch_handler.cpp
+++ b/include/gpufl/backends/nvidia/kernel_launch_handler.cpp
@@ -297,10 +297,11 @@ void KernelLaunchHandler::handle(CUpti_CallbackDomain domain,
         }
 
         if (backend_->GetOptions().enable_stack_trace) {
-            const std::string trace = core::GetCallStack(2);
-            const std::string cleanTrace = detail::SanitizeStackTrace(trace);
-            meta.stack_id =
-                StackRegistry::instance().getOrRegister(cleanTrace);
+            // Capture raw return addresses only (cheap); symbol resolution is
+            // deferred to the collector thread via StackRegistry::get(),
+            // keeping dbghelp/SymFromAddr off this per-launch CUPTI callback.
+            meta.stack_id = StackRegistry::instance().getOrRegister(
+                core::CaptureCallStackRaw(2));
         } else {
             meta.stack_id = 0;
         }
@@ -533,30 +534,44 @@ bool KernelLaunchHandler::handleActivityRecord(const CUpti_Activity* record,
     {
         const uint64_t corr = k->correlationId;
         out.corr_id = corr;
-        std::lock_guard lk(backend_->meta_mu_);
-        if (auto it = backend_->meta_by_corr_.find(corr);
-            it != backend_->meta_by_corr_.end()) {
-            const LaunchMeta& m = it->second;
-            out.scope_depth = m.scope_depth;
-            out.stack_id = m.stack_id;
-            std::copy(std::begin(m.user_scope), std::end(m.user_scope),
+
+        // Copy the launch metadata out under the lock, then release it
+        // immediately. The occupancy math below touches no shared state, so
+        // holding meta_mu_ across it (previously ~80 lines incl. GetSMProps +
+        // snprintf) needlessly blocked the app launch threads writing new
+        // metadata. Keep the critical section to find + copy + erase.
+        LaunchMeta meta;
+        bool found = false;
+        {
+            std::lock_guard lk(backend_->meta_mu_);
+            if (auto it = backend_->meta_by_corr_.find(corr);
+                it != backend_->meta_by_corr_.end()) {
+                meta = it->second;
+                found = true;
+                // Always erase after processing — launches without grid/block
+                // metadata used to leave stale entries that FlushPendingKernels
+                // then resurrected as synthetic duplicates at session stop().
+                backend_->meta_by_corr_.erase(it);
+            }
+        }
+
+        if (found) {
+            out.scope_depth = meta.scope_depth;
+            out.stack_id = meta.stack_id;
+            std::copy(std::begin(meta.user_scope), std::end(meta.user_scope),
                       std::begin(out.user_scope));
-            out.api_start_ns = m.api_enter_ns;
-            out.api_exit_ns = m.api_exit_ns;
-            // Snapshot `has_details` before the erase below — we still need
-            // it to decide whether to compute occupancy. Erasing first
-            // would invalidate `m` (dangling reference).
-            const bool hadDetails = m.has_details;
-            if (hadDetails) {
+            out.api_start_ns = meta.api_enter_ns;
+            out.api_exit_ns = meta.api_exit_ns;
+            if (meta.has_details) {
                 out.has_details = true;
-                out.grid_x = m.grid_x;
-                out.grid_y = m.grid_y;
-                out.grid_z = m.grid_z;
-                out.block_x = m.block_x;
-                out.block_y = m.block_y;
-                out.block_z = m.block_z;
+                out.grid_x = meta.grid_x;
+                out.grid_y = meta.grid_y;
+                out.grid_z = meta.grid_z;
+                out.block_x = meta.block_x;
+                out.block_y = meta.block_y;
+                out.block_z = meta.block_z;
                 out.local_bytes = static_cast<int>(k->localMemoryPerThread);
-                out.const_bytes = m.const_bytes;
+                out.const_bytes = meta.const_bytes;
 
                 // Compute per-resource occupancy from activity record data
                 // (registers, shared memory) and SM properties.
@@ -629,13 +644,6 @@ bool KernelLaunchHandler::handleActivityRecord(const CUpti_Activity* record,
                 std::snprintf(out.limiting_resource,
                               sizeof(out.limiting_resource), "%s", limiting);
             }
-            // Always erase after processing — previously this was nested
-            // inside `if (hadDetails)`, so launches without grid/block
-            // metadata left stale entries in meta_by_corr_. At session
-            // stop() FlushPendingKernels would then emit synthetic
-            // duplicates for kernels that already had real activity
-            // records emitted here. Move erase out of the conditional.
-            backend_->meta_by_corr_.erase(it);
         }
     }
 

--- a/include/gpufl/backends/nvidia/kernel_launch_handler.hpp
+++ b/include/gpufl/backends/nvidia/kernel_launch_handler.hpp
@@ -26,10 +26,9 @@ class KernelLaunchHandler : public ICuptiHandler {
 
    private:
     CuptiBackend* backend_;
-    // Cache for demangled kernel names — avoids re-demangling on every launch
-    std::mutex demangle_mu_;
-    std::unordered_map<std::string, std::string> demangle_cache_;
-    const std::string& cachedDemangle(const char* mangled);
+    // NOTE: kernel-name demangling moved OFF the callback path (Step 4a). The
+    // collector thread demangles raw names (DemangleKernelNameCached in
+    // monitor.cpp); there is no per-callback demangle mutex anymore.
 };
 
 }  // namespace gpufl

--- a/include/gpufl/backends/nvidia/mem_transfer_handler.cpp
+++ b/include/gpufl/backends/nvidia/mem_transfer_handler.cpp
@@ -181,20 +181,31 @@ void MemTransferHandler::handle(CUpti_CallbackDomain domain,
 
     if (cbInfo->callbackSite == CUPTI_API_ENTER) {
         GFL_LOG_DEBUG("Entering MEM event");
-        LaunchMeta meta{};
-        meta.api_enter_ns = detail::GetTimestampNs();
+
+        // Push a KERNEL_LAUNCH_META record to the lock-free ring (Step 4b-2):
+        // the memcpy/memset meta join shares the kernel join map and moved to
+        // the collector thread, so this callback takes NO meta_mu_. has_details
+        // stays false (no grid/block), so no synthetic occupancy is computed.
+        ActivityRecord metaRec{};
+        metaRec.type = TraceType::KERNEL_LAUNCH_META;
+        metaRec.corr_id = cbInfo->correlationId;
+        // For a hypothetical synthetic mem op orphaned at stop() (memcpy/memset
+        // normally always get an activity record, so none in practice); matches
+        // the old FlushPendingKernels device_id.
+        metaRec.device_id = backend_->device_id_;
+        metaRec.api_start_ns = detail::GetTimestampNs();  // API_ENTER ns
 
         const char* nm = cbInfo->functionName;
         if (!nm) nm = "mem_transfer";
-        std::snprintf(meta.name, sizeof(meta.name), "%s", nm);
+        std::snprintf(metaRec.name, sizeof(metaRec.name), "%s", nm);
 
         if (backend_->GetOptions().enable_stack_trace) {
             // Raw addresses only; symbolization deferred to the collector
             // thread (StackRegistry::get()) — off this per-call CUPTI callback.
-            meta.stack_id = gpufl::StackRegistry::instance().getOrRegister(
+            metaRec.stack_id = gpufl::StackRegistry::instance().getOrRegister(
                 gpufl::core::CaptureCallStackRaw(2));
         } else {
-            meta.stack_id = 0;
+            metaRec.stack_id = 0;
         }
 
         auto& stack = getThreadScopeStack();
@@ -205,27 +216,25 @@ void MemTransferHandler::handle(CUpti_CallbackDomain domain,
                 fullPath += stack[i];
             }
             fullPath += "|";
-            fullPath += meta.name;
-            std::snprintf(meta.user_scope, sizeof(meta.user_scope), "%s",
+            fullPath += metaRec.name;
+            std::snprintf(metaRec.user_scope, sizeof(metaRec.user_scope), "%s",
                           fullPath.c_str());
-            meta.scope_depth = stack.size();
+            metaRec.scope_depth = stack.size();
         } else {
             std::string fullPath = "global|";
-            fullPath += meta.name;
-            std::snprintf(meta.user_scope, sizeof(meta.user_scope), "%s",
+            fullPath += metaRec.name;
+            std::snprintf(metaRec.user_scope, sizeof(metaRec.user_scope), "%s",
                           fullPath.c_str());
-            meta.scope_depth = 0;
+            metaRec.scope_depth = 0;
         }
 
-        std::lock_guard<std::mutex> lk(backend_->meta_mu_);
-        backend_->meta_by_corr_[cbInfo->correlationId] = meta;
+        g_monitorBuffer.Push(metaRec);
     } else if (cbInfo->callbackSite == CUPTI_API_EXIT) {
-        const int64_t t = detail::GetTimestampNs();
-        std::lock_guard<std::mutex> lk(backend_->meta_mu_);
-        auto it = backend_->meta_by_corr_.find(cbInfo->correlationId);
-        if (it != backend_->meta_by_corr_.end()) {
-            it->second.api_exit_ns = t;
-        }
+        ActivityRecord exitRec{};
+        exitRec.type = TraceType::KERNEL_API_EXIT;
+        exitRec.corr_id = cbInfo->correlationId;
+        exitRec.api_exit_ns = detail::GetTimestampNs();
+        g_monitorBuffer.Push(exitRec);
     }
 }
 
@@ -248,21 +257,9 @@ bool MemTransferHandler::handleActivityRecord(const CUpti_Activity* record,
         out.src_kind = m->srcKind;
         out.dst_kind = m->dstKind;
         std::snprintf(out.name, sizeof(out.name), "memcpy");
-        {
-            std::lock_guard lk(backend_->meta_mu_);
-            if (auto it = backend_->meta_by_corr_.find(out.corr_id);
-                it != backend_->meta_by_corr_.end()) {
-                const LaunchMeta& meta = it->second;
-                out.scope_depth = meta.scope_depth;
-                out.stack_id = meta.stack_id;
-                std::copy(std::begin(meta.user_scope),
-                          std::end(meta.user_scope),
-                          std::begin(out.user_scope));
-                out.api_start_ns = meta.api_enter_ns;
-                out.api_exit_ns = meta.api_exit_ns;
-                backend_->meta_by_corr_.erase(it);
-            }
-        }
+        // Scope/stack/API-timestamp join runs on the collector thread now
+        // (joinLaunchMeta in monitor.cpp, keyed by corr_id) — no meta_mu_ here.
+        // (Step 4b-2.)
         g_monitorBuffer.Push(out);
         backend_->NoteMemoryActivityEmitted();
         return true;
@@ -280,21 +277,9 @@ bool MemTransferHandler::handleActivityRecord(const CUpti_Activity* record,
         out.duration_ns = static_cast<int64_t>(m->end - m->start);
         out.bytes = m->bytes;
         std::snprintf(out.name, sizeof(out.name), "memset");
-        {
-            std::lock_guard lk(backend_->meta_mu_);
-            if (auto it = backend_->meta_by_corr_.find(out.corr_id);
-                it != backend_->meta_by_corr_.end()) {
-                const LaunchMeta& meta = it->second;
-                out.scope_depth = meta.scope_depth;
-                out.stack_id = meta.stack_id;
-                std::copy(std::begin(meta.user_scope),
-                          std::end(meta.user_scope),
-                          std::begin(out.user_scope));
-                out.api_start_ns = meta.api_enter_ns;
-                out.api_exit_ns = meta.api_exit_ns;
-                backend_->meta_by_corr_.erase(it);
-            }
-        }
+        // Scope/stack/API-timestamp join runs on the collector thread now
+        // (joinLaunchMeta in monitor.cpp, keyed by corr_id) — no meta_mu_ here.
+        // (Step 4b-2.)
         g_monitorBuffer.Push(out);
         backend_->NoteMemoryActivityEmitted();
         return true;

--- a/include/gpufl/backends/nvidia/mem_transfer_handler.cpp
+++ b/include/gpufl/backends/nvidia/mem_transfer_handler.cpp
@@ -189,10 +189,10 @@ void MemTransferHandler::handle(CUpti_CallbackDomain domain,
         std::snprintf(meta.name, sizeof(meta.name), "%s", nm);
 
         if (backend_->GetOptions().enable_stack_trace) {
-            const std::string trace = gpufl::core::GetCallStack(2);
-            const std::string cleanTrace = detail::SanitizeStackTrace(trace);
-            meta.stack_id =
-                gpufl::StackRegistry::instance().getOrRegister(cleanTrace);
+            // Raw addresses only; symbolization deferred to the collector
+            // thread (StackRegistry::get()) — off this per-call CUPTI callback.
+            meta.stack_id = gpufl::StackRegistry::instance().getOrRegister(
+                gpufl::core::CaptureCallStackRaw(2));
         } else {
             meta.stack_id = 0;
         }

--- a/include/gpufl/backends/nvidia/synchronization_handler.cpp
+++ b/include/gpufl/backends/nvidia/synchronization_handler.cpp
@@ -1,7 +1,10 @@
 #include "gpufl/backends/nvidia/synchronization_handler.hpp"
 
+#include "gpufl/core/activity_record.hpp"
 #include "gpufl/core/common.hpp"   // detail::GetTimestampNs, detail::SanitizeStackTrace
 #include "gpufl/core/debug_logger.hpp"
+#include "gpufl/core/monitor.hpp"  // g_monitorBuffer
+#include "gpufl/core/ring_buffer.hpp"
 #include "gpufl/core/stack_registry.hpp"
 #include "gpufl/core/stack_trace.hpp"
 
@@ -114,43 +117,43 @@ void SynchronizationHandler::handle(CUpti_CallbackDomain /*domain*/,
 
     if (cbInfo->callbackSite == CUPTI_API_ENTER) {
         // Capture the user's call stack now — by the time the matching
-        // SYNCHRONIZATION activity record arrives on the buffer-flush
-        // thread, this thread's stack is long gone.
-        CuptiBackend::SyncMeta meta{};
-        meta.api_enter_ns = detail::GetTimestampNs();
-
+        // SYNCHRONIZATION activity record arrives on the buffer-flush thread,
+        // this thread's stack is long gone — and push it as a SYNC_META record
+        // to the lock-free ring (Step 4c). The corr->stack join moved to the
+        // single collector thread (g_syncStackByCorr in monitor.cpp), so this
+        // callback takes NO sync_meta_mu_. (The old SyncMeta also held an
+        // api_enter_ns that nothing downstream read; dropped.)
+        ActivityRecord metaRec{};
+        metaRec.type = TraceType::SYNC_META;
+        metaRec.corr_id = cbInfo->correlationId;
         if (backend_->GetOptions().enable_stack_trace) {
             // Raw addresses only; symbolization deferred to the collector
             // thread (StackRegistry::get()) — off this per-call CUPTI callback.
-            meta.stack_id = gpufl::StackRegistry::instance().getOrRegister(
+            metaRec.stack_id = gpufl::StackRegistry::instance().getOrRegister(
                 gpufl::core::CaptureCallStackRaw(2));
         } else {
-            meta.stack_id = 0;
+            metaRec.stack_id = 0;
         }
-
-        {
-            std::lock_guard<std::mutex> lk(backend_->sync_meta_mu_);
-            backend_->sync_meta_by_corr_[cbInfo->correlationId] = meta;
-        }
+        g_monitorBuffer.Push(metaRec);
         GFL_LOG_DEBUG("[SynchronizationHandler] API_ENTER corr=",
-                      cbInfo->correlationId, " stack_id=", meta.stack_id,
+                      cbInfo->correlationId, " stack_id=", metaRec.stack_id,
                       " cbid=", cbid);
     }
-    // Unlike kernels we don't need an API_EXIT recorder — sync wall
-    // time is measured by CUPTI directly on the SYNCHRONIZATION
-    // activity record (start/end fields), not derived from API
-    // enter/exit timestamps. We still capture API_ENTER only because
-    // that's where we have the user's stack.
+    // Unlike kernels we don't need an API_EXIT recorder — sync wall time is
+    // measured by CUPTI directly on the SYNCHRONIZATION activity record
+    // (start/end fields), not derived from API enter/exit timestamps. We still
+    // capture API_ENTER only because that's where we have the user's stack.
 }
 
 bool SynchronizationHandler::handleActivityRecord(
         const CUpti_Activity* /*record*/, int64_t /*baseCpuNs*/,
         uint64_t /*baseCuptiTs*/) {
-    // Sync activity records are processed inline in cupti_backend.cpp's
-    // BufferCompleted (where the stack_id lookup against
-    // sync_meta_by_corr_ also lives). Returning false here means the
-    // dispatcher keeps walking the handler list and lets the inline
-    // path handle the record.
+    // Sync activity records are still translated inline in cupti_backend.cpp's
+    // BufferCompleted (timing/type/stream → ActivityRecord, sub-100ns filter),
+    // which pushes the RAW record to the ring; the stack_id join now happens on
+    // the collector thread (g_syncStackByCorr in monitor.cpp, Step 4c).
+    // Returning false here means the dispatcher keeps walking the handler list
+    // and lets that inline path handle the record.
     return false;
 }
 

--- a/include/gpufl/backends/nvidia/synchronization_handler.cpp
+++ b/include/gpufl/backends/nvidia/synchronization_handler.cpp
@@ -120,10 +120,10 @@ void SynchronizationHandler::handle(CUpti_CallbackDomain /*domain*/,
         meta.api_enter_ns = detail::GetTimestampNs();
 
         if (backend_->GetOptions().enable_stack_trace) {
-            const std::string trace = gpufl::core::GetCallStack(2);
-            const std::string cleanTrace = detail::SanitizeStackTrace(trace);
-            meta.stack_id =
-                gpufl::StackRegistry::instance().getOrRegister(cleanTrace);
+            // Raw addresses only; symbolization deferred to the collector
+            // thread (StackRegistry::get()) — off this per-call CUPTI callback.
+            meta.stack_id = gpufl::StackRegistry::instance().getOrRegister(
+                gpufl::core::CaptureCallStackRaw(2));
         } else {
             meta.stack_id = 0;
         }

--- a/include/gpufl/backends/nvidia/synchronization_handler.hpp
+++ b/include/gpufl/backends/nvidia/synchronization_handler.hpp
@@ -22,15 +22,15 @@ namespace gpufl {
  *   activity-join split, same StackRegistry interning, same
  *   {@code enable_stack_trace} opt-in. Only the CBID set differs.
  *
- * Storage:
- *   The captured stack_id (interned via StackRegistry) is stashed
- *   into CuptiBackend's `sync_meta_by_corr_` map under its own mutex
- *   (independent of the kernel-launch metadata map), and read out by
- *   the SYNCHRONIZATION branch of cupti_backend.cpp's BufferCompleted
- *   activity processor — which copies it into ActivityRecord.stack_id
- *   on its way to the monitor ring buffer. CollectorLoop later
- *   resolves the stack_id back into a real string via
- *   StackRegistry::get() and emits it as SynchronizationEvent.stack_trace.
+ * Storage (Step 4c):
+ *   The captured stack_id (interned via StackRegistry) is pushed as a
+ *   SYNC_META record to the lock-free monitor ring — NO mutex. The
+ *   collector thread stashes it in its worker-local g_syncStackByCorr
+ *   map and joins it onto the matching SYNCHRONIZATION activity record
+ *   (translated inline in cupti_backend.cpp's BufferCompleted) by
+ *   correlationId, then resolves the stack_id back into a real string
+ *   via StackRegistry::get() and emits it as
+ *   SynchronizationEvent.stack_trace.
  *
  * Activity records:
  *   This handler does NOT own a handleActivityRecord() implementation —

--- a/include/gpufl/core/activity_record.hpp
+++ b/include/gpufl/core/activity_record.hpp
@@ -11,7 +11,11 @@ namespace gpufl {
 
 struct ActivityRecord {
     uint32_t device_id = 0;
-    char name[128]{};
+    // Holds the RAW (mangled) kernel name on the producer side; the collector
+    // thread demangles it (Step 4a). Sized to fit long templated CUDA/cutlass
+    // mangled names without truncation (truncating a mangled name breaks
+    // demangling). Non-kernel records store their already-final name here.
+    char name[256]{};
     TraceType type = TraceType::KERNEL;
     StreamHandle stream = 0;
     int64_t cpu_start_ns = 0;

--- a/include/gpufl/core/monitor.cpp
+++ b/include/gpufl/core/monitor.cpp
@@ -220,6 +220,17 @@ static void flushBatches(Logger& logger, const std::string& session_id) {
 // field the join and the synthetic-kernel path need, so no parallel struct.
 static std::unordered_map<uint64_t, ActivityRecord> g_launchMetaByCorr;
 
+// Worker-local sync-stack join map (Step 4c). The corr->stack join that ran
+// under CuptiBackend::sync_meta_mu_ in BufferCompleted now happens here on the
+// single collector thread, lock-free. Populated by SYNC_META records (sync
+// API_ENTER), consumed + erased when the matching SYNCHRONIZATION activity
+// record is processed. Only the stack_id is carried/joined — the old SyncMeta
+// also held an api_enter_ns that nothing downstream ever read, so it's dropped.
+// No synthetic drain: sync activity records are 1:1 with the API call, and
+// orphans (e.g. sub-100ns syncs filtered in BufferCompleted) are simply dropped,
+// same as before; the map is reset per session in Monitor::Initialize.
+static std::unordered_map<uint64_t, size_t> g_syncStackByCorr;
+
 // Join launch-callback metadata (scope path, stack id, API timestamps, const-
 // bank size) from the worker-local meta map onto an activity record, then erase
 // the entry. The activity record supplies everything else (kernel timing / dims
@@ -401,6 +412,13 @@ static bool collectorProcessNext() {
                 it != g_launchMetaByCorr.end()) {
                 it->second.api_exit_ns = rec.api_exit_ns;
             }
+            return true;
+        }
+        if (rec.type == TraceType::SYNC_META) {
+            // Stash the sync call stack until its SYNCHRONIZATION activity
+            // record arrives (Step 4c). Last-write-wins on corr collision (sync
+            // corrs are unique per call, so collisions don't occur in practice).
+            g_syncStackByCorr[rec.corr_id] = rec.stack_id;
             return true;
         }
 
@@ -603,6 +621,16 @@ static bool collectorProcessNext() {
             // hot loops with identical stacks ship the string exactly
             // once via dictionary_update — ~14× wire compression on
             // the canonical "sync inside a loop" workload.
+            //
+            // Join the API_ENTER call stack here (Step 4c) — moved off the
+            // BufferCompleted thread / sync_meta_mu_ onto this single consumer.
+            // 1:1 with the API call, so erase on join. Best-effort: a missing
+            // SYNC_META (dropped to ring backpressure) leaves stack_id 0.
+            if (auto it = g_syncStackByCorr.find(rec.corr_id);
+                it != g_syncStackByCorr.end()) {
+                rec.stack_id = it->second;
+                g_syncStackByCorr.erase(it);
+            }
             SynchronizationEventBatchRow row;
             row.start_ns    = rec.cpu_start_ns;
             row.duration_ns = duration_ns;
@@ -671,6 +699,7 @@ void Monitor::Initialize(const MonitorOptions& opts) {
     // Worker-local launch-meta join map (Step 4b-2): drop any entries a prior
     // session left behind so corr ids can't collide across init/shutdown cycles.
     g_launchMetaByCorr.clear();
+    g_syncStackByCorr.clear();  // Step 4c: same cross-session hygiene for syncs.
     g_kernelBatchId  = 0;
     g_memcpyBatchId  = 0;
     g_scopeBatch.clear();

--- a/include/gpufl/core/monitor.cpp
+++ b/include/gpufl/core/monitor.cpp
@@ -1,5 +1,6 @@
 #include "gpufl/core/monitor.hpp"
 
+#include <algorithm>
 #include <atomic>
 #include <chrono>
 #include <cstring>
@@ -204,6 +205,167 @@ static void flushBatches(Logger& logger, const std::string& session_id) {
     }
 }
 
+// Worker-local launch-meta join map (Step 4b-2). The corr->meta join that ran
+// under CuptiBackend::meta_mu_ on the CUPTI callback + BufferCompleted threads
+// now happens here, on the single collector thread, so NO lock is needed (same
+// threading model as g_kernelNameDemangleCache: written only by the collector,
+// and by the main thread AFTER the collector is joined at shutdown — never
+// concurrently). Keyed by CUPTI correlationId. Populated by KERNEL_LAUNCH_META
+// records (API_ENTER), api_exit_ns patched by KERNEL_API_EXIT records
+// (API_EXIT), consumed + erased when the matching KERNEL / MEMCPY / MEMSET
+// activity record is processed. Entries still present at shutdown are launches
+// CUPTI never delivered an activity record for; drainSyntheticKernels() flushes
+// them as synthetic kernels (replacing CuptiBackend::FlushPendingKernels).
+// Stores the whole KERNEL_LAUNCH_META ActivityRecord — it already carries every
+// field the join and the synthetic-kernel path need, so no parallel struct.
+static std::unordered_map<uint64_t, ActivityRecord> g_launchMetaByCorr;
+
+// Join launch-callback metadata (scope path, stack id, API timestamps, const-
+// bank size) from the worker-local meta map onto an activity record, then erase
+// the entry. The activity record supplies everything else (kernel timing / dims
+// / occupancy from CUpti_ActivityKernel11; bytes / kind for mem ops). Best-
+// effort: if no meta arrived for this corr the record is left untouched — same
+// as the old meta_mu_ join missing (e.g. the API_ENTER push lost to ring
+// backpressure, or an activity record that arrived before its launch callback).
+static void joinLaunchMeta(ActivityRecord& rec) {
+    auto it = g_launchMetaByCorr.find(rec.corr_id);
+    if (it == g_launchMetaByCorr.end()) return;
+    const ActivityRecord& m = it->second;
+    rec.scope_depth  = m.scope_depth;
+    rec.stack_id     = m.stack_id;
+    std::memcpy(rec.user_scope, m.user_scope, sizeof(rec.user_scope));
+    rec.api_start_ns = m.api_start_ns;
+    rec.api_exit_ns  = m.api_exit_ns;
+    rec.const_bytes  = m.const_bytes;
+    g_launchMetaByCorr.erase(it);
+}
+
+// Emit one fully-joined KERNEL record: intern the (demangled) name, push the
+// kernel batch row, and — when detailed — the deferred detail row; flush if the
+// batch filled. Extracted from collectorProcessNext's KERNEL branch (Step 4b-2)
+// so drainSyntheticKernels can reuse the exact same emission path. `rec` must
+// already carry the joined scope/stack metadata and resolved `stack_trace`.
+static void emitKernelRecord(const ActivityRecord& rec,
+                             const std::string& stack_trace, Runtime* rt) {
+    // Demangle on the collector thread (Step 4a) — rec.name holds the RAW
+    // mangled name pushed by the CUPTI callback/activity path.
+    const uint32_t kernel_id =
+        g_dictManager.internKernel(DemangleKernelNameCached(rec.name).c_str());
+
+    KernelBatchRow row;
+    row.start_ns    = rec.cpu_start_ns;
+    row.kernel_id   = kernel_id;
+    row.stream_id   = static_cast<uint32_t>(rec.stream);
+    row.duration_ns = rec.duration_ns;
+    row.corr_id     = rec.corr_id;
+    row.dyn_shared  = rec.dyn_shared;
+    row.num_regs    = rec.num_regs;
+    row.has_details = rec.has_details ? 1 : 0;
+    // Pre-stamped by KernelLaunchHandler; both fields are 0 when no framework
+    // was tracking this launch.
+    row.external_kind = rec.external_kind;
+    row.external_id   = rec.external_id;
+    g_kernelBatch.push(row);
+
+    if (rec.has_details) {
+        KernelDetailRow detail;
+        detail.corr_id    = rec.corr_id;
+        detail.session_id = rt->session_id;
+        detail.pid        = detail::GetPid();
+        detail.app        = rt->app_name;
+        detail.grid_x = rec.grid_x; detail.grid_y = rec.grid_y;
+        detail.grid_z = rec.grid_z;
+        detail.block_x = rec.block_x; detail.block_y = rec.block_y;
+        detail.block_z = rec.block_z;
+        detail.static_shared         = rec.static_shared;
+        detail.local_bytes           = rec.local_bytes;
+        detail.const_bytes           = rec.const_bytes;
+        detail.occupancy             = rec.occupancy;
+        detail.reg_occupancy         = rec.reg_occupancy;
+        detail.smem_occupancy        = rec.smem_occupancy;
+        detail.warp_occupancy        = rec.warp_occupancy;
+        detail.block_occupancy       = rec.block_occupancy;
+        std::memcpy(detail.limiting_resource, rec.limiting_resource,
+                    sizeof(detail.limiting_resource));
+        detail.max_active_blocks      = rec.max_active_blocks;
+        detail.local_mem_total        = rec.local_mem_total;
+        detail.local_mem_per_thread   = rec.local_mem_per_thread;
+        detail.cache_config_requested = rec.cache_config_requested;
+        detail.cache_config_executed  = rec.cache_config_executed;
+        detail.shared_mem_executed    = rec.shared_mem_executed;
+        detail.user_scope  = rec.user_scope;
+        detail.stack_trace = stack_trace;
+        // Defer: written after the kernel batch by flushBatches().
+        g_pendingDetails.push_back(std::move(detail));
+    }
+
+    if (g_kernelBatch.needsFlush()) {
+        flushBatches(*rt->logger, rt->session_id);
+    }
+}
+
+// Flush launch metas that never got a CUPTI activity record as synthetic
+// kernels (Step 4b-2 — replaces CuptiBackend::FlushPendingKernels). Runs on the
+// collector thread AFTER the ring is fully drained, so g_launchMetaByCorr holds
+// exactly the orphaned launches (every kernel with an activity record has
+// already joined + erased its entry). Common in PC Sampling / SASS safe modes,
+// where CONCURRENT_KERNEL activity is off and launch callbacks are the only
+// kernel source; empty (no-op) in normal Trace/Deep mode.
+//
+// CUPTI gave us no GPU timestamps for these, so duration is approximated as the
+// gap to the next launch's dispatch (kernels run sequentially on the default
+// stream of single-stream workloads) — or `flushNs` for the last one. The
+// simplified occupancy was precomputed on the launch callback (it has the
+// nvidia-only SM properties this core TU must not reach for); we just carry it.
+// Idempotent: clears the map, so the second call from Monitor::Shutdown's
+// post-join drain is a no-op.
+static void drainSyntheticKernels(Runtime* rt) {
+    if (g_launchMetaByCorr.empty()) return;
+    if (!(rt && rt->logger)) return;
+    const int64_t flushNs = detail::GetTimestampNs();
+
+    std::vector<uint64_t> orderedCorr;
+    orderedCorr.reserve(g_launchMetaByCorr.size());
+    for (const auto& [corr, _] : g_launchMetaByCorr) orderedCorr.push_back(corr);
+    std::sort(orderedCorr.begin(), orderedCorr.end(),
+              [&](uint64_t a, uint64_t b) {
+                  return g_launchMetaByCorr[a].api_start_ns <
+                         g_launchMetaByCorr[b].api_start_ns;
+              });
+
+    GFL_LOG_DEBUG("[drainSyntheticKernels] draining ", orderedCorr.size(),
+                  " synthetic kernel(s) at flushNs=", flushNs);
+
+    for (size_t i = 0; i < orderedCorr.size(); ++i) {
+        const uint64_t corr = orderedCorr[i];
+        // Copy the stored meta: it already carries name, device_id, scope,
+        // stack, has_details, grid/block/dyn_shared and the precomputed
+        // simplified occupancy. We only override the synthetic-specific fields.
+        ActivityRecord out = g_launchMetaByCorr[corr];
+        out.type = TraceType::KERNEL;
+        out.stream = 0;
+        out.cpu_start_ns = out.api_start_ns;  // API_ENTER ns
+        const int64_t nextEnterNs =
+            (i + 1 < orderedCorr.size())
+                ? g_launchMetaByCorr[orderedCorr[i + 1]].api_start_ns
+                : flushNs;
+        int64_t synthDur = nextEnterNs - out.api_start_ns;
+        if (synthDur < 0) synthDur = 0;  // clock skew guard
+        out.duration_ns = synthDur;
+        out.corr_id = static_cast<unsigned>(corr);
+        if (out.api_exit_ns <= 0) out.api_exit_ns = flushNs;
+
+        const std::string stack_trace =
+            (out.stack_id != 0) ? StackRegistry::instance().get(out.stack_id)
+                                : "";
+        GFL_LOG_DEBUG("[drainSyntheticKernels] synth corr=", corr,
+                      " name=", out.name, " scope=", out.user_scope,
+                      " dur=", out.duration_ns, "ns");
+        emitKernelRecord(out, stack_trace, rt);
+    }
+    g_launchMetaByCorr.clear();
+}
+
 // Consume + route ONE record from the ring buffer; returns false when empty.
 // File-scope (was a lambda inside CollectorLoop) so Monitor::Shutdown can
 // re-drain on the MAIN thread after joining the collector. On Windows
@@ -214,6 +376,34 @@ static bool collectorProcessNext() {
         ActivityRecord rec{};
         if (!g_monitorBuffer.Consume(rec)) return false;
 
+        // Launch-meta control records (Step 4b-2): collector-thread-only join-
+        // map maintenance, never emitted. Handled before the runtime/logger
+        // check — they carry no output, only the join state that later KERNEL /
+        // MEMCPY / MEMSET activity records read.
+        if (rec.type == TraceType::KERNEL_LAUNCH_META) {
+            // Merge into the worker-local join map. Keep-first-unless-upgrade: a
+            // single logical launch fires BOTH runtime and driver callbacks with
+            // the SAME corr; the first (runtime) wins unless it lacked grid/block
+            // details and a later record supplies them. Mirrors the merge the old
+            // KernelLaunchHandler::handle did under meta_mu_. (MemTransferHandler
+            // metas always have has_details=false, so duplicate-corr mem callbacks
+            // resolve to the first/runtime one — its user-facing scope label.)
+            auto it = g_launchMetaByCorr.find(rec.corr_id);
+            if (it == g_launchMetaByCorr.end()) {
+                g_launchMetaByCorr.emplace(rec.corr_id, rec);
+            } else if (!it->second.has_details && rec.has_details) {
+                it->second = rec;
+            }
+            return true;
+        }
+        if (rec.type == TraceType::KERNEL_API_EXIT) {
+            if (auto it = g_launchMetaByCorr.find(rec.corr_id);
+                it != g_launchMetaByCorr.end()) {
+                it->second.api_exit_ns = rec.api_exit_ns;
+            }
+            return true;
+        }
+
         const int64_t duration_ns = rec.duration_ns;
         Runtime* rt = runtime();
         if (!(rt && rt->logger)) {
@@ -223,6 +413,12 @@ static bool collectorProcessNext() {
         }
         if (rec.type == TraceType::KERNEL || rec.type == TraceType::MEMCPY ||
             rec.type == TraceType::MEMSET) {
+            // Join launch-callback metadata recorded at API_ENTER (Step 4b-2).
+            // Before the cutover the producing handler did this under meta_mu_;
+            // now the raw activity record arrives with empty scope/stack and we
+            // fill it here from the worker-local map (lock-free — single
+            // consumer). No-op while the map is empty (scaffolding / cache miss).
+            joinLaunchMeta(rec);
             const std::string stack_trace =
                 (rec.stack_id != 0) ? StackRegistry::instance().get(rec.stack_id)
                                     : "";
@@ -230,61 +426,7 @@ static bool collectorProcessNext() {
                 g_adapter ? g_adapter->platformName() : "unknown";
 
             if (rec.type == TraceType::KERNEL) {
-                // Demangle on the collector thread (Step 4a) — rec.name holds
-                // the RAW mangled name pushed by the CUPTI callback/activity path.
-                const uint32_t kernel_id = g_dictManager.internKernel(
-                    DemangleKernelNameCached(rec.name).c_str());
-
-                KernelBatchRow row;
-                row.start_ns    = rec.cpu_start_ns;
-                row.kernel_id   = kernel_id;
-                row.stream_id   = static_cast<uint32_t>(rec.stream);
-                row.duration_ns = duration_ns;
-                row.corr_id     = rec.corr_id;
-                row.dyn_shared  = rec.dyn_shared;
-                row.num_regs    = rec.num_regs;
-                row.has_details = rec.has_details ? 1 : 0;
-                // Pre-stamped by KernelLaunchHandler; both fields are
-                // 0 when no framework was tracking this launch.
-                row.external_kind = rec.external_kind;
-                row.external_id   = rec.external_id;
-                g_kernelBatch.push(row);
-
-                if (rec.has_details) {
-                    KernelDetailRow detail;
-                    detail.corr_id    = rec.corr_id;
-                    detail.session_id = rt->session_id;
-                    detail.pid        = detail::GetPid();
-                    detail.app        = rt->app_name;
-                    detail.grid_x = rec.grid_x; detail.grid_y = rec.grid_y;
-                    detail.grid_z = rec.grid_z;
-                    detail.block_x = rec.block_x; detail.block_y = rec.block_y;
-                    detail.block_z = rec.block_z;
-                    detail.static_shared         = rec.static_shared;
-                    detail.local_bytes           = rec.local_bytes;
-                    detail.const_bytes           = rec.const_bytes;
-                    detail.occupancy             = rec.occupancy;
-                    detail.reg_occupancy         = rec.reg_occupancy;
-                    detail.smem_occupancy        = rec.smem_occupancy;
-                    detail.warp_occupancy        = rec.warp_occupancy;
-                    detail.block_occupancy       = rec.block_occupancy;
-                    std::memcpy(detail.limiting_resource, rec.limiting_resource,
-                                sizeof(detail.limiting_resource));
-                    detail.max_active_blocks      = rec.max_active_blocks;
-                    detail.local_mem_total        = rec.local_mem_total;
-                    detail.local_mem_per_thread   = rec.local_mem_per_thread;
-                    detail.cache_config_requested = rec.cache_config_requested;
-                    detail.cache_config_executed  = rec.cache_config_executed;
-                    detail.shared_mem_executed    = rec.shared_mem_executed;
-                    detail.user_scope  = rec.user_scope;
-                    detail.stack_trace = stack_trace;
-                    // Defer: written after the kernel batch by flushBatches().
-                    g_pendingDetails.push_back(std::move(detail));
-                }
-
-                if (g_kernelBatch.needsFlush()) {
-                    flushBatches(*rt->logger, rt->session_id);
-                }
+                emitKernelRecord(rec, stack_trace, rt);
 
             } else if (rec.type == TraceType::MEMCPY) {
                 MemcpyBatchRow row;
@@ -508,8 +650,11 @@ void CollectorLoop() {
     while (collectorProcessNext()) { ++drained; }
     GFL_LOG_DEBUG("[CollectorLoop] drain-remaining consumed=", drained);
 
-    // Final flush of any partially-filled batches
+    // Final flush of any partially-filled batches. drainSyntheticKernels runs
+    // FIRST (ring now empty → the meta map holds only orphaned launches) so the
+    // synthetic kernel rows it emits are included in this last flush.
     if (Runtime* rt = runtime(); rt && rt->logger) {
+        drainSyntheticKernels(rt);
         flushBatches(*rt->logger, rt->session_id);
     }
     GFL_LOG_DEBUG("[CollectorLoop] END");
@@ -523,6 +668,9 @@ void Monitor::Initialize(const MonitorOptions& opts) {
     g_dictManager.enable_source_collection = opts.enable_source_collection;
     g_kernelBatch.clear();
     g_memcpyBatch.clear();
+    // Worker-local launch-meta join map (Step 4b-2): drop any entries a prior
+    // session left behind so corr ids can't collide across init/shutdown cycles.
+    g_launchMetaByCorr.clear();
     g_kernelBatchId  = 0;
     g_memcpyBatchId  = 0;
     g_scopeBatch.clear();
@@ -583,6 +731,10 @@ void Monitor::Shutdown() {
         int drained = 0;
         while (collectorProcessNext()) { ++drained; }
         if (Runtime* rt = runtime(); rt && rt->logger) {
+            // Emit any launch metas the collector's own drain didn't reach
+            // (Windows process-exit can tear the collector down early). No-op
+            // when CollectorLoop already drained them — the map is cleared.
+            drainSyntheticKernels(rt);
             flushBatches(*rt->logger, rt->session_id);
         }
         GFL_LOG_DEBUG("Monitor::Shutdown: post-join drained=", drained);

--- a/include/gpufl/core/monitor.cpp
+++ b/include/gpufl/core/monitor.cpp
@@ -25,6 +25,7 @@
 #include "gpufl/core/ring_buffer.hpp"
 #include "gpufl/core/runtime.hpp"
 #include "gpufl/core/stack_registry.hpp"
+#include "gpufl/core/stack_trace.hpp"
 
 namespace gpufl {
 
@@ -43,6 +44,22 @@ static BatchBuffer<KernelBatchRow>  g_kernelBatch;
 static BatchBuffer<MemcpyBatchRow>  g_memcpyBatch;
 static uint64_t g_kernelBatchId = 0;
 static uint64_t g_memcpyBatchId = 0;
+
+// Worker-local kernel-name demangle cache (Step 4a). Demangling moved off the
+// CUPTI callback/activity threads to here. collectorProcessNext runs only on
+// the collector thread (and on the main thread AFTER the collector is joined
+// at shutdown), never concurrently — so no lock is needed (the old
+// callback-side cache used demangle_mu_).
+static std::unordered_map<std::string, std::string> g_kernelNameDemangleCache;
+static const std::string& DemangleKernelNameCached(const char* raw) {
+    static const std::string kFallback = "kernel_launch";
+    if (!raw || raw[0] == '\0') return kFallback;
+    auto it = g_kernelNameDemangleCache.find(raw);
+    if (it != g_kernelNameDemangleCache.end()) return it->second;
+    auto [ins, _] =
+        g_kernelNameDemangleCache.emplace(raw, gpufl::core::DemangleName(raw));
+    return ins->second;
+}
 // Deferred kernel detail rows — written after the kernel batch so the
 // backend's UPDATE (match by corr_id) always finds the INSERT first.
 static std::vector<KernelDetailRow> g_pendingDetails;
@@ -213,7 +230,10 @@ static bool collectorProcessNext() {
                 g_adapter ? g_adapter->platformName() : "unknown";
 
             if (rec.type == TraceType::KERNEL) {
-                const uint32_t kernel_id = g_dictManager.internKernel(rec.name);
+                // Demangle on the collector thread (Step 4a) — rec.name holds
+                // the RAW mangled name pushed by the CUPTI callback/activity path.
+                const uint32_t kernel_id = g_dictManager.internKernel(
+                    DemangleKernelNameCached(rec.name).c_str());
 
                 KernelBatchRow row;
                 row.start_ns    = rec.cpu_start_ns;

--- a/include/gpufl/core/stack_registry.hpp
+++ b/include/gpufl/core/stack_registry.hpp
@@ -1,8 +1,13 @@
 #pragma once
+#include <cstddef>
+#include <cstdint>
 #include <functional>
 #include <mutex>
 #include <string>
 #include <unordered_map>
+#include <vector>
+
+#include "gpufl/core/stack_trace.hpp"
 
 namespace gpufl {
 class StackRegistry {
@@ -23,24 +28,67 @@ class StackRegistry {
         return *inst;
     }
 
-    size_t getOrRegister(const std::string& stackTrace) {
-        const size_t hash = std::hash<std::string>{}(stackTrace);
+    // Hot path (CUPTI callback / launch thread): register a captured RawStack
+    // (return addresses only). NO symbolization happens here — resolution is
+    // deferred to get(), which runs on the collector/worker thread. This keeps
+    // dbghelp's SymFromAddr (a process-global lock) off the per-launch path.
+    size_t getOrRegister(const core::RawStack& raw) {
+        const size_t hash = hashRaw(raw);
+        if (hash == 0) return 0;
 
-        // Optimization: Check without lock first (if using a read/write lock)
-        // For simplicity here, we use a standard mutex.
         std::lock_guard<std::mutex> lock(mu_);
         if (storage_.find(hash) == storage_.end()) {
-            storage_[hash] = stackTrace;
-            newEntries_.push_back(
-                hash);  // Track what needs to be flushed to logs
+            Entry e;
+            e.raw = raw;
+            storage_.emplace(hash, std::move(e));
+            newEntries_.push_back(hash);
         }
         return hash;
     }
 
-    std::string get(const size_t hash) {
+    // Legacy: register an already-symbolized string (stored as pre-resolved).
+    // Kept so callers that already hold a resolved trace don't break.
+    size_t getOrRegister(const std::string& stackTrace) {
+        const size_t hash = std::hash<std::string>{}(stackTrace);
+
         std::lock_guard<std::mutex> lock(mu_);
-        const auto it = storage_.find(hash);
-        return (it != storage_.end()) ? it->second : "unknown";
+        if (storage_.find(hash) == storage_.end()) {
+            Entry e;
+            e.resolved = stackTrace;
+            e.isResolved = true;
+            storage_.emplace(hash, std::move(e));
+            newEntries_.push_back(hash);
+        }
+        return hash;
+    }
+
+    // Cold path (collector/worker thread): resolve the RawStack to a sanitized
+    // string, cached after first resolution. Symbol resolution runs OUTSIDE the
+    // lock so it never blocks hot-path getOrRegister() calls.
+    std::string get(const size_t hash) {
+        if (hash == 0) return "";
+
+        core::RawStack raw;
+        {
+            std::lock_guard<std::mutex> lock(mu_);
+            const auto it = storage_.find(hash);
+            if (it == storage_.end()) return "unknown";
+            if (it->second.isResolved) return it->second.resolved;
+            raw = it->second.raw;
+        }
+
+        // Heavy symbolization happens here, without the lock held.
+        std::string resolved = core::ResolveCallStack(raw);
+
+        {
+            std::lock_guard<std::mutex> lock(mu_);
+            const auto it = storage_.find(hash);
+            if (it != storage_.end() && !it->second.isResolved) {
+                it->second.resolved = resolved;
+                it->second.isResolved = true;
+            }
+        }
+        return resolved;
     }
 
     std::vector<size_t> consumeNewEntries() {
@@ -51,8 +99,28 @@ class StackRegistry {
     }
 
    private:
+    struct Entry {
+        core::RawStack raw;     // pending frames (used when !isResolved)
+        std::string resolved;   // cached symbolized+sanitized string
+        bool isResolved = false;
+    };
+
+    // FNV-1a over the raw return addresses. Identical call sites produce
+    // identical address sequences → same id (dedup preserved). Distinct
+    // sequences that symbolize to the same string still dedup downstream at
+    // internFunction(), so no wire-level duplication results.
+    static size_t hashRaw(const core::RawStack& raw) {
+        if (raw.count == 0) return 0;
+        size_t h = 1469598103934665603ULL;
+        for (uint8_t i = 0; i < raw.count; ++i) {
+            h ^= reinterpret_cast<size_t>(raw.frames[i]);
+            h *= 1099511628211ULL;
+        }
+        return h;
+    }
+
     std::mutex mu_;
-    std::unordered_map<size_t, std::string> storage_;
+    std::unordered_map<size_t, Entry> storage_;
     std::vector<size_t> newEntries_;
 };
 }  // namespace gpufl

--- a/include/gpufl/core/stack_trace.cpp
+++ b/include/gpufl/core/stack_trace.cpp
@@ -1,9 +1,10 @@
 #include "gpufl/core/stack_trace.hpp"
+
+#include "gpufl/core/common.hpp"  // detail::SanitizeStackTrace
 #include "gpufl/core/itanium_demangle.hpp"
 
 #include <cstdlib>
 #include <sstream>
-#include <vector>
 
 #ifdef _WIN32
 // clang-format off
@@ -36,7 +37,23 @@ std::string DemangleName(const char* mangled) {
     return mangled;
 }
 
-std::string GetCallStack(int skipFrames) {
+RawStack CaptureCallStackRaw(int skipFrames) {
+    RawStack raw;
+    void* stack[RawStack::kMaxFrames];
+    const unsigned short frames =
+        CaptureStackBackTrace(0, RawStack::kMaxFrames, stack, nullptr);
+    // Store outermost-first (matches the historical GetCallStack ordering),
+    // dropping the top `skipFrames` frames (capture fn + immediate wrappers).
+    for (int i = static_cast<int>(frames) - 1;
+         i >= skipFrames && raw.count < RawStack::kMaxFrames; --i) {
+        raw.frames[raw.count++] = stack[i];
+    }
+    return raw;
+}
+
+// Symbolize raw frames into an un-sanitized "outer|...|inner" string.
+// Heavy: dbghelp's SymFromAddr takes a process-global lock. Off-hot-path only.
+static std::string SymbolizeRaw(const RawStack& raw) {
     HANDLE process = GetCurrentProcess();
 
     static bool symbolsInitialized = false;
@@ -45,22 +62,20 @@ std::string GetCallStack(int skipFrames) {
         symbolsInitialized = true;
     }
 
-    void* stack[62];
-    unsigned short frames = CaptureStackBackTrace(0, 62, stack, nullptr);
-
-    std::ostringstream oss;
-
     alignas(SYMBOL_INFO) char buffer[sizeof(SYMBOL_INFO) + 256];
     SYMBOL_INFO* symbol = reinterpret_cast<SYMBOL_INFO*>(buffer);
     symbol->MaxNameLen = 255;
     symbol->SizeOfStruct = sizeof(SYMBOL_INFO);
 
+    std::ostringstream oss;
     bool first = true;
-    for (int i = static_cast<int>(frames) - 1; i >= skipFrames; --i) {
-        if (SymFromAddr(process, reinterpret_cast<DWORD64>(stack[i]), 0, symbol)) {
+    for (uint8_t i = 0; i < raw.count; ++i) {
+        if (SymFromAddr(process, reinterpret_cast<DWORD64>(raw.frames[i]), 0,
+                        symbol)) {
             std::string name = symbol->Name;
 
             if (name.empty()) continue;
+            if (name.find("CaptureCallStackRaw") != std::string::npos) continue;
             if (name.find("GetCallStack") != std::string::npos) continue;
             if (name.find("BaseThreadInitThunk") != std::string::npos) continue;
             if (name.find("RtlUserThreadStart") != std::string::npos) continue;
@@ -72,6 +87,16 @@ std::string GetCallStack(int skipFrames) {
     }
 
     return oss.str();
+}
+
+std::string ResolveCallStack(const RawStack& raw) {
+    return detail::SanitizeStackTrace(SymbolizeRaw(raw));
+}
+
+std::string GetCallStack(int skipFrames) {
+    // +1 compensates for CaptureCallStackRaw's own frame so the kept frame
+    // set matches the historical inline-capture behavior of this function.
+    return SymbolizeRaw(CaptureCallStackRaw(skipFrames + 1));
 }
 }  // namespace core
 }  // namespace gpufl
@@ -113,29 +138,40 @@ std::string DemangleName(const char* mangled) {
     return mangled;
 }
 
-std::string GetCallStack(int skipFrames) {
-    void* callstack[64];
-    int frames = backtrace(callstack, 64);
-    char** strs = backtrace_symbols(callstack, frames);
+RawStack CaptureCallStackRaw(int skipFrames) {
+    RawStack raw;
+    void* callstack[RawStack::kMaxFrames];
+    const int frames = backtrace(callstack, RawStack::kMaxFrames);
+    for (int i = frames - 1;
+         i >= skipFrames && raw.count < RawStack::kMaxFrames; --i) {
+        raw.frames[raw.count++] = callstack[i];
+    }
+    return raw;
+}
 
+// Symbolize raw frames into an un-sanitized "outer|...|inner" string.
+// Heavy (backtrace_symbols allocates + parses). Off-hot-path only.
+static std::string SymbolizeRaw(const RawStack& raw) {
+    if (raw.count == 0) return "";
+    char** strs = backtrace_symbols(raw.frames, raw.count);
     if (!strs) return "unknown";
 
     std::ostringstream oss;
     bool first = true;
-
-    for (int i = frames - 1; i >= skipFrames; --i) {
+    for (uint8_t i = 0; i < raw.count; ++i) {
         std::string line = strs[i];
         std::string name;
 
         size_t openParen = line.find('(');
         size_t plusSign = line.find('+');
         if (openParen != std::string::npos && plusSign != std::string::npos) {
-            std::string raw =
+            std::string rawname =
                 line.substr(openParen + 1, plusSign - openParen - 1);
-            name = DemangleName(raw.c_str());
+            name = DemangleName(rawname.c_str());
         }
 
         if (name.empty()) continue;
+        if (name.find("CaptureCallStackRaw") != std::string::npos) continue;
         if (name.find("GetCallStack") != std::string::npos) continue;
         if (name.find("clone") != std::string::npos) continue;
         if (name.find("_start") != std::string::npos) continue;
@@ -148,6 +184,14 @@ std::string GetCallStack(int skipFrames) {
 
     free(strs);
     return oss.str();
+}
+
+std::string ResolveCallStack(const RawStack& raw) {
+    return detail::SanitizeStackTrace(SymbolizeRaw(raw));
+}
+
+std::string GetCallStack(int skipFrames) {
+    return SymbolizeRaw(CaptureCallStackRaw(skipFrames + 1));
 }
 }  // namespace core
 }  // namespace gpufl

--- a/include/gpufl/core/stack_trace.hpp
+++ b/include/gpufl/core/stack_trace.hpp
@@ -1,12 +1,44 @@
 #pragma once
+#include <cstdint>
 #include <string>
 
 namespace gpufl::core {
+
+/**
+ * A captured call stack as raw return addresses only — NO symbol resolution.
+ * Capturing addresses (CaptureStackBackTrace / backtrace) is cheap and safe to
+ * do on a hot path (e.g. inside a CUPTI launch callback). Turning addresses
+ * into symbol names (SymFromAddr / backtrace_symbols) is expensive — dbghelp
+ * serializes globally — so that step is deferred to ResolveCallStack(), run off
+ * the hot path on the collector/worker thread.
+ */
+struct RawStack {
+    static constexpr int kMaxFrames = 64;
+    void* frames[kMaxFrames] = {};  // outermost-first (matches GetCallStack order)
+    uint8_t count = 0;
+};
+
+/**
+ * Cheap: walk the current call stack and store raw return addresses only.
+ * `skipFrames` top frames (this function + immediate wrappers) are dropped.
+ * No symbolization, no dbghelp lock — safe on the per-launch hot path.
+ */
+RawStack CaptureCallStackRaw(int skipFrames = 1);
+
+/**
+ * Expensive: resolve a RawStack to a sanitized "main|FunctionA|FunctionB"
+ * string (SymFromAddr / backtrace_symbols + user-frame filtering). Call OFF
+ * the hot path (collector/worker thread), e.g. from StackRegistry::get().
+ */
+std::string ResolveCallStack(const RawStack& raw);
+
 /**
  * Captures the current call stack and returns it as a string.
- * Format: "main::FunctionA::FunctionB"
- * * @param skipFrames Number of top frames to skip (default 1 to skip
- * GetCallStack itself)
+ * Format: "main|FunctionA|FunctionB"
+ * @param skipFrames Number of top frames to skip (default 1)
+ *
+ * NOTE: this symbolizes synchronously. Prefer CaptureCallStackRaw() +
+ * deferred ResolveCallStack() on hot paths.
  */
 std::string GetCallStack(int skipFrames = 1);
 

--- a/include/gpufl/core/trace_type.hpp
+++ b/include/gpufl/core/trace_type.hpp
@@ -109,5 +109,12 @@ enum class TraceType : uint8_t {
     //   collector sets api_exit_ns on the matching g_launchMetaByCorr entry.
     //   Fields used on ActivityRecord: corr_id, api_exit_ns.
     KERNEL_API_EXIT,
+    // SYNC_META: pushed by SynchronizationHandler on API_ENTER (Step 4c). Carries
+    //   the user call stack for a CUDA sync API so the collector can join it onto
+    //   the matching SYNCHRONIZATION activity record by corr_id (the join used to
+    //   run under CuptiBackend::sync_meta_mu_ in BufferCompleted). The collector
+    //   stores corr_id->stack_id in g_syncStackByCorr and never emits this record.
+    //   Fields used on ActivityRecord: corr_id, stack_id.
+    SYNC_META,
 };
 }

--- a/include/gpufl/core/trace_type.hpp
+++ b/include/gpufl/core/trace_type.hpp
@@ -85,5 +85,29 @@ enum class TraceType : uint8_t {
     //   graph_id      — unique id of the graph (so repeated launches
     //                   of the same compiled graph share an id)
     GRAPH_LAUNCH,
+    // ── Internal-only collector control records (Step 4b-2) ──────────────
+    // These NEVER reach a wire Model — the collector consumes them to maintain
+    // its launch-meta join map and emits nothing. Appended at the END so every
+    // existing TraceType ordinal is unchanged (the enum is routed in-process
+    // only; the NDJSON wire format keys off Model type strings, not this enum).
+    //
+    // Carry the corr->meta join — which used to run under CuptiBackend::meta_mu_
+    // on the CUPTI callback + BufferCompleted threads — from those threads to
+    // the single collector thread, where the join becomes lock-free.
+    //
+    // KERNEL_LAUNCH_META: pushed by KernelLaunchHandler / MemTransferHandler on
+    //   API_ENTER. The collector stores it in g_launchMetaByCorr keyed by
+    //   corr_id; the matching KERNEL / MEMCPY / MEMSET activity record later
+    //   joins scope path, stack id, and API timestamps from it. Entries with no
+    //   activity record by shutdown become synthetic kernels (drainSynthetic
+    //   Kernels). Fields used on ActivityRecord: corr_id, name (raw), device_id,
+    //   api_start_ns (= API_ENTER ns), user_scope, scope_depth, stack_id, plus
+    //   has_details + grid/block/dyn_shared and the precomputed simplified
+    //   occupancy (synthetic-kernel modes only).
+    KERNEL_LAUNCH_META,
+    // KERNEL_API_EXIT: pushed on API_EXIT by the same two handlers. The
+    //   collector sets api_exit_ns on the matching g_launchMetaByCorr entry.
+    //   Fields used on ActivityRecord: corr_id, api_exit_ns.
+    KERNEL_API_EXIT,
 };
 }


### PR DESCRIPTION
## Description
### refactor(nvidia/cupti): zero-lock activity-path callbacks

Removes every per-correlation mutex from the CUPTI hot path. Kernel/mem/sync
callbacks now just push raw records to the lock-free ring; all corr-keyed joins
run on the single collector thread → callbacks are lock-free & heap-free. No
wire/behavior change.

- Move stack-symbolize, demangle, occupancy off the callback threads (Steps 1–4b-1).
- Drop `meta_mu_` (4b-2), `sync_meta_mu_` (4c), `handler_mu_` (5): joins → collector;
  new internal `KERNEL_LAUNCH_META`/`KERNEL_API_EXIT`/`SYNC_META` types (never serialized).
- Fix cross-session companion-map leak; add `prewarm`/`serialize` repro flags.

**SASS+kernel-activity deadlock:** diagnosed as NVIDIA CUPTI/driver-internal (gdb:
gpufl absent from the lock cycle; pre-warm rules out patch-timing). Mitigable by
serializing launches (validated 3/3) but trades fidelity → left unimplemented;
safe-default Deep ships, override stays opt-in.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Refactoring 

## Testing
## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas