### PR TITLE
Add multi-pass profiling and kernel replay counter reporting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ cmake/
 CMakeFiles/
 CMakeCache.txt
 wget-log*
+runs/
 
 ### docker
 example/python/docker/**/

--- a/README.md
+++ b/README.md
@@ -191,7 +191,10 @@ gpufl.shutdown()
 
 ## Profiling Engines
 
-CUPTI only allows one profiling mode per CUDA context at a time. Choose an engine at init:
+GPUFlight separates lightweight activity tracing from heavier counter/sampling
+engines. In embedded C++/Python mode you normally choose one
+`ProfilingEngine` at init. In launcher mode (`gpufl trace`) you can run
+multiple passes of the same command and upload/merge them later.
 
 ```python
 from gpufl import ProfilingEngine
@@ -209,7 +212,31 @@ gpufl.init("my-app",
 | `SassMetrics` | Per-instruction execution counts (binary instrumentation) | `session.inspect_profile_samples()` | Thread divergence and instruction-level behavior |
 | `PmSampling` | Time-series hardware counter samples from CUPTI PM Sampling | `session.inspect_pm_sampling()` | Hardware-counter timelines by scope |
 | `RangeProfiler` | SM throughput, L1/L2 hit rates, DRAM bandwidth, tensor core % | `session.inspect_perf_metrics()` | Hardware counter deep-dives |
+| `RangeProfilerKernelReplay` | Kernel replay hardware counters keyed by replay range/kernel name | `session.inspect_perf_metrics()` / report | Per-kernel hardware counters when timing can be correlated separately |
 | `Deep` | Deep decision pipeline: SASS first, PC-sampling fallback, PM Sampling when available | Text report plus profiling analyzer views | Single-run deep profiling with safe defaults |
+
+### Launcher multi-pass
+
+`gpufl trace` can run several passes of the same target process. This is the
+recommended path when you want data from engines that cannot safely coexist in
+one CUDA context.
+
+```bash
+gpufl trace --passes Trace,PcSampling,RangeProfilerKernelReplay -- python train.py
+```
+
+For embedded examples and test scripts, the lower-level compatibility-matrix
+knob is also available:
+
+```bash
+GPUFL_ENGINE_COMBO=Trace,PcSampling,RangeProfilerKernelReplay ./my_app
+```
+
+Think of merged data as a union of capabilities, not a blind overwrite.
+`Trace` owns canonical kernel timing. `PcSampling` adds stall samples that do
+not overlap with trace timing. `RangeProfilerKernelReplay` adds per-kernel
+hardware counters; local reports and `inspect_perf_metrics()` surface those
+rows alongside scope-level `RangeProfiler` counters.
 
 ### C++ Usage
 

--- a/daemon/launcher/cli_parse.cpp
+++ b/daemon/launcher/cli_parse.cpp
@@ -20,6 +20,28 @@ FlagBreak splitFlag(const std::string& tok) {
     return {tok.substr(0, eq), tok.substr(eq + 1)};
 }
 
+// Canonical engine names accepted by --engine and by each --passes token.
+// Must match the set gpufl::init() parses for GPUFL_PROFILING_ENGINE (see
+// gpufl.cpp). The launcher only validates + forwards verbatim; init() is the
+// single string→enum parser, so this is the one launcher-side copy to keep in
+// sync with the ProfilingEngine ladder.
+constexpr const char* kEngines[] = {
+    "Monitor", "Trace", "PcSampling", "SassMetrics",
+    "PmSampling", "RangeProfiler", "Deep"};
+bool isValidEngine(const std::string& e) {
+    for (auto* k : kEngines) if (e == k) return true;
+    return false;
+}
+
+// Trim ASCII spaces/tabs from both ends — lets `--passes Trace, SassMetrics`
+// (with spaces after commas) parse the same as the no-space form.
+std::string trim(const std::string& s) {
+    const auto b = s.find_first_not_of(" \t");
+    if (b == std::string::npos) return "";
+    const auto e = s.find_last_not_of(" \t");
+    return s.substr(b, e - b + 1);
+}
+
 }  // namespace
 
 const char* topLevelHelp() {
@@ -52,6 +74,15 @@ const char* traceHelp() {
         "        --engine <ENG>      Override profiling engine. One of:\n"
         "                            Monitor | Trace | PcSampling | SassMetrics |\n"
         "                            PmSampling | RangeProfiler | Deep\n"
+        "                            (Deep = the default multi-pass plan: Trace,\n"
+        "                            PcSampling, SassMetrics run as isolated passes\n"
+        "                            and merged by the backend.)\n"
+        "        --passes <LIST>     Multi-pass run: comma-separated engines, one\n"
+        "                            isolated pass each, merged by the backend.\n"
+        "                            e.g. Trace,PcSampling,SassMetrics. Mutually\n"
+        "                            exclusive with --engine. (PcSampling needs\n"
+        "                            admin / GPU perf-counter access; that pass is\n"
+        "                            reported + skipped if unprivileged.)\n"
         "    -q, --quiet             Suppress launcher chatter (errors still printed)\n"
         "    -v, --verbose           Verbose launcher logging\n"
         "        --upload            After the run, upload the trace to the\n"
@@ -62,7 +93,9 @@ const char* traceHelp() {
         "EXAMPLES:\n"
         "    gpufl trace -- python train.py\n"
         "    gpufl trace --name=quantize -- ./inference_server\n"
-        "    gpufl trace --profile=light -- python long_train.py\n";
+        "    gpufl trace --profile=light -- python long_train.py\n"
+        "    gpufl trace --engine Deep -- python train.py        # multi-pass\n"
+        "    gpufl trace --passes Trace,SassMetrics -- ./app     # custom plan\n";
 }
 
 ParsedTopLevel parseTopLevel(int argc, char** argv) {
@@ -137,21 +170,40 @@ TraceParseResult parseTraceArgs(const std::vector<std::string>& argv) {
         } else if (key == "--engine") {
             auto err = take_value(out.engine);
             if (!err.empty()) return {std::nullopt, err};
-            // Must match the canonical engine names gpufl::init() accepts
-            // for GPUFL_PROFILING_ENGINE (see gpufl.cpp). The launcher only
-            // validates here and forwards the string verbatim; init() is the
-            // single string->enum parser, so this list is the one place to
-            // keep in sync with the ProfilingEngine ladder.
-            static const char* kEngines[] = {
-                "Monitor", "Trace", "PcSampling", "SassMetrics",
-                "PmSampling", "RangeProfiler", "Deep"};
-            bool ok = false;
-            for (auto* e : kEngines) if (out.engine == e) { ok = true; break; }
-            if (!ok) {
+            if (!isValidEngine(out.engine)) {
                 return {std::nullopt,
                         "invalid --engine value: " + out.engine +
                         " (expected: Monitor | Trace | PcSampling | SassMetrics | "
                         "PmSampling | RangeProfiler | Deep)"};
+            }
+        } else if (key == "--passes") {
+            std::string v;
+            auto err = take_value(v);
+            if (!err.empty()) return {std::nullopt, err};
+            // Comma-separated engine list → one isolated pass each. Every token
+            // must be a canonical engine name (same set as --engine).
+            out.passes.clear();
+            size_t start = 0;
+            while (true) {
+                const size_t comma = v.find(',', start);
+                const std::string item = trim(v.substr(
+                    start,
+                    comma == std::string::npos ? std::string::npos : comma - start));
+                if (!item.empty()) {
+                    if (!isValidEngine(item)) {
+                        return {std::nullopt,
+                                "invalid --passes engine: " + item +
+                                " (expected a comma-separated list of: Monitor | "
+                                "Trace | PcSampling | SassMetrics | PmSampling | "
+                                "RangeProfiler | Deep)"};
+                    }
+                    out.passes.push_back(item);
+                }
+                if (comma == std::string::npos) break;
+                start = comma + 1;
+            }
+            if (out.passes.empty()) {
+                return {std::nullopt, "--passes requires at least one engine"};
             }
         } else {
             // A non-flag token before `--` is almost certainly the
@@ -162,6 +214,12 @@ TraceParseResult parseTraceArgs(const std::vector<std::string>& argv) {
             }
             return {std::nullopt, "unknown flag: " + key};
         }
+    }
+    if (!out.passes.empty() && !out.engine.empty()) {
+        return {std::nullopt,
+                "--engine and --passes are mutually exclusive (use --passes to "
+                "list engines for a multi-pass run, or --engine for one engine "
+                "— --engine Deep expands to the default multi-pass plan)"};
     }
     if (!seen_dash_dash) {
         return {std::nullopt, "missing `--` separator before command"};
@@ -282,6 +340,23 @@ UploadParseResult parseUploadArgs(const std::vector<std::string>& argv) {
         return {std::nullopt, "--session-id and --all-sessions are mutually exclusive"};
     }
     return {out, ""};
+}
+
+std::vector<std::string> resolvePassPlan(const TraceArgs& args) {
+    // 1. Explicit plan wins.
+    if (!args.passes.empty()) return args.passes;
+    // 2. Deep at the launcher = the multi-pass orchestrator: each engine runs
+    //    in its OWN process/pass (isolated), which dodges the SASS +
+    //    kernel-activity deadlock by construction; the backend stitches the
+    //    passes back into one kernel view. (The library / Python Deep engine
+    //    is unchanged — still the single-process PcSamplingWithSass composite;
+    //    only the launcher expands Deep here.)
+    if (args.engine == "Deep") {
+        return {"Trace", "PcSampling", "SassMetrics"};
+    }
+    // 3. Single pass — the explicit engine, or "" = the profile's default
+    //    engine. This is the legacy single-pass path, unchanged.
+    return {args.engine};
 }
 
 }  // namespace gpufl::launcher

--- a/daemon/launcher/cli_parse.hpp
+++ b/daemon/launcher/cli_parse.hpp
@@ -14,6 +14,12 @@ struct TraceArgs {
     std::string output_dir;             // --output / -o; default: ~/.gpufl/traces/{ts}_{sid}
     std::string profile = "comprehensive"; // --profile
     std::string engine;                 // --engine; empty = profile default
+    // --passes: explicit multi-pass plan — a comma-separated list of engines,
+    // one isolated pass each (e.g. "Trace,PcSampling,SassMetrics"). Mutually
+    // exclusive with --engine. Empty here means "no explicit plan"; the plan is
+    // then resolved from --engine (Deep expands to the default multi-pass plan)
+    // — see resolvePassPlan().
+    std::vector<std::string> passes;
     bool verbose = false;               // -v
     bool quiet = false;                 // -q
     bool upload = false;                // --upload: ship trace to backend post-run
@@ -61,6 +67,19 @@ struct TraceParseResult {
 };
 
 TraceParseResult parseTraceArgs(const std::vector<std::string>& argv);
+
+// Resolves the ordered multi-pass plan (one isolated CUPTI engine per pass)
+// from parsed trace args. Precedence:
+//   1. explicit --passes list (verbatim);
+//   2. --engine Deep        → the default multi-pass plan
+//                             [Trace, PcSampling, SassMetrics];
+//   3. otherwise            → a single pass = {engine} (engine may be "" =
+//                             use the profile's default engine — the legacy
+//                             single-pass behavior, unchanged).
+// A returned size() > 1 is a multi-pass run (the launcher assigns one
+// analysis_id and labels each pass). This is the single source of truth for
+// the default plan, shared by the Linux and Windows launchers.
+std::vector<std::string> resolvePassPlan(const TraceArgs& args);
 
 // Parses the args passed to `gpufl upload`. On success returns the
 // populated UploadArgs. On failure (missing log_path, bad flag,

--- a/daemon/launcher/trace_command.cpp
+++ b/daemon/launcher/trace_command.cpp
@@ -83,6 +83,28 @@ std::string makeSessionId() {
     return os.str();
 }
 
+// 128-bit UUID-shaped id shared by all passes of one multi-pass analysis.
+// Opaque to the backend (it only groups by string equality), so the exact
+// layout doesn't matter — just full-width randomness for collision safety
+// across accounts (makeSessionId's 32 bits is fine for a local dir name but
+// too narrow to group analyses on the backend).
+std::string makeAnalysisId() {
+    static std::mt19937_64 rng{
+        static_cast<uint64_t>(
+            std::chrono::steady_clock::now().time_since_epoch().count()) ^
+        0x9e3779b97f4a7c15ULL};
+    const uint64_t a = rng();
+    const uint64_t b = rng();
+    char buf[40];
+    std::snprintf(buf, sizeof(buf), "%08x-%04x-%04x-%04x-%012llx",
+                  static_cast<unsigned>(a >> 32),
+                  static_cast<unsigned>((a >> 16) & 0xffff),
+                  static_cast<unsigned>(a & 0xffff),
+                  static_cast<unsigned>((b >> 48) & 0xffff),
+                  static_cast<unsigned long long>(b & 0xffffffffffffULL));
+    return buf;
+}
+
 std::string makeTimestamp() {
     auto t = std::time(nullptr);
     std::tm tm{};
@@ -133,9 +155,19 @@ int runTrace(const TraceArgs& args) {
         return 3;
     }
 
-    const std::string session_id = makeSessionId();
+    // Resolve the multi-pass plan (explicit --passes, --engine Deep expanded,
+    // or a single pass) — the shared source of truth lives in cli_parse.
+    const std::vector<std::string> plan = resolvePassPlan(args);
+    const bool multipass = plan.size() > 1;
+
+    // One analysis_id shared by every pass lets the backend stitch the isolated
+    // passes into a single kernel view. Single-pass runs get none and keep the
+    // legacy {ts}_{sid} dir name.
+    const std::string analysis_id = multipass ? makeAnalysisId() : std::string();
+    const std::string dir_tag = multipass ? analysis_id : makeSessionId();
+
     const fs::path output_dir = args.output_dir.empty()
-                              ? defaultOutputDir(session_id)
+                              ? defaultOutputDir(dir_tag)
                               : fs::path(args.output_dir);
 
     std::error_code ec;
@@ -150,8 +182,11 @@ int runTrace(const TraceArgs& args) {
                                ? baseName(args.command.front())
                                : args.name;
 
-    // LD_PRELOAD respects ":"-separated existing values; preserve any
-    // the user already set so we don't break their setup.
+    // ── Env shared by every pass: set once, inherited by each child. The log
+    //    dir is shared too — each pass's process writes under its OWN
+    //    session-id subdir (Logger's <dir>/<session_id>/ layout), so the
+    //    uploader discovers N sessions and the backend groups them by
+    //    analysis_id. LD_PRELOAD keeps any value the user already set. ──
     std::string ld_preload = inject_lib.string();
     if (const char* prev = std::getenv("LD_PRELOAD"); prev && *prev) {
         ld_preload = std::string(prev) + ":" + ld_preload;
@@ -164,14 +199,10 @@ int runTrace(const TraceArgs& args) {
     setEnvOrDie(inject::kEnvAppName, app_name);
     setEnvOrDie(inject::kEnvLogDir, output_dir.string());
     setEnvOrDie(inject::kEnvProfile, args.profile);
-    if (!args.engine.empty()) {
-        setEnvOrDie(inject::kEnvProfilingEngine, args.engine);
-    }
 
-    // --upload: fail fast here (before we exec the target) if the creds
-    // the inject lib's post-run uploadLogs() will need aren't in the
-    // environment. Better a clear usage error now than a buried warning
-    // after a long run finishes.
+    // --upload: fail fast here (before we exec) if the creds the inject lib's
+    // post-run uploadLogs() will need aren't in the environment. Each pass
+    // uploads its own session; the backend groups them by analysis_id.
     if (args.upload) {
         const char* api_key     = std::getenv("GPUFL_API_KEY");
         const char* backend_url = std::getenv("GPUFL_BACKEND_URL");
@@ -184,9 +215,20 @@ int runTrace(const TraceArgs& args) {
         setEnvOrDie(inject::kEnvUpload, "1");
     }
 
+    if (multipass) {
+        setEnvOrDie(inject::kEnvAnalysisId, analysis_id);
+        setEnvOrDie(inject::kEnvPassCount, std::to_string(plan.size()));
+    }
+
     if (!args.quiet) {
         std::fprintf(stderr, "[gpufl] capturing → %s\n",
                      output_dir.string().c_str());
+        if (multipass) {
+            std::fprintf(stderr, "[gpufl] multi-pass analysis %s — %zu passes:",
+                         analysis_id.c_str(), plan.size());
+            for (const auto& e : plan) std::fprintf(stderr, " %s", e.c_str());
+            std::fputc('\n', stderr);
+        }
         if (args.verbose) {
             std::fprintf(stderr, "[gpufl] inject lib: %s\n",
                          inject_lib.string().c_str());
@@ -195,54 +237,95 @@ int runTrace(const TraceArgs& args) {
         }
     }
 
-    const auto t_start = std::chrono::steady_clock::now();
+    // ── Run the workload once per pass. A failing pass does NOT abort the
+    //    rest (a partial analysis still captures the passes that worked); the
+    //    first non-zero pass becomes the launcher's exit code. ──
+    int overall_rc = 0;
+    for (size_t i = 0; i < plan.size(); ++i) {
+        const std::string& engine = plan[i];
 
-    pid_t pid = ::fork();
-    if (pid < 0) {
-        std::fprintf(stderr, "gpufl: fork failed: %s\n", std::strerror(errno));
-        return 2;
-    }
-    if (pid == 0) {
-        // Child: execvp the target. The env we just set is inherited.
-        std::vector<char*> argv;
-        argv.reserve(args.command.size() + 1);
-        for (auto& s : args.command) argv.push_back(const_cast<char*>(s.c_str()));
-        argv.push_back(nullptr);
-        ::execvp(args.command.front().c_str(), argv.data());
-        // execvp only returns on failure.
-        std::fprintf(stderr, "gpufl: cannot exec %s: %s\n",
-                     args.command.front().c_str(), std::strerror(errno));
-        std::_Exit(127);
-    }
+        // Per-pass engine. An empty engine (legacy single pass with no
+        // --engine) leaves GPUFL_PROFILING_ENGINE as the user/profile set it.
+        if (!engine.empty()) {
+            setEnvOrDie(inject::kEnvProfilingEngine, engine);
+        }
+        if (multipass) {
+            setEnvOrDie(inject::kEnvPassIndex, std::to_string(i));
+        }
 
-    int status = 0;
-    while (::waitpid(pid, &status, 0) < 0) {
-        if (errno == EINTR) continue;
-        std::fprintf(stderr, "gpufl: waitpid failed: %s\n", std::strerror(errno));
-        return 2;
-    }
+        const std::string what =
+            multipass ? ("pass " + std::to_string(i + 1) + "/" +
+                         std::to_string(plan.size()) + " (" + engine + ")")
+                      : std::string("target");
 
-    const auto t_elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
-                         std::chrono::steady_clock::now() - t_start)
-                         .count();
+        if (!args.quiet && multipass) {
+            std::fprintf(stderr, "\n[gpufl] ── %s ──\n", what.c_str());
+            if (engine == "PcSampling") {
+                std::fprintf(stderr,
+                    "[gpufl] note: PcSampling needs admin / NVIDIA CP \"allow GPU "
+                    "performance counters to all users\"; this pass reports \"needs "
+                    "admin\" and yields no PC data if unprivileged.\n");
+            }
+        }
+
+        const auto t_start = std::chrono::steady_clock::now();
+
+        pid_t pid = ::fork();
+        if (pid < 0) {
+            std::fprintf(stderr, "gpufl: fork failed: %s\n", std::strerror(errno));
+            return 2;
+        }
+        if (pid == 0) {
+            // Child: execvp the target. The env we just set is inherited.
+            std::vector<char*> argv;
+            argv.reserve(args.command.size() + 1);
+            for (auto& s : args.command) argv.push_back(const_cast<char*>(s.c_str()));
+            argv.push_back(nullptr);
+            ::execvp(args.command.front().c_str(), argv.data());
+            // execvp only returns on failure.
+            std::fprintf(stderr, "gpufl: cannot exec %s: %s\n",
+                         args.command.front().c_str(), std::strerror(errno));
+            std::_Exit(127);
+        }
+
+        int status = 0;
+        while (::waitpid(pid, &status, 0) < 0) {
+            if (errno == EINTR) continue;
+            std::fprintf(stderr, "gpufl: waitpid failed: %s\n", std::strerror(errno));
+            return 2;
+        }
+
+        const auto t_elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+                             std::chrono::steady_clock::now() - t_start)
+                             .count();
+
+        int rc;
+        if (WIFEXITED(status)) {
+            rc = WEXITSTATUS(status);
+            if (!args.quiet) {
+                std::fprintf(stderr, "[gpufl] %s exited (rc=%d) in %.2fs\n",
+                             what.c_str(), rc, t_elapsed / 1000.0);
+            }
+        } else if (WIFSIGNALED(status)) {
+            rc = 128 + WTERMSIG(status);
+            if (!args.quiet) {
+                std::fprintf(stderr, "[gpufl] %s killed by signal %d in %.2fs\n",
+                             what.c_str(), WTERMSIG(status), t_elapsed / 1000.0);
+            }
+        } else {
+            rc = 1;
+        }
+
+        // First failing pass sets the exit code; keep going so later passes
+        // still run and the analysis is as complete as possible.
+        if (rc != 0 && overall_rc == 0) overall_rc = rc;
+    }
 
     if (!args.quiet) {
-        if (WIFEXITED(status)) {
-            std::fprintf(stderr,
-                         "[gpufl] target exited (rc=%d) in %.2fs\n",
-                         WEXITSTATUS(status), t_elapsed / 1000.0);
-        } else if (WIFSIGNALED(status)) {
-            std::fprintf(stderr,
-                         "[gpufl] target killed by signal %d in %.2fs\n",
-                         WTERMSIG(status), t_elapsed / 1000.0);
-        }
-        std::fprintf(stderr,
-                     "[gpufl] inspect: %s\n", output_dir.string().c_str());
+        std::fprintf(stderr, "[gpufl] inspect: %s\n", output_dir.string().c_str());
     }
 
-    if (WIFEXITED(status)) return WEXITSTATUS(status);
-    if (WIFSIGNALED(status)) return 128 + WTERMSIG(status);
-    return 1;
+    return overall_rc;
 }
 
 }  // namespace gpufl::launcher

--- a/daemon/launcher/trace_command.cpp
+++ b/daemon/launcher/trace_command.cpp
@@ -29,7 +29,7 @@
 #include <string>
 #include <vector>
 
-#include "gpufl/inject/inject_entry.hpp"
+#include "gpufl/core/env_vars.hpp"
 
 namespace fs = std::filesystem;
 
@@ -188,36 +188,36 @@ int runTrace(const TraceArgs& args) {
     //    uploader discovers N sessions and the backend groups them by
     //    analysis_id. LD_PRELOAD keeps any value the user already set. ──
     std::string ld_preload = inject_lib.string();
-    if (const char* prev = std::getenv("LD_PRELOAD"); prev && *prev) {
+    if (const char* prev = std::getenv(gpufl::env::kLdPreload); prev && *prev) {
         ld_preload = std::string(prev) + ":" + ld_preload;
     }
 
-    setEnvOrDie("LD_PRELOAD", ld_preload);
-    setEnvOrDie("CUDA_INJECTION64_PATH", inject_lib.string());
-    setEnvOrDie("NVTX_INJECTION64_PATH", inject_lib.string());
-    setEnvOrDie(inject::kEnvSentinel, "1");
-    setEnvOrDie(inject::kEnvAppName, app_name);
-    setEnvOrDie(inject::kEnvLogDir, output_dir.string());
-    setEnvOrDie(inject::kEnvProfile, args.profile);
+    setEnvOrDie(gpufl::env::kLdPreload, ld_preload);
+    setEnvOrDie(gpufl::env::kCudaInjection64Path, inject_lib.string());
+    setEnvOrDie(gpufl::env::kNvtxInjection64Path, inject_lib.string());
+    setEnvOrDie(gpufl::env::kInject, "1");
+    setEnvOrDie(gpufl::env::kAppName, app_name);
+    setEnvOrDie(gpufl::env::kLogDir, output_dir.string());
+    setEnvOrDie(gpufl::env::kInjectProfile, args.profile);
 
     // --upload: fail fast here (before we exec) if the creds the inject lib's
     // post-run uploadLogs() will need aren't in the environment. Each pass
     // uploads its own session; the backend groups them by analysis_id.
     if (args.upload) {
-        const char* api_key     = std::getenv("GPUFL_API_KEY");
-        const char* backend_url = std::getenv("GPUFL_BACKEND_URL");
+        const char* api_key     = std::getenv(gpufl::env::kApiKey);
+        const char* backend_url = std::getenv(gpufl::env::kBackendUrl);
         if (!api_key || !*api_key || !backend_url || !*backend_url) {
             std::fprintf(stderr,
                 "gpufl trace --upload: GPUFL_API_KEY and GPUFL_BACKEND_URL "
                 "must both be set in the environment to upload.\n");
             return 2;
         }
-        setEnvOrDie(inject::kEnvUpload, "1");
+        setEnvOrDie(gpufl::env::kInjectUpload, "1");
     }
 
     if (multipass) {
-        setEnvOrDie(inject::kEnvAnalysisId, analysis_id);
-        setEnvOrDie(inject::kEnvPassCount, std::to_string(plan.size()));
+        setEnvOrDie(gpufl::env::kAnalysisId, analysis_id);
+        setEnvOrDie(gpufl::env::kPassCount, std::to_string(plan.size()));
     }
 
     if (!args.quiet) {
@@ -247,10 +247,10 @@ int runTrace(const TraceArgs& args) {
         // Per-pass engine. An empty engine (legacy single pass with no
         // --engine) leaves GPUFL_PROFILING_ENGINE as the user/profile set it.
         if (!engine.empty()) {
-            setEnvOrDie(inject::kEnvProfilingEngine, engine);
+            setEnvOrDie(gpufl::env::kProfilingEngine, engine);
         }
         if (multipass) {
-            setEnvOrDie(inject::kEnvPassIndex, std::to_string(i));
+            setEnvOrDie(gpufl::env::kPassIndex, std::to_string(i));
         }
 
         const std::string what =

--- a/daemon/launcher/trace_command_win.cpp
+++ b/daemon/launcher/trace_command_win.cpp
@@ -88,6 +88,27 @@ std::string makeSessionId() {
     return os.str();
 }
 
+// 128-bit UUID-shaped id shared by all passes of one multi-pass analysis.
+// Opaque to the backend (it only groups by string equality); makeSessionId's
+// 32 bits is fine for a local dir name but too narrow to group analyses on the
+// backend, so use full-width randomness here. (Mirrors the Linux launcher.)
+std::string makeAnalysisId() {
+    static std::mt19937_64 rng{
+        static_cast<uint64_t>(
+            std::chrono::steady_clock::now().time_since_epoch().count()) ^
+        0x9e3779b97f4a7c15ULL};
+    const uint64_t a = rng();
+    const uint64_t b = rng();
+    char buf[40];
+    std::snprintf(buf, sizeof(buf), "%08x-%04x-%04x-%04x-%012llx",
+                  static_cast<unsigned>(a >> 32),
+                  static_cast<unsigned>((a >> 16) & 0xffff),
+                  static_cast<unsigned>(a & 0xffff),
+                  static_cast<unsigned>((b >> 48) & 0xffff),
+                  static_cast<unsigned long long>(b & 0xffffffffffffULL));
+    return buf;
+}
+
 std::string makeTimestamp() {
     const auto t = std::time(nullptr);
     std::tm tm{};
@@ -192,9 +213,19 @@ int runTrace(const TraceArgs& args) {
         return 3;
     }
 
-    const std::string session_id = makeSessionId();
+    // Resolve the multi-pass plan (explicit --passes, --engine Deep expanded,
+    // or a single pass) — the shared source of truth lives in cli_parse.
+    const std::vector<std::string> plan = resolvePassPlan(args);
+    const bool multipass = plan.size() > 1;
+
+    // One analysis_id shared by every pass lets the backend stitch the isolated
+    // passes into a single kernel view. Single-pass runs get none and keep the
+    // legacy {ts}_{sid} dir name.
+    const std::string analysis_id = multipass ? makeAnalysisId() : std::string();
+    const std::string dir_tag = multipass ? analysis_id : makeSessionId();
+
     const fs::path output_dir = args.output_dir.empty()
-                              ? defaultOutputDir(session_id)
+                              ? defaultOutputDir(dir_tag)
                               : fs::path(args.output_dir);
 
     std::error_code ec;
@@ -226,18 +257,19 @@ int runTrace(const TraceArgs& args) {
 
     // No LD_PRELOAD on Windows — the driver loads the DLL via the injection
     // path. We still set both CUDA + NVTX injection vars to the same DLL.
+    // These (and the shared log dir) are set once and inherited by every
+    // child; each pass's process writes under its OWN session-id subdir, so
+    // the uploader discovers N sessions grouped by analysis_id.
     setEnvOrDie("CUDA_INJECTION64_PATH", inject_lib.string());
     setEnvOrDie("NVTX_INJECTION64_PATH", inject_lib.string());
     setEnvOrDie(inject::kEnvSentinel, "1");
     setEnvOrDie(inject::kEnvAppName, app_name);
     setEnvOrDie(inject::kEnvLogDir, output_dir.string());
     setEnvOrDie(inject::kEnvProfile, args.profile);
-    if (!args.engine.empty()) {
-        setEnvOrDie(inject::kEnvProfilingEngine, args.engine);
-    }
 
     // --upload: fail fast before launch if creds the inject DLL's post-run
-    // uploadLogs() will need aren't in the environment.
+    // uploadLogs() will need aren't in the environment. Each pass uploads its
+    // own session; the backend groups them by analysis_id.
     if (args.upload) {
         const char* api_key     = std::getenv("GPUFL_API_KEY");
         const char* backend_url = std::getenv("GPUFL_BACKEND_URL");
@@ -250,8 +282,19 @@ int runTrace(const TraceArgs& args) {
         setEnvOrDie(inject::kEnvUpload, "1");
     }
 
+    if (multipass) {
+        setEnvOrDie(inject::kEnvAnalysisId, analysis_id);
+        setEnvOrDie(inject::kEnvPassCount, std::to_string(plan.size()));
+    }
+
     if (!args.quiet) {
         std::fprintf(stderr, "[gpufl] capturing -> %s\n", output_dir.string().c_str());
+        if (multipass) {
+            std::fprintf(stderr, "[gpufl] multi-pass analysis %s - %zu passes:",
+                         analysis_id.c_str(), plan.size());
+            for (const auto& e : plan) std::fprintf(stderr, " %s", e.c_str());
+            std::fputc('\n', stderr);
+        }
         if (args.verbose) {
             std::fprintf(stderr, "[gpufl] inject dll: %s\n", inject_lib.string().c_str());
             std::fprintf(stderr, "[gpufl] app_name: %s\n", app_name.c_str());
@@ -259,52 +302,93 @@ int runTrace(const TraceArgs& args) {
         }
     }
 
-    // CreateProcessW wants a mutable command-line buffer. lpApplicationName
-    // = null so the program is resolved from the command line (incl. PATH),
-    // mirroring execvp's PATH search.
-    std::wstring cmdline = widen(buildCommandLine(args.command));
-    std::vector<wchar_t> cmdbuf(cmdline.begin(), cmdline.end());
-    cmdbuf.push_back(L'\0');
+    // ── Run the workload once per pass. A failing pass does NOT abort the
+    //    rest (a partial analysis still captures the passes that worked); the
+    //    first non-zero pass becomes the launcher's exit code. ──
+    int overall_rc = 0;
+    for (size_t i = 0; i < plan.size(); ++i) {
+        const std::string& engine = plan[i];
 
-    STARTUPINFOW si{};
-    si.cb = sizeof(si);
-    PROCESS_INFORMATION pi{};
+        // Per-pass engine. An empty engine (legacy single pass with no
+        // --engine) leaves GPUFL_PROFILING_ENGINE as the user/profile set it.
+        if (!engine.empty()) {
+            setEnvOrDie(inject::kEnvProfilingEngine, engine);
+        }
+        if (multipass) {
+            setEnvOrDie(inject::kEnvPassIndex, std::to_string(i));
+        }
 
-    const auto t_start = std::chrono::steady_clock::now();
+        const std::string what =
+            multipass ? ("pass " + std::to_string(i + 1) + "/" +
+                         std::to_string(plan.size()) + " (" + engine + ")")
+                      : std::string("target");
 
-    // The env we just set via SetEnvironmentVariable is inherited because
-    // lpEnvironment is null (child gets a copy of our environment block).
-    if (!CreateProcessW(/*lpApplicationName=*/nullptr,
-                        cmdbuf.data(),
-                        /*procAttrs=*/nullptr, /*threadAttrs=*/nullptr,
-                        /*inheritHandles=*/TRUE,
-                        /*creationFlags=*/0,
-                        /*lpEnvironment=*/nullptr,
-                        /*lpCurrentDirectory=*/nullptr,
-                        &si, &pi)) {
-        std::fprintf(stderr, "gpufl: cannot launch %s (CreateProcess err=%lu)\n",
-                     args.command.front().c_str(),
-                     static_cast<unsigned long>(GetLastError()));
-        return 2;
+        if (!args.quiet && multipass) {
+            std::fprintf(stderr, "\n[gpufl] -- %s --\n", what.c_str());
+            if (engine == "PcSampling") {
+                std::fprintf(stderr,
+                    "[gpufl] note: PcSampling needs admin / NVIDIA CP \"allow GPU "
+                    "performance counters to all users\"; this pass reports \"needs "
+                    "admin\" and yields no PC data if unprivileged.\n");
+            }
+        }
+
+        // CreateProcessW wants a mutable command-line buffer and may modify it,
+        // so rebuild it per pass. lpApplicationName = null so the program is
+        // resolved from the command line (incl. PATH), mirroring execvp.
+        std::wstring cmdline = widen(buildCommandLine(args.command));
+        std::vector<wchar_t> cmdbuf(cmdline.begin(), cmdline.end());
+        cmdbuf.push_back(L'\0');
+
+        STARTUPINFOW si{};
+        si.cb = sizeof(si);
+        PROCESS_INFORMATION pi{};
+
+        const auto t_start = std::chrono::steady_clock::now();
+
+        // The env we set via SetEnvironmentVariable is inherited because
+        // lpEnvironment is null (child gets a copy of our environment block).
+        if (!CreateProcessW(/*lpApplicationName=*/nullptr,
+                            cmdbuf.data(),
+                            /*procAttrs=*/nullptr, /*threadAttrs=*/nullptr,
+                            /*inheritHandles=*/TRUE,
+                            /*creationFlags=*/0,
+                            /*lpEnvironment=*/nullptr,
+                            /*lpCurrentDirectory=*/nullptr,
+                            &si, &pi)) {
+            std::fprintf(stderr, "gpufl: cannot launch %s (CreateProcess err=%lu)\n",
+                         args.command.front().c_str(),
+                         static_cast<unsigned long>(GetLastError()));
+            return 2;
+        }
+
+        WaitForSingleObject(pi.hProcess, INFINITE);
+
+        DWORD exit_code = 1;
+        GetExitCodeProcess(pi.hProcess, &exit_code);
+        CloseHandle(pi.hThread);
+        CloseHandle(pi.hProcess);
+
+        const auto t_elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+                             std::chrono::steady_clock::now() - t_start).count();
+
+        if (!args.quiet) {
+            std::fprintf(stderr, "[gpufl] %s exited (rc=%lu) in %.2fs\n",
+                         what.c_str(), static_cast<unsigned long>(exit_code),
+                         t_elapsed / 1000.0);
+        }
+
+        // First failing pass sets the exit code; keep going so later passes
+        // still run and the analysis is as complete as possible.
+        if (exit_code != 0 && overall_rc == 0)
+            overall_rc = static_cast<int>(exit_code);
     }
 
-    WaitForSingleObject(pi.hProcess, INFINITE);
-
-    DWORD exit_code = 1;
-    GetExitCodeProcess(pi.hProcess, &exit_code);
-    CloseHandle(pi.hThread);
-    CloseHandle(pi.hProcess);
-
-    const auto t_elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
-                         std::chrono::steady_clock::now() - t_start).count();
-
     if (!args.quiet) {
-        std::fprintf(stderr, "[gpufl] target exited (rc=%lu) in %.2fs\n",
-                     static_cast<unsigned long>(exit_code), t_elapsed / 1000.0);
         std::fprintf(stderr, "[gpufl] inspect: %s\n", output_dir.string().c_str());
     }
 
-    return static_cast<int>(exit_code);
+    return overall_rc;
 }
 
 }  // namespace gpufl::launcher

--- a/daemon/launcher/trace_command_win.cpp
+++ b/daemon/launcher/trace_command_win.cpp
@@ -35,7 +35,7 @@
 #include <string>
 #include <vector>
 
-#include "gpufl/inject/inject_entry.hpp"
+#include "gpufl/core/env_vars.hpp"
 
 namespace fs = std::filesystem;
 
@@ -260,31 +260,31 @@ int runTrace(const TraceArgs& args) {
     // These (and the shared log dir) are set once and inherited by every
     // child; each pass's process writes under its OWN session-id subdir, so
     // the uploader discovers N sessions grouped by analysis_id.
-    setEnvOrDie("CUDA_INJECTION64_PATH", inject_lib.string());
-    setEnvOrDie("NVTX_INJECTION64_PATH", inject_lib.string());
-    setEnvOrDie(inject::kEnvSentinel, "1");
-    setEnvOrDie(inject::kEnvAppName, app_name);
-    setEnvOrDie(inject::kEnvLogDir, output_dir.string());
-    setEnvOrDie(inject::kEnvProfile, args.profile);
+    setEnvOrDie(gpufl::env::kCudaInjection64Path, inject_lib.string());
+    setEnvOrDie(gpufl::env::kNvtxInjection64Path, inject_lib.string());
+    setEnvOrDie(gpufl::env::kInject, "1");
+    setEnvOrDie(gpufl::env::kAppName, app_name);
+    setEnvOrDie(gpufl::env::kLogDir, output_dir.string());
+    setEnvOrDie(gpufl::env::kInjectProfile, args.profile);
 
     // --upload: fail fast before launch if creds the inject DLL's post-run
     // uploadLogs() will need aren't in the environment. Each pass uploads its
     // own session; the backend groups them by analysis_id.
     if (args.upload) {
-        const char* api_key     = std::getenv("GPUFL_API_KEY");
-        const char* backend_url = std::getenv("GPUFL_BACKEND_URL");
+        const char* api_key     = std::getenv(gpufl::env::kApiKey);
+        const char* backend_url = std::getenv(gpufl::env::kBackendUrl);
         if (!api_key || !*api_key || !backend_url || !*backend_url) {
             std::fprintf(stderr,
                 "gpufl trace --upload: GPUFL_API_KEY and GPUFL_BACKEND_URL "
                 "must both be set in the environment to upload.\n");
             return 2;
         }
-        setEnvOrDie(inject::kEnvUpload, "1");
+        setEnvOrDie(gpufl::env::kInjectUpload, "1");
     }
 
     if (multipass) {
-        setEnvOrDie(inject::kEnvAnalysisId, analysis_id);
-        setEnvOrDie(inject::kEnvPassCount, std::to_string(plan.size()));
+        setEnvOrDie(gpufl::env::kAnalysisId, analysis_id);
+        setEnvOrDie(gpufl::env::kPassCount, std::to_string(plan.size()));
     }
 
     if (!args.quiet) {
@@ -312,10 +312,10 @@ int runTrace(const TraceArgs& args) {
         // Per-pass engine. An empty engine (legacy single pass with no
         // --engine) leaves GPUFL_PROFILING_ENGINE as the user/profile set it.
         if (!engine.empty()) {
-            setEnvOrDie(inject::kEnvProfilingEngine, engine);
+            setEnvOrDie(gpufl::env::kProfilingEngine, engine);
         }
         if (multipass) {
-            setEnvOrDie(inject::kEnvPassIndex, std::to_string(i));
+            setEnvOrDie(gpufl::env::kPassIndex, std::to_string(i));
         }
 
         const std::string what =

--- a/daemon/launcher/upload_command.cpp
+++ b/daemon/launcher/upload_command.cpp
@@ -11,6 +11,8 @@
 
 #include "upload_command.hpp"
 
+#include "gpufl/core/env_vars.hpp"
+
 #include <cstdio>
 #include <cstdlib>
 #include <string>
@@ -31,8 +33,8 @@ std::string resolve(const std::string& flag, const char* env_name) {
 }  // namespace
 
 int runUpload(const UploadArgs& args) {
-    const std::string backend_url = resolve(args.backend_url, "GPUFL_BACKEND_URL");
-    const std::string api_key     = resolve(args.api_key,     "GPUFL_API_KEY");
+    const std::string backend_url = resolve(args.backend_url, gpufl::env::kBackendUrl);
+    const std::string api_key     = resolve(args.api_key,     gpufl::env::kApiKey);
 
     if (backend_url.empty()) {
         std::fprintf(stderr,
@@ -49,7 +51,7 @@ int runUpload(const UploadArgs& args) {
     opts.log_path          = args.log_path;
     opts.backend_url       = backend_url;
     opts.api_key           = api_key;
-    opts.api_path          = resolve(args.api_path, "GPUFL_API_PATH");
+    opts.api_path          = resolve(args.api_path, gpufl::env::kApiPath);
     opts.total_timeout_ms  = args.timeout_s * 1000;
     opts.max_retries       = args.retries;
     opts.report_progress   = !args.quiet;

--- a/daemon/monitor/main.cpp
+++ b/daemon/monitor/main.cpp
@@ -11,6 +11,7 @@
 #endif
 
 #include "gpufl/gpufl.hpp"
+#include "gpufl/core/env_vars.hpp"
 
 namespace {
 
@@ -72,11 +73,11 @@ int main() {
         return 1;
     }
 
-    const std::string appName = getenv_or("GPUFL_MONITOR_APP", "gpufl-monitor");
+    const std::string appName = getenv_or(gpufl::env::kMonitorApp, "gpufl-monitor");
     const std::string logPath =
-        getenv_or("GPUFL_MONITOR_LOG_DIR", "/var/gpufl/monitor/session");
+        getenv_or(gpufl::env::kMonitorLogDir, "/var/gpufl/monitor/session");
     const int intervalMs =
-        std::stoi(getenv_or("GPUFL_MONITOR_INTERVAL_MS", "5000"));
+        std::stoi(getenv_or(gpufl::env::kMonitorIntervalMs, "5000"));
 
     std::cout << "Starting GPUFL monitor with app name: " << appName
               << ", log path: " << logPath << ", interval: " << intervalMs

--- a/example/cuda/CMakeLists.txt
+++ b/example/cuda/CMakeLists.txt
@@ -40,6 +40,7 @@ add_executable(occupancy_demo occupancy_demo.cu)
 add_executable(sass_divergence_demo sass_divergence_demo.cu)
 add_executable(memory_coalescing_demo memory_coalescing_demo.cu)
 add_executable(deep_deadlock_repro deep_deadlock_repro.cu)
+add_executable(multi_engine_demo multi_engine_demo.cu)
 
 target_compile_options(gfl_block_example PRIVATE
         $<$<COMPILE_LANGUAGE:CUDA>:
@@ -58,6 +59,15 @@ target_compile_options(sass_divergence_demo PRIVATE
 # SASS needs the cubin embedded so the disassembly + patching path engages —
 # same -lineinfo + gencode treatment as the other SASS-exercising examples.
 target_compile_options(deep_deadlock_repro PRIVATE
+        $<$<COMPILE_LANGUAGE:CUDA>:
+        -lineinfo
+        -gencode=arch=compute_86,code=sm_86
+        -gencode=arch=compute_86,code=compute_86
+        >)
+
+# Multi-engine composite demo: PC / SASS want the cubin embedded (-lineinfo +
+# gencode) for source correlation. Adjust the arch to your GPU.
+target_compile_options(multi_engine_demo PRIVATE
         $<$<COMPILE_LANGUAGE:CUDA>:
         -lineinfo
         -gencode=arch=compute_86,code=sm_86
@@ -161,6 +171,12 @@ target_link_libraries(deep_deadlock_repro PRIVATE
         CUDA::cudart
 )
 
+target_link_libraries(multi_engine_demo PRIVATE
+        gpufl::gpufl
+        CUDA::cupti
+        CUDA::cudart
+)
+
 
 # Properties
 set_target_properties(gfl_block_example PROPERTIES
@@ -202,6 +218,9 @@ set_target_properties(memory_coalescing_demo PROPERTIES
         CUDA_SEPARABLE_COMPILATION ON
 )
 set_target_properties(deep_deadlock_repro PROPERTIES
+        CUDA_SEPARABLE_COMPILATION ON
+)
+set_target_properties(multi_engine_demo PROPERTIES
         CUDA_SEPARABLE_COMPILATION ON
 )
 
@@ -264,7 +283,7 @@ if (WIN32)
                 "${CUPTI_DLL_DIR}/nvperf_host*.dll"
                 "${CUPTI_DLL_DIR}/nvperf_target*.dll")
 
-        foreach (TARGET_NAME test_occupancy system_monitor gfl_block_example cupti_pc_sampling list_sass_metrics vector_add_benchmark manykernel_benchmark occupancy_demo sass_divergence_demo deep_deadlock_repro)
+        foreach (TARGET_NAME test_occupancy system_monitor gfl_block_example cupti_pc_sampling list_sass_metrics vector_add_benchmark manykernel_benchmark occupancy_demo sass_divergence_demo deep_deadlock_repro multi_engine_demo)
             add_custom_command(TARGET ${TARGET_NAME} POST_BUILD
                     COMMAND ${CMAKE_COMMAND} -E copy_if_different
                     "${CUPTI_DLL_TO_COPY}"

--- a/example/cuda/multi_engine_demo.cu
+++ b/example/cuda/multi_engine_demo.cu
@@ -1,0 +1,200 @@
+// multi_engine_demo.cu
+//
+// Runs MULTIPLE profiling engines in ONE process via the generalized
+// CompositeEngine — to measure the engine-compatibility matrix (which engines can
+// coexist) and to exercise the redefined Deep (= the maximal coexisting set).
+//
+// ── HOW TO SELECT ENGINES ────────────────────────────────────────────────────
+// Set GPUFL_ENGINE_COMBO (comma-separated canonical engine names) BEFORE running.
+// This is the cross-cutting knob: it works here AND for the `gpufl` launcher
+// injecting into PyTorch / any CUDA process (you cannot recompile a Python run,
+// so the env var is the real mechanism). When set, it overrides the single
+// `opts.profiling_engine` selection and builds a CompositeEngine.
+//
+//   PowerShell (this demo):
+//     $env:GPUFL_ENGINE_COMBO = "Trace,PcSampling"
+//     .\multi_engine_demo.exe
+//
+//   Launcher / PyTorch:
+//     $env:GPUFL_ENGINE_COMBO = "Trace,PcSampling,PmSampling,RangeProfiler"
+//     gpufl.exe trace --engine Trace -- python train.py
+//
+// Combos to try — Trace gives REAL kernel timings; the rest enrich the same run:
+//     Trace,PcSampling             PC stall-reason sampling + real kernels
+//     Trace,PmSampling             time-series SM / mem / tensor utilization
+//     Trace,RangeProfiler          HW throughput counters (collected per scope)
+//     Trace,PcSampling,PmSampling  a triple (if both pairs pass on your GPU)
+//   (Trace,SassMetrics DEADLOCKS — SASS + kernel activity is an NVIDIA driver bug.)
+//
+// ── RUN AS ADMINISTRATOR ─────────────────────────────────────────────────────
+// PerfWorks engines (PmSampling / RangeProfiler) call cuptiProfilerInitialize,
+// which returns CUPTI_ERROR_UNKNOWN (999) WITHOUT GPU performance-counter access.
+// Either run elevated, OR enable: NVIDIA Control Panel -> Developer -> "Manage GPU
+// Performance Counters" -> "Allow access to the GPU performance counters to all
+// users". (PcSampling + Trace do not need this.)
+//
+// ── WHY THE SCOPES MATTER ────────────────────────────────────────────────────
+// PC / PM / Range collect PER gpufl scope (GFL_SCOPE / GFL_BENCH). Without a scope
+// they arm but produce nothing — the final drain races CUDA context teardown.
+// Every measured region below is wrapped in a scope so the samplers collect while
+// the context is alive.
+//
+// ── READING THE RESULT ───────────────────────────────────────────────────────
+// With enable_debug_output the run prints, after shutdown:
+//     [Composite][matrix] PcSamplingEngine  armed=yes produced=yes
+//     [Composite][matrix] PmSamplingEngine  armed=yes produced=no
+//     ...
+// "armed" = the engine started; "produced" = it emitted >=1 sample/record. Plus
+// the uploaded session shows real kernels (Trace) alongside each engine's data.
+//
+// Build (example tree, BUILD_GPUFL_EXAMPLE=ON):
+//   cmake --build <build-dir> --config Release --target multi_engine_demo
+// NOTE: the gencode in CMakeLists.txt targets sm_86; adjust it to your GPU's
+// compute capability for matching cubin (PTX JIT still runs on other archs).
+
+#include <cuda_runtime.h>
+
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+
+#include "gpufl/core/common.hpp"
+#include "gpufl/core/monitor.hpp"
+#include "gpufl/gpufl.hpp"
+
+static bool CheckCuda(cudaError_t err, const char* call, const char* file,
+                      int line) {
+    if (err == cudaSuccess) return true;
+    std::cerr << "[CUDA ERROR] " << file << ":" << line << " " << call
+              << " failed: " << cudaGetErrorString(err) << " ("
+              << static_cast<int>(err) << ")" << std::endl;
+    return false;
+}
+
+#define CHECK_CUDA(call)                                             \
+    do {                                                             \
+        if (!CheckCuda((call), #call, __FILE__, __LINE__)) return 2; \
+    } while (0)
+
+// Compute-bound: a long FMA chain. Keeps the SMs busy long enough for PC sampling
+// to land stall samples and for PM / Range to read steady-state counters.
+__global__ void computeHeavy(float* out, const float* in, int n, int iters) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx < n) {
+        float val = in[idx];
+        for (int i = 0; i < iters; ++i) {
+            val = val * 1.0009f + 0.0001f;
+            val = fmaf(val, 0.9991f, 0.0002f);
+        }
+        out[idx] = val;
+    }
+}
+
+// Memory-bound: strided gather/scatter. A different stall profile (memory
+// dependency / long-scoreboard) so PC sampling and the counters show contrast.
+__global__ void memoryStride(float* out, const float* in, int n, int stride) {
+    int idx = blockIdx.x * blockDim.x + threadIdx.x;
+    if (idx < n) {
+        float acc = 0.0f;
+        for (int k = 0; k < 32; ++k) {
+            int j = (idx * stride + k * 131) % n;
+            acc += in[j];
+        }
+        out[idx] = acc;
+    }
+}
+
+int main() {
+    gpufl::InitOptions opts;
+    opts.app_name = "multi_engine_demo";
+    opts.log_path = "multi_engine";
+    opts.system_sample_rate_ms = 10;
+    opts.continuous_system_sampling = true;
+    opts.enable_debug_output = true;  // shows the [Composite][matrix] lines
+    // Base engine when GPUFL_ENGINE_COMBO is NOT set: plain Trace (kernels only).
+    // When the combo env IS set it overrides this and builds the CompositeEngine.
+    opts.profiling_engine = gpufl::ProfilingEngine::Trace;
+
+    if (const char* combo = std::getenv("GPUFL_ENGINE_COMBO")) {
+        std::cout << "GPUFL_ENGINE_COMBO = " << combo << std::endl;
+    } else {
+        std::cout << "GPUFL_ENGINE_COMBO not set -> plain Trace. Set it to run a "
+                     "composite, e.g. Trace,PcSampling,PmSampling" << std::endl;
+    }
+
+    if (!gpufl::init(opts)) {
+        std::cerr << "Failed to initialize gpufl" << std::endl;
+        return 1;
+    }
+
+    std::cout << "=== Multi-engine composite demo ===" << std::endl;
+
+    const int n = 1 << 20;  // 1M elements
+    const size_t bytes = n * sizeof(float);
+
+    float* d_in = nullptr;
+    float* d_out = nullptr;
+    CHECK_CUDA(cudaMalloc(&d_in, bytes));
+    CHECK_CUDA(cudaMalloc(&d_out, bytes));
+
+    float* h_in = new float[n];
+    srand(7);
+    for (int i = 0; i < n; ++i) {
+        h_in[i] = static_cast<float>(rand()) / static_cast<float>(RAND_MAX);
+    }
+    CHECK_CUDA(cudaMemcpy(d_in, h_in, bytes, cudaMemcpyHostToDevice));
+
+    dim3 block(256);
+    dim3 grid((n + block.x - 1) / block.x);
+
+    // Warmup scope absorbs one-time cost (PTX->SASS JIT, cubin load, context
+    // init, PC/PM/Range first-time configuration) so the measured scopes reflect
+    // steady-state work.
+    std::cout << "  [warmup] priming context + JIT + sampler config..." << std::endl;
+    GFL_SCOPE("0_warmup") {
+        computeHeavy<<<grid, block>>>(d_out, d_in, n, 256);
+        memoryStride<<<grid, block>>>(d_out, d_in, n, 17);
+        CHECK_CUDA(cudaGetLastError());
+        CHECK_CUDA(cudaDeviceSynchronize());
+    }
+
+    // Measured region 1: compute-bound, repeated so the samplers accumulate.
+    std::cout << "  [1/3] compute_heavy — 3 warmup + 12 measured" << std::endl;
+    GFL_BENCH("1_compute_heavy",
+              gpufl::ScopeMeta{}.setRepeat(12).setWarmup(3)) {
+        computeHeavy<<<grid, block>>>(d_out, d_in, n, 2048);
+        cudaDeviceSynchronize();
+    };
+    CHECK_CUDA(cudaGetLastError());
+
+    // Measured region 2: memory-bound.
+    std::cout << "  [2/3] memory_stride — 3 warmup + 12 measured" << std::endl;
+    GFL_BENCH("2_memory_stride",
+              gpufl::ScopeMeta{}.setRepeat(12).setWarmup(3)) {
+        memoryStride<<<grid, block>>>(d_out, d_in, n, 97);
+        cudaDeviceSynchronize();
+    };
+    CHECK_CUDA(cudaGetLastError());
+
+    // Measured region 3: mixed — both kernels in one scope.
+    std::cout << "  [3/3] mixed — both kernels" << std::endl;
+    GFL_SCOPE("3_mixed") {
+        computeHeavy<<<grid, block>>>(d_out, d_in, n, 1024);
+        memoryStride<<<grid, block>>>(d_out, d_in, n, 53);
+        CHECK_CUDA(cudaGetLastError());
+        CHECK_CUDA(cudaDeviceSynchronize());
+    }
+
+    CHECK_CUDA(cudaFree(d_in));
+    CHECK_CUDA(cudaFree(d_out));
+    delete[] h_in;
+
+    gpufl::shutdown();
+    gpufl::generateReport();
+
+    std::cout << "\n=== Done ===" << std::endl;
+    std::cout << "Look for '[Composite][matrix] <engine> armed=.. produced=..' "
+                 "above, and check the uploaded session for kernels + each "
+                 "engine's data." << std::endl;
+    return 0;
+}

--- a/example/cuda/sass_divergence_demo.cu
+++ b/example/cuda/sass_divergence_demo.cu
@@ -150,7 +150,7 @@ int main() {
     opts.enable_debug_output = true;
     opts.continuous_system_sampling = true;
     opts.enable_stack_trace = true;
-    opts.profiling_engine = gpufl::ProfilingEngine::Deep;
+    opts.profiling_engine = gpufl::ProfilingEngine::RangeProfilerKernelReplay;
 
     if (!gpufl::init(opts)) {
         std::cerr << "Failed to initialize gpufl" << std::endl;

--- a/include/gpufl/backends/amd/rocprofiler_backend.cpp
+++ b/include/gpufl/backends/amd/rocprofiler_backend.cpp
@@ -277,6 +277,7 @@ int RocprofilerBackend::toolInitialize() {
             case ProfilingEngine::SassMetrics:
             case ProfilingEngine::Deep:
             case ProfilingEngine::RangeProfiler:
+            case ProfilingEngine::RangeProfilerKernelReplay:
                 engine_ = std::make_unique<DispatchCounterEngine>();
                 break;
             default:

--- a/include/gpufl/backends/nvidia/cupti_backend.cpp
+++ b/include/gpufl/backends/nvidia/cupti_backend.cpp
@@ -289,11 +289,13 @@ inline void PreloadMatchingPerfWorks() {}
 }  // namespace
 
 bool CuptiBackend::ShouldEnableNvtxMarkerActivityBeforeEngine_() const {
+    if (!collectsKernelEvents()) return false;
     if (!IsSassProfilerMode()) return true;
     return AllowSassMarkerActivity();
 }
 
 bool CuptiBackend::ShouldEnableNvtxMarkerActivityForSelectedEngine_() const {
+    if (!collectsKernelEvents()) return false;
     if (!IsSassProfilerMode()) return true;
     if (AllowSassMarkerActivity()) return true;
 
@@ -357,6 +359,37 @@ std::vector<ProfilingEngine> ParseEngineComboEnv() {
     }
     return out;
 }
+
+bool EngineListContains(const std::vector<ProfilingEngine>& engines,
+                        ProfilingEngine engine) {
+    return std::find(engines.begin(), engines.end(), engine) != engines.end();
+}
+
+void ApplyComboPlanOverrides(ResolvedProfilingPlan& plan,
+                             const std::vector<ProfilingEngine>& combo) {
+    if (combo.empty()) return;
+
+    // PC / SASS read cubin binaries for source correlation and disassembly.
+    // The policy resolver sees only the base single engine, so re-apply this
+    // after every resolve while a combo is active.
+    if (EngineListContains(combo, ProfilingEngine::PcSampling) ||
+        EngineListContains(combo, ProfilingEngine::SassMetrics)) {
+        plan.needs_cubin_capture = true;
+    }
+
+    // A combo dictates its own activity set. Single-engine SASS safe-mode
+    // gating would otherwise suppress Trace's timeline activity when the base
+    // engine happens to be SASS/Deep.
+    plan.sass_metrics_only = false;
+    plan.safe_sass_activity_defaults = false;
+    plan.allow_sass_kernel_activity = true;
+    plan.allow_sass_marker_activity = true;
+    plan.allow_sass_mem_transfer_activity = true;
+    plan.allow_sass_memory2_activity = true;
+    plan.allow_sass_sync_activity = true;
+    plan.allow_sass_graph_activity = true;
+    plan.allow_sass_external_correlation = true;
+}
 }  // namespace
 
 void CuptiBackend::initialize(const MonitorOptions& opts) {
@@ -376,30 +409,9 @@ void CuptiBackend::initialize(const MonitorOptions& opts) {
     combo_ = ParseEngineComboEnv();
     if (!combo_.empty()) {
         const auto has = [&](ProfilingEngine e) {
-            return std::find(combo_.begin(), combo_.end(), e) != combo_.end();
+            return EngineListContains(combo_, e);
         };
-        // PC / SASS read cubin binaries for source correlation; the single-engine
-        // plan only sets needs_cubin_capture for those engines, so force it on
-        // when the combo includes one (the plan was resolved from a single engine).
-        if (has(ProfilingEngine::PcSampling) || has(ProfilingEngine::SassMetrics)) {
-            resolved_plan_.needs_cubin_capture = true;
-        }
-        // A combo dictates its OWN activity set (collectsKernelEvents() + full
-        // trace activity). The single-engine SASS safe-mode gating
-        // (safe_sass_activity_defaults / sass_metrics_only) only makes sense for
-        // a lone SASS/Deep run; if the base engine happened to be SASS/Deep it
-        // would otherwise suppress Trace's mem/sync/marker/external activity in
-        // the combo. Clear it so a combo's activity is predictable regardless of
-        // the base engine.
-        resolved_plan_.sass_metrics_only = false;
-        resolved_plan_.safe_sass_activity_defaults = false;
-        resolved_plan_.allow_sass_kernel_activity = true;
-        resolved_plan_.allow_sass_marker_activity = true;
-        resolved_plan_.allow_sass_mem_transfer_activity = true;
-        resolved_plan_.allow_sass_memory2_activity = true;
-        resolved_plan_.allow_sass_sync_activity = true;
-        resolved_plan_.allow_sass_graph_activity = true;
-        resolved_plan_.allow_sass_external_correlation = true;
+        ApplyComboPlanOverrides(resolved_plan_, combo_);
         std::vector<std::unique_ptr<IProfilingEngine>> subs;
 #if GPUFL_HAS_PERFWORKS
         if (has(ProfilingEngine::PmSampling))
@@ -592,6 +604,10 @@ void CuptiBackend::start() {
     kernel_activity_emitted_.store(0, std::memory_order_relaxed);
     kernel_activity_throttled_.store(0, std::memory_order_relaxed);
     memory_activity_emitted_.store(0, std::memory_order_relaxed);
+    mem_transfer_activity_emitted_.store(0, std::memory_order_relaxed);
+    sync_activity_emitted_.store(0, std::memory_order_relaxed);
+    nvtx_marker_emitted_.store(0, std::memory_order_relaxed);
+    graph_activity_emitted_.store(0, std::memory_order_relaxed);
     external_correlation_seen_.store(0, std::memory_order_relaxed);
     source_locator_seen_.store(0, std::memory_order_relaxed);
     function_record_seen_.store(0, std::memory_order_relaxed);
@@ -645,6 +661,7 @@ void CuptiBackend::start() {
         device_facts_.cupti_version = GetCuptiVersion();
         resolved_plan_ = NvidiaProfilingPolicy::Resolve(
             profiling_request_, device_facts_, EnvOverrides::FromProcess());
+        ApplyComboPlanOverrides(resolved_plan_, combo_);
     } else if (engine_) {
         GFL_LOG_ERROR(
             "[CuptiBackend] Failed to get CUDA context; "
@@ -687,7 +704,8 @@ void CuptiBackend::start() {
     // activity kind required (CUPTI emits these regardless of which
     // API kinds are enabled). Soft-fail on enable so a CUPTI build that
     // doesn't support the kind still lets the rest of collection work.
-    if (opts_.enable_synchronization && AllowSassSyncActivity()) {
+    const bool timelineActivity = collectsKernelEvents();
+    if (timelineActivity && opts_.enable_synchronization && AllowSassSyncActivity()) {
         const CUptiResult res_sync =
             cuptiActivityEnable(CUPTI_ACTIVITY_KIND_SYNCHRONIZATION);
         if (res_sync != CUPTI_SUCCESS) {
@@ -708,7 +726,7 @@ void CuptiBackend::start() {
     // without MEMORY2 — they had MEMORY (deprecated) which has a
     // different record shape. We don't try to fall back; if MEMORY2
     // isn't available we log and continue without F3 attribution.
-    if (opts_.enable_memory_tracking && AllowSassMemory2Activity()) {
+    if (timelineActivity && opts_.enable_memory_tracking && AllowSassMemory2Activity()) {
         const CUptiResult res_mem =
             cuptiActivityEnable(CUPTI_ACTIVITY_KIND_MEMORY2);
         if (res_mem != CUPTI_SUCCESS) {
@@ -723,7 +741,7 @@ void CuptiBackend::start() {
     // because some Blackwell driver builds reset PC sampling on first
     // graph launch — the planning doc has the full risk note. Soft-
     // fail on enable so older CUPTI without the kind keeps working.
-    if (opts_.enable_cuda_graphs_tracking && AllowSassGraphActivity()) {
+    if (timelineActivity && opts_.enable_cuda_graphs_tracking && AllowSassGraphActivity()) {
         const CUptiResult res_g =
             cuptiActivityEnable(CUPTI_ACTIVITY_KIND_GRAPH_TRACE);
         if (res_g != CUPTI_SUCCESS) {
@@ -756,7 +774,8 @@ void CuptiBackend::start() {
     // we may need DRIVER too — defer until we see a session that needs
     // it.)
     const bool enableExternalCorrelation =
-        opts_.enable_external_correlation && AllowSassExternalCorrelation();
+        timelineActivity && opts_.enable_external_correlation &&
+        AllowSassExternalCorrelation();
     if (opts_.enable_external_correlation && IsSassProfilerMode() &&
         !AllowSassExternalCorrelation()) {
         GFL_LOG_DEBUG(
@@ -885,7 +904,7 @@ void CuptiBackend::start() {
     // initialize() phase. Idempotent; CUPTI ignores the second enable
     // when the kind is already on. SYNCHRONIZATION isn't tied to any
     // handler so it would otherwise be silently dropped.
-    if (opts_.enable_synchronization && AllowSassSyncActivity()) {
+    if (timelineActivity && opts_.enable_synchronization && AllowSassSyncActivity()) {
         const CUptiResult sync_res =
             cuptiActivityEnable(CUPTI_ACTIVITY_KIND_SYNCHRONIZATION);
         GFL_LOG_DEBUG(
@@ -895,7 +914,7 @@ void CuptiBackend::start() {
     }
 
     // F3: matching post-engine re-enable for MEMORY2.
-    if (opts_.enable_memory_tracking && AllowSassMemory2Activity()) {
+    if (timelineActivity && opts_.enable_memory_tracking && AllowSassMemory2Activity()) {
         const CUptiResult mem_res =
             cuptiActivityEnable(CUPTI_ACTIVITY_KIND_MEMORY2);
         GFL_LOG_DEBUG(
@@ -905,7 +924,7 @@ void CuptiBackend::start() {
     }
 
     // F4: matching post-engine re-enable for GRAPH_TRACE.
-    if (opts_.enable_cuda_graphs_tracking && AllowSassGraphActivity()) {
+    if (timelineActivity && opts_.enable_cuda_graphs_tracking && AllowSassGraphActivity()) {
         const CUptiResult g_res =
             cuptiActivityEnable(CUPTI_ACTIVITY_KIND_GRAPH_TRACE);
         GFL_LOG_DEBUG(
@@ -948,16 +967,35 @@ void CuptiBackend::EmitCaptureCapabilities_() const {
         return;
     }
 
-    const bool sassMode = IsSassProfilerMode();
-    const bool pcSamplingMode =
-        opts_.profiling_engine == ProfilingEngine::PcSampling;
+    const auto comboHas = [&](ProfilingEngine e) {
+        return std::find(combo_.begin(), combo_.end(), e) != combo_.end();
+    };
+    const bool requestedSass =
+        comboActive() ? comboHas(ProfilingEngine::SassMetrics)
+                      : (opts_.profiling_engine == ProfilingEngine::SassMetrics ||
+                         opts_.profiling_engine == ProfilingEngine::Deep);
+    const bool requestedPc =
+        comboActive() ? comboHas(ProfilingEngine::PcSampling)
+                      : (opts_.profiling_engine == ProfilingEngine::PcSampling ||
+                         opts_.profiling_engine == ProfilingEngine::Deep);
+    const bool requestedPm =
+        comboActive() ? comboHas(ProfilingEngine::PmSampling)
+                      : (opts_.profiling_engine == ProfilingEngine::PmSampling ||
+                         opts_.profiling_engine == ProfilingEngine::Deep);
+    const bool requestedRange =
+        comboActive() ? comboHas(ProfilingEngine::RangeProfiler)
+                      : opts_.profiling_engine == ProfilingEngine::RangeProfiler;
+    const bool sassMode = requestedSass;
+    const bool pcSamplingMode = requestedPc;
     const bool kernelActivity = collectsKernelEvents();
     const bool syntheticKernels = !kernelActivity && (sassMode || pcSamplingMode);
+    const bool cubinRequested = requestedPc || requestedSass;
     const bool cubinCapture = NeedsCubinCapture();
 
     bool sassActive = false;
     bool pcActive = false;
     bool pmActive = false;
+    bool rangeActive = false;
 
     // Capability emission happens after final engine shutdown so the report can
     // see late-flushed samples. Some engines drop their operational flag during
@@ -980,6 +1018,8 @@ void CuptiBackend::EmitCaptureCapabilities_() const {
                     pcActive = armed || produced;
                 else if (dynamic_cast<const PmSamplingEngine*>(sub.get()))
                     pmActive = armed || produced;
+                else if (dynamic_cast<const RangeProfilerEngine*>(sub.get()))
+                    rangeActive = armed || produced;
             }
         }
     } else if (opts_.profiling_engine == ProfilingEngine::SassMetrics && engine_) {
@@ -988,6 +1028,8 @@ void CuptiBackend::EmitCaptureCapabilities_() const {
         pcActive = engine_->isOperational() || engine_->producedData();
     } else if (opts_.profiling_engine == ProfilingEngine::PmSampling && engine_) {
         pmActive = engine_->isOperational() || engine_->producedData();
+    } else if (opts_.profiling_engine == ProfilingEngine::RangeProfiler && engine_) {
+        rangeActive = engine_->isOperational() || engine_->producedData();
     } else if (opts_.profiling_engine == ProfilingEngine::Deep) {
         if (const auto* deep =
                 dynamic_cast<const PcSamplingWithSassEngine*>(engine_.get())) {
@@ -1004,6 +1046,14 @@ void CuptiBackend::EmitCaptureCapabilities_() const {
         kernel_activity_emitted_.load(std::memory_order_relaxed);
     const uint64_t memoryRows =
         memory_activity_emitted_.load(std::memory_order_relaxed);
+    const uint64_t memTransferRows =
+        mem_transfer_activity_emitted_.load(std::memory_order_relaxed);
+    const uint64_t syncRows =
+        sync_activity_emitted_.load(std::memory_order_relaxed);
+    const uint64_t nvtxRows =
+        nvtx_marker_emitted_.load(std::memory_order_relaxed);
+    const uint64_t graphRows =
+        graph_activity_emitted_.load(std::memory_order_relaxed);
     const uint64_t externalRows =
         external_correlation_seen_.load(std::memory_order_relaxed);
     const uint64_t sourceRows =
@@ -1012,12 +1062,17 @@ void CuptiBackend::EmitCaptureCapabilities_() const {
         function_record_seen_.load(std::memory_order_relaxed);
     const bool kernelHasData = kernelRows > 0;
     const bool memoryHasData = memoryRows > 0;
+    const bool memTransferHasData = memTransferRows > 0;
+    const bool syncHasData = syncRows > 0;
+    const bool nvtxHasData = nvtxRows > 0;
+    const bool graphHasData = graphRows > 0;
     const bool externalHasData = externalRows > 0;
     const bool sourceHasData = sourceRows > 0 || functionRows > 0;
 
     bool sassHasData = false;
     bool pcHasData = false;
     bool pmHasData = false;
+    bool rangeHasData = false;
     if (comboActive()) {
         if (const auto* comp =
                 dynamic_cast<const CompositeEngine*>(engine_.get())) {
@@ -1029,6 +1084,8 @@ void CuptiBackend::EmitCaptureCapabilities_() const {
                     pcHasData = sub->producedData();
                 else if (dynamic_cast<const PmSamplingEngine*>(sub.get()))
                     pmHasData = sub->producedData();
+                else if (dynamic_cast<const RangeProfilerEngine*>(sub.get()))
+                    rangeHasData = sub->producedData();
             }
         }
     } else if (engine_) {
@@ -1043,6 +1100,8 @@ void CuptiBackend::EmitCaptureCapabilities_() const {
             pcHasData = engine_->producedData();
         } else if (opts_.profiling_engine == ProfilingEngine::PmSampling) {
             pmHasData = engine_->producedData();
+        } else if (opts_.profiling_engine == ProfilingEngine::RangeProfiler) {
+            rangeHasData = engine_->producedData();
         }
     }
 
@@ -1062,78 +1121,162 @@ void CuptiBackend::EmitCaptureCapabilities_() const {
     evt.selected_engine = selected;
 
     const bool metricsOnly = SassMetricsOnlyMode();
-    AddCapability(evt, "kernel_events", true,
+    AddCapability(evt, "kernel_events", kernelActivity,
                   kernelHasData
                       ? (syntheticKernels ? "fallback" : "collected")
-                      : (metricsOnly ? "skipped" : "enabled_no_data"),
+                      : (kernelActivity
+                            ? (metricsOnly ? "skipped" : "enabled_no_data")
+                            : "not_requested"),
                   metricsOnly
                       ? "sass_metrics_only"
-                      : (syntheticKernels ? "launch_callbacks_synthetic" : "cupti_activity"),
+                      : (kernelActivity
+                            ? (syntheticKernels ? "launch_callbacks_synthetic"
+                                                : "cupti_activity")
+                            : "disabled"),
                   kernelHasData
                       ? (syntheticKernels
                             ? (pcSamplingMode ? "cupti_kernel_activity_conflicts_with_pc_sampling"
                                               : "cupti_kernel_activity_deadlock_risk")
                             : "")
-                      : (metricsOnly ? "disabled_to_preserve_sass_counters"
-                                     : "enabled_but_no_records"),
+                      : (kernelActivity
+                            ? (metricsOnly ? "disabled_to_preserve_sass_counters"
+                                           : "enabled_but_no_records")
+                            : "not_selected"),
                   kernelHasData
                       ? (syntheticKernels
                             ? (pcSamplingMode
                                   ? "Kernel rows were collected from launch callbacks; durations are estimated because CUPTI kernel activity is disabled while PC Sampling API is active."
                                   : "Kernel rows were collected from launch callbacks; durations are estimated because CUPTI kernel activity is disabled in SASS safe mode.")
                             : "Kernel rows were collected from CUPTI kernel activity records.")
-                      : (metricsOnly
+                      : (!kernelActivity
+                            ? "Kernel timeline activity was not requested by the selected engine domains."
+                            : metricsOnly
                             ? "Kernel activity was intentionally disabled because CUPTI SASS Metrics requires metrics-only mode on this GPU/driver to produce non-zero counters."
                             : "Kernel tracing was enabled but emitted no kernel rows this session."));
-    AddCapability(evt, "kernel_names", true,
+    AddCapability(evt, "kernel_names", kernelActivity,
                   kernelHasData
                       ? (syntheticKernels ? "partial" : "collected")
-                      : (metricsOnly ? "skipped" : "enabled_no_data"),
+                      : (kernelActivity
+                            ? (metricsOnly ? "skipped" : "enabled_no_data")
+                            : "not_requested"),
                   metricsOnly
                       ? "sass_metrics_only"
-                      : (syntheticKernels ? "callback_symbol_probe" : "cupti_activity_name"),
+                      : (kernelActivity
+                            ? (syntheticKernels ? "callback_symbol_probe"
+                                                : "cupti_activity_name")
+                            : "disabled"),
                   kernelHasData
                       ? (syntheticKernels ? "symbol_name_may_be_unavailable" : "")
-                      : (metricsOnly ? "disabled_to_preserve_sass_counters"
-                                     : "enabled_but_no_records"),
+                      : (kernelActivity
+                            ? (metricsOnly ? "disabled_to_preserve_sass_counters"
+                                           : "enabled_but_no_records")
+                            : "not_selected"),
                   kernelHasData
                       ? (syntheticKernels
                             ? "Kernel names use CUPTI callback symbolName when safely readable, otherwise the CUDA launch API name."
                             : "Kernel names came from CUPTI activity records.")
-                      : (metricsOnly
+                      : (!kernelActivity
+                            ? "Kernel name tracing was not requested by the selected engine domains."
+                            : metricsOnly
                             ? "Kernel name tracing was intentionally disabled to keep SASS metric counters valid."
                             : "Kernel name capture was enabled but no kernel rows were emitted."));
-    AddCapability(evt, "kernel_details", true,
+    AddCapability(evt, "kernel_details", kernelActivity,
                   kernelHasData
                       ? (syntheticKernels ? "partial" : "collected")
-                      : (metricsOnly ? "skipped" : "enabled_no_data"),
+                      : (kernelActivity
+                            ? (metricsOnly ? "skipped" : "enabled_no_data")
+                            : "not_requested"),
                   metricsOnly
                       ? "sass_metrics_only"
-                      : (syntheticKernels ? "launch_callback_params" : "cupti_activity_details"),
+                      : (kernelActivity
+                            ? (syntheticKernels ? "launch_callback_params"
+                                                : "cupti_activity_details")
+                            : "disabled"),
                   kernelHasData
                       ? (syntheticKernels ? "activity_details_unavailable" : "")
-                      : (metricsOnly ? "disabled_to_preserve_sass_counters"
-                                     : "enabled_but_no_records"),
+                      : (kernelActivity
+                            ? (metricsOnly ? "disabled_to_preserve_sass_counters"
+                                           : "enabled_but_no_records")
+                            : "not_selected"),
                   kernelHasData
                       ? (syntheticKernels
                             ? "Grid/block parameters are captured from launch callbacks; register and occupancy details may be unavailable."
                             : "Kernel details came from CUPTI activity records and launch metadata.")
-                      : (metricsOnly
+                      : (!kernelActivity
+                            ? "Kernel detail tracing was not requested by the selected engine domains."
+                            : metricsOnly
                             ? "Kernel detail tracing was intentionally disabled to keep SASS metric counters valid."
                             : "Kernel detail capture was enabled but no kernel rows were emitted."));
-    AddCapability(evt, "cubin_disassembly", cubinCapture,
-                  cubinCapture ? "collected" : "not_requested",
+    AddCapability(evt, "memcpy_activity", kernelActivity,
+                  kernelActivity
+                      ? (memTransferHasData ? "collected" : "enabled_no_data")
+                      : "not_requested",
+                  kernelActivity ? "cupti_memcpy_activity" : "disabled",
+                  kernelActivity
+                      ? (memTransferHasData ? "" : "enabled_but_no_records")
+                      : "not_selected",
+                  kernelActivity
+                      ? (memTransferHasData
+                            ? "Memcpy/memset activity records were collected."
+                            : "Memcpy/memset activity was enabled but emitted no rows this session.")
+                      : "Memcpy/memset timeline activity was not requested by the selected engine domains.");
+    const bool syncRequested =
+        kernelActivity && opts_.enable_synchronization && AllowSassSyncActivity();
+    AddCapability(evt, "sync_activity", syncRequested,
+                  syncRequested
+                      ? (syncHasData ? "collected" : "enabled_no_data")
+                      : (opts_.enable_synchronization ? "skipped" : "not_requested"),
+                  syncRequested ? "cupti_synchronization" : "disabled",
+                  syncRequested
+                      ? (syncHasData ? "" : "enabled_but_no_records")
+                      : (kernelActivity ? "disabled_by_policy" : "not_selected"),
+                  syncRequested
+                      ? (syncHasData
+                            ? "CUDA synchronization activity records were collected."
+                            : "CUDA synchronization activity was enabled but emitted no rows this session.")
+                      : "CUDA synchronization timeline activity was not collected.");
+    AddCapability(evt, "nvtx_markers", kernelActivity,
+                  kernelActivity
+                      ? (nvtxHasData ? "collected" : "enabled_no_data")
+                      : "not_requested",
+                  kernelActivity ? "cupti_marker_activity" : "disabled",
+                  kernelActivity
+                      ? (nvtxHasData ? "" : "enabled_but_no_records")
+                      : "not_selected",
+                  kernelActivity
+                      ? (nvtxHasData
+                            ? "NVTX marker activity records were collected."
+                            : "NVTX marker activity was enabled but emitted no completed ranges this session.")
+                      : "NVTX timeline activity was not requested by the selected engine domains.");
+    const bool graphRequested =
+        kernelActivity && opts_.enable_cuda_graphs_tracking && AllowSassGraphActivity();
+    AddCapability(evt, "graph_activity", graphRequested,
+                  graphRequested
+                      ? (graphHasData ? "collected" : "enabled_no_data")
+                      : (opts_.enable_cuda_graphs_tracking ? "skipped" : "not_requested"),
+                  graphRequested ? "cupti_graph_trace" : "disabled",
+                  graphRequested
+                      ? (graphHasData ? "" : "enabled_but_no_records")
+                      : (kernelActivity ? "disabled_by_option" : "not_selected"),
+                  graphRequested
+                      ? (graphHasData
+                            ? "CUDA graph launch activity records were collected."
+                            : "CUDA graph launch activity was enabled but emitted no rows this session.")
+                      : "CUDA graph launch timeline activity was not collected.");
+    AddCapability(evt, "cubin_disassembly", cubinRequested,
+                  cubinCapture ? "collected" :
+                      (cubinRequested ? "skipped" : "not_requested"),
                   cubinCapture ? "module_resource_callbacks" : "disabled",
-                  "",
+                  cubinRequested && !cubinCapture ? "cubin_capture_disabled" : "",
                   cubinCapture
                       ? "CUBINs were captured for offline SASS disassembly."
-                      : "This profiling engine does not request CUBIN capture.");
+                      : (cubinRequested
+                            ? "This profiling path requested CUBIN capture, but it was disabled by policy or environment."
+                            : "This profiling engine does not request CUBIN capture."));
     AddCapability(evt, "sass_metrics",
-                  opts_.profiling_engine == ProfilingEngine::SassMetrics ||
-                      opts_.profiling_engine == ProfilingEngine::Deep,
+                  requestedSass,
                   sassActive ? (sassHasData ? "collected" : "enabled_no_data") :
-                      ((opts_.profiling_engine == ProfilingEngine::SassMetrics ||
-                        opts_.profiling_engine == ProfilingEngine::Deep) ? "skipped" : "not_requested"),
+                      (requestedSass ? "skipped" : "not_requested"),
                   sassActive ? "cupti_sass_metrics" : "disabled",
                   sassActive ? (sassHasData ? "" : "enabled_but_no_samples")
                              : "not_selected_or_not_operational",
@@ -1143,11 +1286,10 @@ void CuptiBackend::EmitCaptureCapabilities_() const {
                             : "SASS metrics were enabled but produced no instruction-level samples this session (e.g. kernels too short, or CUPTI replay returned no data).")
                       : "SASS metrics were not collected for this session.");
     AddCapability(evt, "pc_sampling",
-                  opts_.profiling_engine == ProfilingEngine::PcSampling ||
-                      opts_.profiling_engine == ProfilingEngine::Deep,
+                  requestedPc,
                   pcActive ? (pcHasData ? "collected" : "enabled_no_data") :
                       (opts_.profiling_engine == ProfilingEngine::Deep && sassActive ? "skipped" :
-                       (opts_.profiling_engine == ProfilingEngine::PcSampling ? "skipped" : "not_requested")),
+                       (requestedPc ? "skipped" : "not_requested")),
                   pcActive ? "cupti_pc_sampling" : "disabled",
                   opts_.profiling_engine == ProfilingEngine::Deep && sassActive
                       ? "mutually_exclusive_with_sass_metrics" :
@@ -1160,11 +1302,9 @@ void CuptiBackend::EmitCaptureCapabilities_() const {
                             : "PC sampling was enabled but produced no stall samples this session (e.g. kernels too short for the sampling period).")
                                   : "PC sampling was not collected for this session."));
     AddCapability(evt, "pm_sampling",
-                  opts_.profiling_engine == ProfilingEngine::PmSampling ||
-                      opts_.profiling_engine == ProfilingEngine::Deep,
+                  requestedPm,
                   pmActive ? (pmHasData ? "collected" : "enabled_no_data")
-                           : ((opts_.profiling_engine == ProfilingEngine::PmSampling ||
-                               opts_.profiling_engine == ProfilingEngine::Deep) ? "skipped" : "not_requested"),
+                           : (requestedPm ? "skipped" : "not_requested"),
                   pmActive ? "cupti_pm_sampling" : "disabled",
                   pmActive ? (pmHasData ? "" : "enabled_but_no_samples")
                            : "not_selected_or_not_operational",
@@ -1173,6 +1313,18 @@ void CuptiBackend::EmitCaptureCapabilities_() const {
                             ? "PM sampling hardware metric samples were collected for this session."
                             : "PM sampling was enabled but produced no hardware samples this session.")
                       : "PM sampling was not collected for this session.");
+    AddCapability(evt, "range_counters",
+                  requestedRange,
+                  rangeActive ? (rangeHasData ? "collected" : "enabled_no_data")
+                              : (requestedRange ? "skipped" : "not_requested"),
+                  rangeActive ? "cupti_range_profiler" : "disabled",
+                  rangeActive ? (rangeHasData ? "" : "enabled_but_no_ranges")
+                              : "not_selected_or_not_operational",
+                  rangeActive
+                      ? (rangeHasData
+                            ? "Range Profiler scope-level hardware counters were collected for this session."
+                            : "Range Profiler was enabled but produced no decoded range counters this session.")
+                      : "Range Profiler counters were not collected for this session.");
     AddCapability(evt, "source_correlation", pcActive,
                   pcActive ? (sourceHasData ? "collected" : "enabled_no_data")
                            : (sassActive ? "skipped" : "not_requested"),
@@ -1185,15 +1337,18 @@ void CuptiBackend::EmitCaptureCapabilities_() const {
                             : "PC sampling source correlation was enabled but emitted no source locator/function records.")
                       : "CUDA source-line correlation was not collected in this session.");
     const bool memoryRequestedAndAllowed =
-        opts_.enable_memory_tracking && AllowSassMemory2Activity();
-    AddCapability(evt, "memory_activity", opts_.enable_memory_tracking,
+        kernelActivity && opts_.enable_memory_tracking && AllowSassMemory2Activity();
+    AddCapability(evt, "memory_activity",
+                  kernelActivity && opts_.enable_memory_tracking,
                   memoryRequestedAndAllowed
                       ? (memoryHasData ? "collected" : "enabled_no_data")
-                      : (opts_.enable_memory_tracking ? "skipped" : "not_requested"),
+                      : (opts_.enable_memory_tracking
+                            ? (kernelActivity ? "skipped" : "not_requested")
+                            : "not_requested"),
                   memoryRequestedAndAllowed ? "cupti_memory" : "disabled",
                   memoryRequestedAndAllowed
                       ? (memoryHasData ? "" : "enabled_but_no_records")
-                      : (opts_.enable_memory_tracking && !AllowSassMemory2Activity()
+                      : (kernelActivity && opts_.enable_memory_tracking && !AllowSassMemory2Activity()
                             ? "sass_safe_mode_memory_activity_disabled" : ""),
                   memoryRequestedAndAllowed
                       ? (memoryHasData
@@ -1201,15 +1356,19 @@ void CuptiBackend::EmitCaptureCapabilities_() const {
                             : "CUPTI memory activity was enabled but emitted no memory rows this session.")
                       : "CUPTI memory activity was not collected.");
     const bool externalRequestedAndAllowed =
-        opts_.enable_external_correlation && AllowSassExternalCorrelation();
-    AddCapability(evt, "external_correlation", opts_.enable_external_correlation,
+        kernelActivity && opts_.enable_external_correlation &&
+        AllowSassExternalCorrelation();
+    AddCapability(evt, "external_correlation",
+                  kernelActivity && opts_.enable_external_correlation,
                   externalRequestedAndAllowed
                       ? (externalHasData ? "collected" : "enabled_no_data")
-                      : (opts_.enable_external_correlation ? "skipped" : "not_requested"),
+                      : (opts_.enable_external_correlation
+                            ? (kernelActivity ? "skipped" : "not_requested")
+                            : "not_requested"),
                   externalRequestedAndAllowed ? "cupti_external_correlation" : "disabled",
                   externalRequestedAndAllowed
                       ? (externalHasData ? "" : "enabled_but_no_records")
-                      : (opts_.enable_external_correlation && !AllowSassExternalCorrelation()
+                      : (kernelActivity && opts_.enable_external_correlation && !AllowSassExternalCorrelation()
                             ? "sass_safe_mode_external_correlation_disabled" : ""),
                   externalRequestedAndAllowed
                       ? (externalHasData
@@ -1606,6 +1765,8 @@ void CUPTIAPI CuptiBackend::BufferCompleted(CUcontext context,
                                               sizeof(out.user_scope), "%s",
                                               entry.domain.c_str());
                                 g_monitorBuffer.Push(out);
+                                backend->nvtx_marker_emitted_.fetch_add(
+                                    1, std::memory_order_relaxed);
                             }
                         }
                         // Other flag values (e.g. SYNC-only points) are
@@ -1647,6 +1808,8 @@ void CUPTIAPI CuptiBackend::BufferCompleted(CUcontext context,
                         out.corr_id      = g->correlationId;
                         out.graph_id     = g->graphId;
                         g_monitorBuffer.Push(out);
+                        backend->graph_activity_emitted_.fetch_add(
+                            1, std::memory_order_relaxed);
                     } else if (record->kind ==
                                CUPTI_ACTIVITY_KIND_MEMORY2) {
                         // F3: cudaMalloc / cudaFree / cudaMallocAsync /
@@ -1721,6 +1884,8 @@ void CUPTIAPI CuptiBackend::BufferCompleted(CUcontext context,
                         // no sync_meta_mu_ here. out.stack_id stays 0; the
                         // collector fills it. (Step 4c.)
                         g_monitorBuffer.Push(out);
+                        backend->sync_activity_emitted_.fetch_add(
+                            1, std::memory_order_relaxed);
                     }
                     // (EXTERNAL_CORRELATION handled in pass 1 above —
                     //  the early `continue` at the top of this loop

--- a/include/gpufl/backends/nvidia/cupti_backend.cpp
+++ b/include/gpufl/backends/nvidia/cupti_backend.cpp
@@ -360,20 +360,160 @@ std::vector<ProfilingEngine> ParseEngineComboEnv() {
     return out;
 }
 
-bool EngineListContains(const std::vector<ProfilingEngine>& engines,
-                        ProfilingEngine engine) {
-    return std::find(engines.begin(), engines.end(), engine) != engines.end();
+bool WindowsInjectedProcess() {
+#if defined(_WIN32)
+    const char* injected = std::getenv(gpufl::env::kInject);
+    return injected && std::strcmp(injected, "1") == 0;
+#else
+    return false;
+#endif
+}
+
+// NVIDIA calls InitializeInjection while the Windows CUDA driver is still
+// initializing. Creating a CUDA context from that callback can re-enter the
+// driver and deadlock, so the injected path only uses an already-current
+// context.
+bool TryCurrentCudaContext(CUcontext* ctx) {
+    if (!ctx) return false;
+    if (*ctx && IsContextValid(*ctx)) return true;
+
+    CUcontext current = nullptr;
+    if (cuCtxGetCurrent(&current) == CUDA_SUCCESS && current) {
+        *ctx = current;
+        return true;
+    }
+    return false;
+}
+
+struct EngineRequestSet {
+    bool trace = false;
+    bool pc = false;
+    bool sass = false;
+    bool pm = false;
+    bool range = false;
+
+    bool needsCubin() const { return pc || sass; }
+    bool ownsTimelineActivity() const { return trace || pm || range; }
+};
+
+EngineRequestSet BuildEngineRequestSet(
+    ProfilingEngine selected,
+    const std::vector<ProfilingEngine>& combo) {
+    EngineRequestSet out;
+    if (!combo.empty()) {
+        for (const ProfilingEngine engine : combo) {
+            out.trace = out.trace || engine == ProfilingEngine::Trace;
+            out.pc = out.pc || engine == ProfilingEngine::PcSampling;
+            out.sass = out.sass || engine == ProfilingEngine::SassMetrics;
+            out.pm = out.pm || engine == ProfilingEngine::PmSampling;
+            out.range = out.range || engine == ProfilingEngine::RangeProfiler;
+        }
+        return out;
+    }
+
+    out.trace = selected == ProfilingEngine::Trace;
+    out.pc = selected == ProfilingEngine::PcSampling ||
+             selected == ProfilingEngine::Deep;
+    out.sass = selected == ProfilingEngine::SassMetrics ||
+               selected == ProfilingEngine::Deep;
+    out.pm = selected == ProfilingEngine::PmSampling ||
+             selected == ProfilingEngine::Deep;
+    out.range = selected == ProfilingEngine::RangeProfiler;
+    return out;
+}
+
+struct EnginePathState {
+    bool active = false;
+    bool has_data = false;
+
+    void observe(bool armed, bool produced) {
+        active = active || armed || produced;
+        has_data = has_data || produced;
+    }
+};
+
+struct EngineRuntimeState {
+    EnginePathState sass;
+    EnginePathState pc;
+    EnginePathState pm;
+    EnginePathState range;
+};
+
+EngineRuntimeState InspectEngineRuntimeState(const IProfilingEngine* engine,
+                                             ProfilingEngine selected,
+                                             bool comboActive) {
+    EngineRuntimeState out;
+    if (!engine) return out;
+
+    auto observeConcrete = [&](const IProfilingEngine* sub) {
+        if (!sub) return;
+        const bool armed = sub->isOperational();
+        const bool produced = sub->producedData();
+
+        if (comboActive) {
+            // Keep the matrix log close to the single place that inspects
+            // runtime engine state.
+            GFL_LOG_ERROR("[Composite][matrix] ", sub->name(), " armed=",
+                          armed ? "yes" : "no", " produced=",
+                          produced ? "yes" : "no");
+        }
+
+        if (dynamic_cast<const SassMetricsEngine*>(sub)) {
+            out.sass.observe(armed, produced);
+        } else if (dynamic_cast<const PcSamplingEngine*>(sub)) {
+            out.pc.observe(armed, produced);
+        } else if (dynamic_cast<const PmSamplingEngine*>(sub)) {
+            out.pm.observe(armed, produced);
+        } else if (dynamic_cast<const RangeProfilerEngine*>(sub)) {
+            out.range.observe(armed, produced);
+        }
+    };
+
+    if (comboActive) {
+        if (const auto* comp = dynamic_cast<const CompositeEngine*>(engine)) {
+            for (const auto& sub : comp->engines()) observeConcrete(sub.get());
+        }
+        return out;
+    }
+
+    if (const auto* deep = dynamic_cast<const PcSamplingWithSassEngine*>(engine)) {
+        out.sass.observe(deep->sassActive(), deep->sassProducedData());
+        out.pc.observe(deep->pcSamplingActive(), deep->pcProducedData());
+        out.pm.observe(deep->pmSamplingActive(), deep->pmProducedData());
+        return out;
+    }
+
+    const bool armed = engine->isOperational();
+    const bool produced = engine->producedData();
+    switch (selected) {
+        case ProfilingEngine::SassMetrics:
+            out.sass.observe(armed, produced);
+            break;
+        case ProfilingEngine::PcSampling:
+            out.pc.observe(armed, produced);
+            break;
+        case ProfilingEngine::PmSampling:
+            out.pm.observe(armed, produced);
+            break;
+        case ProfilingEngine::RangeProfiler:
+            out.range.observe(armed, produced);
+            break;
+        default:
+            break;
+    }
+    return out;
 }
 
 void ApplyComboPlanOverrides(ResolvedProfilingPlan& plan,
                              const std::vector<ProfilingEngine>& combo) {
     if (combo.empty()) return;
+    const EngineRequestSet requests =
+        BuildEngineRequestSet(ProfilingEngine::Monitor, combo);
 
     // PC / SASS read cubin binaries for source correlation and disassembly.
     // The policy resolver sees only the base single engine, so re-apply this
     // after every resolve while a combo is active.
-    if (EngineListContains(combo, ProfilingEngine::PcSampling) ||
-        EngineListContains(combo, ProfilingEngine::SassMetrics)) {
+    if (requests.needsCubin()) {
         plan.needs_cubin_capture = true;
     }
 
@@ -408,22 +548,21 @@ void CuptiBackend::initialize(const MonitorOptions& opts) {
     // (PcSampling LAST) so SASS/Range disable before the PC Sampling API.
     combo_ = ParseEngineComboEnv();
     if (!combo_.empty()) {
-        const auto has = [&](ProfilingEngine e) {
-            return EngineListContains(combo_, e);
-        };
+        const EngineRequestSet requests =
+            BuildEngineRequestSet(opts_.profiling_engine, combo_);
         ApplyComboPlanOverrides(resolved_plan_, combo_);
         std::vector<std::unique_ptr<IProfilingEngine>> subs;
 #if GPUFL_HAS_PERFWORKS
-        if (has(ProfilingEngine::PmSampling))
+        if (requests.pm)
             subs.push_back(std::make_unique<PmSamplingEngine>());
 #endif
-        if (has(ProfilingEngine::SassMetrics))
+        if (requests.sass)
             subs.push_back(std::make_unique<SassMetricsEngine>());
 #if GPUFL_HAS_PERFWORKS
-        if (has(ProfilingEngine::RangeProfiler))
+        if (requests.range)
             subs.push_back(std::make_unique<RangeProfilerEngine>());
 #endif
-        if (has(ProfilingEngine::PcSampling))
+        if (requests.pc)
             subs.push_back(std::make_unique<PcSamplingEngine>());
 
         if (!subs.empty()) {
@@ -648,7 +787,9 @@ void CuptiBackend::start() {
     // SASS safe-mode policy is device dependent, and the policy log should
     // report the real SM version. Querying requiredActivityKinds() before this
     // point used device_id_=0 and could choose the wrong activity policy.
-    const bool haveCudaContext = EnsureCudaContext(&ctx_);
+    const bool haveCudaContext =
+        WindowsInjectedProcess() ? TryCurrentCudaContext(&ctx_)
+                                 : EnsureCudaContext(&ctx_);
     if (haveCudaContext) {
         cuptiGetDeviceId(ctx_, &device_id_);
         GetSMProps(device_id_);
@@ -663,9 +804,17 @@ void CuptiBackend::start() {
             profiling_request_, device_facts_, EnvOverrides::FromProcess());
         ApplyComboPlanOverrides(resolved_plan_, combo_);
     } else if (engine_) {
-        GFL_LOG_ERROR(
+        GFL_LOG_DEBUG(
             "[CuptiBackend] Failed to get CUDA context; "
             "engine will not start.");
+    }
+
+    if (WindowsInjectedProcess() && !haveCudaContext) {
+        GFL_LOG_DEBUG(
+            "[CuptiBackend] Skipping CUPTI activity start during Windows "
+            "injection init because no CUDA context is current.");
+        engine_.reset();
+        return;
     }
 
     if (IsSassProfilerMode()) {
@@ -943,14 +1092,8 @@ bool CuptiBackend::collectsKernelEvents() const {
         // Combo: collect kernel activity iff a kernel-collecting engine is in
         // the set (Trace / PmSampling / RangeProfiler). PC sampling and SASS do
         // not collect kernel activity on their own.
-        for (const ProfilingEngine e : combo_) {
-            if (e == ProfilingEngine::Trace ||
-                e == ProfilingEngine::PmSampling ||
-                e == ProfilingEngine::RangeProfiler) {
-                return true;
-            }
-        }
-        return false;
+        return BuildEngineRequestSet(opts_.profiling_engine, combo_)
+            .ownsTimelineActivity();
     }
     // Single engine — preserve prior behavior exactly:
     //   PcSampling -> off; SASS / Deep -> off unless AllowSassKernelActivity;
@@ -967,77 +1110,18 @@ void CuptiBackend::EmitCaptureCapabilities_() const {
         return;
     }
 
-    const auto comboHas = [&](ProfilingEngine e) {
-        return std::find(combo_.begin(), combo_.end(), e) != combo_.end();
-    };
-    const bool requestedSass =
-        comboActive() ? comboHas(ProfilingEngine::SassMetrics)
-                      : (opts_.profiling_engine == ProfilingEngine::SassMetrics ||
-                         opts_.profiling_engine == ProfilingEngine::Deep);
-    const bool requestedPc =
-        comboActive() ? comboHas(ProfilingEngine::PcSampling)
-                      : (opts_.profiling_engine == ProfilingEngine::PcSampling ||
-                         opts_.profiling_engine == ProfilingEngine::Deep);
-    const bool requestedPm =
-        comboActive() ? comboHas(ProfilingEngine::PmSampling)
-                      : (opts_.profiling_engine == ProfilingEngine::PmSampling ||
-                         opts_.profiling_engine == ProfilingEngine::Deep);
-    const bool requestedRange =
-        comboActive() ? comboHas(ProfilingEngine::RangeProfiler)
-                      : opts_.profiling_engine == ProfilingEngine::RangeProfiler;
-    const bool sassMode = requestedSass;
-    const bool pcSamplingMode = requestedPc;
+    const EngineRequestSet requests =
+        BuildEngineRequestSet(opts_.profiling_engine, combo_);
     const bool kernelActivity = collectsKernelEvents();
-    const bool syntheticKernels = !kernelActivity && (sassMode || pcSamplingMode);
-    const bool cubinRequested = requestedPc || requestedSass;
+    const bool syntheticKernels = !kernelActivity && (requests.sass || requests.pc);
+    const bool cubinRequested = requests.needsCubin();
     const bool cubinCapture = NeedsCubinCapture();
-
-    bool sassActive = false;
-    bool pcActive = false;
-    bool pmActive = false;
-    bool rangeActive = false;
-
     // Capability emission happens after final engine shutdown so the report can
     // see late-flushed samples. Some engines drop their operational flag during
     // shutdown, so keep a path active if it was requested and produced data.
-    if (comboActive()) {
-        if (const auto* comp =
-                dynamic_cast<const CompositeEngine*>(engine_.get())) {
-            for (const auto& sub : comp->engines()) {
-                if (!sub) continue;
-                const bool armed = sub->isOperational();
-                const bool produced = sub->producedData();
-                // The compatibility matrix, straight from the run: which
-                // sub-engines armed and which produced data for this combo.
-                GFL_LOG_ERROR("[Composite][matrix] ", sub->name(), " armed=",
-                              armed ? "yes" : "no", " produced=",
-                              produced ? "yes" : "no");
-                if (dynamic_cast<const SassMetricsEngine*>(sub.get()))
-                    sassActive = armed || produced;
-                else if (dynamic_cast<const PcSamplingEngine*>(sub.get()))
-                    pcActive = armed || produced;
-                else if (dynamic_cast<const PmSamplingEngine*>(sub.get()))
-                    pmActive = armed || produced;
-                else if (dynamic_cast<const RangeProfilerEngine*>(sub.get()))
-                    rangeActive = armed || produced;
-            }
-        }
-    } else if (opts_.profiling_engine == ProfilingEngine::SassMetrics && engine_) {
-        sassActive = engine_->isOperational() || engine_->producedData();
-    } else if (opts_.profiling_engine == ProfilingEngine::PcSampling && engine_) {
-        pcActive = engine_->isOperational() || engine_->producedData();
-    } else if (opts_.profiling_engine == ProfilingEngine::PmSampling && engine_) {
-        pmActive = engine_->isOperational() || engine_->producedData();
-    } else if (opts_.profiling_engine == ProfilingEngine::RangeProfiler && engine_) {
-        rangeActive = engine_->isOperational() || engine_->producedData();
-    } else if (opts_.profiling_engine == ProfilingEngine::Deep) {
-        if (const auto* deep =
-                dynamic_cast<const PcSamplingWithSassEngine*>(engine_.get())) {
-            sassActive = deep->sassActive() || deep->sassProducedData();
-            pcActive = deep->pcSamplingActive() || deep->pcProducedData();
-            pmActive = deep->pmSamplingActive() || deep->pmProducedData();
-        }
-    }
+    const EngineRuntimeState engineState =
+        InspectEngineRuntimeState(engine_.get(), opts_.profiling_engine,
+                                  comboActive());
 
     // Did each path actually emit rows (vs merely arm)? Drives the
     // "enabled_no_data" status so a capability that was turned ON but produced
@@ -1069,48 +1153,12 @@ void CuptiBackend::EmitCaptureCapabilities_() const {
     const bool externalHasData = externalRows > 0;
     const bool sourceHasData = sourceRows > 0 || functionRows > 0;
 
-    bool sassHasData = false;
-    bool pcHasData = false;
-    bool pmHasData = false;
-    bool rangeHasData = false;
-    if (comboActive()) {
-        if (const auto* comp =
-                dynamic_cast<const CompositeEngine*>(engine_.get())) {
-            for (const auto& sub : comp->engines()) {
-                if (!sub) continue;
-                if (dynamic_cast<const SassMetricsEngine*>(sub.get()))
-                    sassHasData = sub->producedData();
-                else if (dynamic_cast<const PcSamplingEngine*>(sub.get()))
-                    pcHasData = sub->producedData();
-                else if (dynamic_cast<const PmSamplingEngine*>(sub.get()))
-                    pmHasData = sub->producedData();
-                else if (dynamic_cast<const RangeProfilerEngine*>(sub.get()))
-                    rangeHasData = sub->producedData();
-            }
-        }
-    } else if (engine_) {
-        if (const auto* deep =
-                dynamic_cast<const PcSamplingWithSassEngine*>(engine_.get())) {
-            sassHasData = deep->sassProducedData();
-            pcHasData = deep->pcProducedData();
-            pmHasData = deep->pmProducedData();
-        } else if (opts_.profiling_engine == ProfilingEngine::SassMetrics) {
-            sassHasData = engine_->producedData();
-        } else if (opts_.profiling_engine == ProfilingEngine::PcSampling) {
-            pcHasData = engine_->producedData();
-        } else if (opts_.profiling_engine == ProfilingEngine::PmSampling) {
-            pmHasData = engine_->producedData();
-        } else if (opts_.profiling_engine == ProfilingEngine::RangeProfiler) {
-            rangeHasData = engine_->producedData();
-        }
-    }
-
     std::string selected = ProfilingEngineWireName(opts_.profiling_engine);
     if (comboActive()) {
         selected = "nvidia.composite";
     } else if (opts_.profiling_engine == ProfilingEngine::Deep) {
-        if (sassActive) selected = "nvidia.sass_metrics";
-        else if (pcActive) selected = "nvidia.pc_sampling";
+        if (engineState.sass.active) selected = "nvidia.sass_metrics";
+        else if (engineState.pc.active) selected = "nvidia.pc_sampling";
         else selected = "nvidia.none";
     }
 
@@ -1135,8 +1183,8 @@ void CuptiBackend::EmitCaptureCapabilities_() const {
                             : "disabled"),
                   kernelHasData
                       ? (syntheticKernels
-                            ? (pcSamplingMode ? "cupti_kernel_activity_conflicts_with_pc_sampling"
-                                              : "cupti_kernel_activity_deadlock_risk")
+                            ? (requests.pc ? "cupti_kernel_activity_conflicts_with_pc_sampling"
+                                           : "cupti_kernel_activity_deadlock_risk")
                             : "")
                       : (kernelActivity
                             ? (metricsOnly ? "disabled_to_preserve_sass_counters"
@@ -1144,7 +1192,7 @@ void CuptiBackend::EmitCaptureCapabilities_() const {
                             : "not_selected"),
                   kernelHasData
                       ? (syntheticKernels
-                            ? (pcSamplingMode
+                            ? (requests.pc
                                   ? "Kernel rows were collected from launch callbacks; durations are estimated because CUPTI kernel activity is disabled while PC Sampling API is active."
                                   : "Kernel rows were collected from launch callbacks; durations are estimated because CUPTI kernel activity is disabled in SASS safe mode.")
                             : "Kernel rows were collected from CUPTI kernel activity records.")
@@ -1274,64 +1322,80 @@ void CuptiBackend::EmitCaptureCapabilities_() const {
                             ? "This profiling path requested CUBIN capture, but it was disabled by policy or environment."
                             : "This profiling engine does not request CUBIN capture."));
     AddCapability(evt, "sass_metrics",
-                  requestedSass,
-                  sassActive ? (sassHasData ? "collected" : "enabled_no_data") :
-                      (requestedSass ? "skipped" : "not_requested"),
-                  sassActive ? "cupti_sass_metrics" : "disabled",
-                  sassActive ? (sassHasData ? "" : "enabled_but_no_samples")
-                             : "not_selected_or_not_operational",
-                  sassActive
-                      ? (sassHasData
+                  requests.sass,
+                  engineState.sass.active
+                      ? (engineState.sass.has_data ? "collected" : "enabled_no_data")
+                      : (requests.sass ? "skipped" : "not_requested"),
+                  engineState.sass.active ? "cupti_sass_metrics" : "disabled",
+                  engineState.sass.active
+                      ? (engineState.sass.has_data ? "" : "enabled_but_no_samples")
+                      : "not_selected_or_not_operational",
+                  engineState.sass.active
+                      ? (engineState.sass.has_data
                             ? "SASS metrics were collected for this session."
                             : "SASS metrics were enabled but produced no instruction-level samples this session (e.g. kernels too short, or CUPTI replay returned no data).")
                       : "SASS metrics were not collected for this session.");
     AddCapability(evt, "pc_sampling",
-                  requestedPc,
-                  pcActive ? (pcHasData ? "collected" : "enabled_no_data") :
-                      (opts_.profiling_engine == ProfilingEngine::Deep && sassActive ? "skipped" :
-                       (requestedPc ? "skipped" : "not_requested")),
-                  pcActive ? "cupti_pc_sampling" : "disabled",
-                  opts_.profiling_engine == ProfilingEngine::Deep && sassActive
+                  requests.pc,
+                  engineState.pc.active
+                      ? (engineState.pc.has_data ? "collected" : "enabled_no_data")
+                      : (opts_.profiling_engine == ProfilingEngine::Deep &&
+                                 engineState.sass.active
+                             ? "skipped"
+                             : (requests.pc ? "skipped" : "not_requested")),
+                  engineState.pc.active ? "cupti_pc_sampling" : "disabled",
+                  opts_.profiling_engine == ProfilingEngine::Deep &&
+                          engineState.sass.active
                       ? "mutually_exclusive_with_sass_metrics" :
-                    (pcActive ? (pcHasData ? "" : "enabled_but_no_samples")
-                              : "not_selected_or_not_operational"),
-                  opts_.profiling_engine == ProfilingEngine::Deep && sassActive
+                    (engineState.pc.active
+                         ? (engineState.pc.has_data ? "" : "enabled_but_no_samples")
+                         : "not_selected_or_not_operational"),
+                  opts_.profiling_engine == ProfilingEngine::Deep &&
+                          engineState.sass.active
                       ? "Deep selected SASS metrics; PC sampling was skipped because SASS metrics and PC sampling are mutually exclusive in one run."
-                      : (pcActive ? (pcHasData
+                      : (engineState.pc.active ? (engineState.pc.has_data
                             ? "PC sampling was collected for this session."
                             : "PC sampling was enabled but produced no stall samples this session (e.g. kernels too short for the sampling period).")
                                   : "PC sampling was not collected for this session."));
     AddCapability(evt, "pm_sampling",
-                  requestedPm,
-                  pmActive ? (pmHasData ? "collected" : "enabled_no_data")
-                           : (requestedPm ? "skipped" : "not_requested"),
-                  pmActive ? "cupti_pm_sampling" : "disabled",
-                  pmActive ? (pmHasData ? "" : "enabled_but_no_samples")
-                           : "not_selected_or_not_operational",
-                  pmActive
-                      ? (pmHasData
+                  requests.pm,
+                  engineState.pm.active
+                      ? (engineState.pm.has_data ? "collected" : "enabled_no_data")
+                      : (requests.pm ? "skipped" : "not_requested"),
+                  engineState.pm.active ? "cupti_pm_sampling" : "disabled",
+                  engineState.pm.active
+                      ? (engineState.pm.has_data ? "" : "enabled_but_no_samples")
+                      : "not_selected_or_not_operational",
+                  engineState.pm.active
+                      ? (engineState.pm.has_data
                             ? "PM sampling hardware metric samples were collected for this session."
                             : "PM sampling was enabled but produced no hardware samples this session.")
                       : "PM sampling was not collected for this session.");
     AddCapability(evt, "range_counters",
-                  requestedRange,
-                  rangeActive ? (rangeHasData ? "collected" : "enabled_no_data")
-                              : (requestedRange ? "skipped" : "not_requested"),
-                  rangeActive ? "cupti_range_profiler" : "disabled",
-                  rangeActive ? (rangeHasData ? "" : "enabled_but_no_ranges")
-                              : "not_selected_or_not_operational",
-                  rangeActive
-                      ? (rangeHasData
+                  requests.range,
+                  engineState.range.active
+                      ? (engineState.range.has_data ? "collected" : "enabled_no_data")
+                      : (requests.range ? "skipped" : "not_requested"),
+                  engineState.range.active ? "cupti_range_profiler" : "disabled",
+                  engineState.range.active
+                      ? (engineState.range.has_data ? "" : "enabled_but_no_ranges")
+                      : "not_selected_or_not_operational",
+                  engineState.range.active
+                      ? (engineState.range.has_data
                             ? "Range Profiler scope-level hardware counters were collected for this session."
                             : "Range Profiler was enabled but produced no decoded range counters this session.")
                       : "Range Profiler counters were not collected for this session.");
-    AddCapability(evt, "source_correlation", pcActive,
-                  pcActive ? (sourceHasData ? "collected" : "enabled_no_data")
-                           : (sassActive ? "skipped" : "not_requested"),
-                  pcActive ? "pc_sampling_source_locator" : "disabled",
-                  pcActive ? (sourceHasData ? "" : "enabled_but_no_records")
-                           : (sassActive ? "sass_metrics_have_no_source_lines" : "not_requested"),
-                  pcActive
+    AddCapability(evt, "source_correlation", engineState.pc.active,
+                  engineState.pc.active
+                      ? (sourceHasData ? "collected" : "enabled_no_data")
+                      : (engineState.sass.active ? "skipped" : "not_requested"),
+                  engineState.pc.active ? "pc_sampling_source_locator" : "disabled",
+                  engineState.pc.active
+                      ? (sourceHasData ? "" : "enabled_but_no_records")
+                      : (engineState.sass.active
+                             ? "sass_metrics_have_no_source_lines"
+                             : "not_requested"),
+                  engineState.pc.active
                       ? (sourceHasData
                             ? "PC sampling source locator/function records were collected for CUDA source correlation."
                             : "PC sampling source correlation was enabled but emitted no source locator/function records.")

--- a/include/gpufl/backends/nvidia/cupti_backend.cpp
+++ b/include/gpufl/backends/nvidia/cupti_backend.cpp
@@ -24,6 +24,7 @@
 #include "gpufl/backends/nvidia/cuda_collector.hpp"
 #include "gpufl/backends/nvidia/cupti_utils.hpp"
 #include "gpufl/core/teardown_flag.hpp"
+#include "gpufl/backends/nvidia/engine/composite_engine.hpp"
 #include "gpufl/backends/nvidia/engine/pc_sampling_engine.hpp"
 #include "gpufl/backends/nvidia/engine/pc_sampling_with_sass_engine.hpp"
 #include "gpufl/backends/nvidia/engine/pm_sampling_engine.hpp"
@@ -36,6 +37,7 @@
 #include "gpufl/core/activity_record.hpp"
 #include "gpufl/core/common.hpp"
 #include "gpufl/core/debug_logger.hpp"
+#include "gpufl/core/env_vars.hpp"
 #include "gpufl/core/logger/logger.hpp"
 #include "gpufl/core/model/lifecycle_model.hpp"
 #include "gpufl/core/runtime.hpp"
@@ -322,6 +324,41 @@ void CuptiBackend::LogNvtxMarkerActivityDisabled_(const char* phase) {
         "GPUFL_SASS_ALLOW_MARKER_ACTIVITY=1 to test SASS + NVTX markers.");
 }
 
+namespace {
+// Parse GPUFL_ENGINE_COMBO (comma-separated canonical engine names) into an
+// engine list. Unknown tokens are logged and skipped; empty/unset => {}.
+std::vector<ProfilingEngine> ParseEngineComboEnv() {
+    std::vector<ProfilingEngine> out;
+    const char* raw = std::getenv(gpufl::env::kEngineCombo);
+    if (!raw || raw[0] == '\0') return out;
+    std::string s(raw);
+    size_t pos = 0;
+    while (pos <= s.size()) {
+        const size_t comma = s.find(',', pos);
+        const size_t end = (comma == std::string::npos) ? s.size() : comma;
+        std::string tok = s.substr(pos, end - pos);
+        const auto b = tok.find_first_not_of(" \t\r\n");
+        const auto e = tok.find_last_not_of(" \t\r\n");
+        if (b != std::string::npos) {
+            tok = tok.substr(b, e - b + 1);
+            if (tok == "Monitor")            out.push_back(ProfilingEngine::Monitor);
+            else if (tok == "Trace")         out.push_back(ProfilingEngine::Trace);
+            else if (tok == "PcSampling")    out.push_back(ProfilingEngine::PcSampling);
+            else if (tok == "SassMetrics")   out.push_back(ProfilingEngine::SassMetrics);
+            else if (tok == "PmSampling")    out.push_back(ProfilingEngine::PmSampling);
+            else if (tok == "RangeProfiler") out.push_back(ProfilingEngine::RangeProfiler);
+            else if (tok == "Deep")          out.push_back(ProfilingEngine::Deep);
+            else
+                GFL_LOG_ERROR("[CuptiBackend] GPUFL_ENGINE_COMBO: unknown engine '",
+                              tok, "' (ignored)");
+        }
+        if (comma == std::string::npos) break;
+        pos = comma + 1;
+    }
+    return out;
+}
+}  // namespace
+
 void CuptiBackend::initialize(const MonitorOptions& opts) {
     opts_ = opts;
     profiling_request_ = MakeProfilingRequest(opts_);
@@ -330,6 +367,60 @@ void CuptiBackend::initialize(const MonitorOptions& opts) {
 
     DebugLogger::setEnabled(opts_.enable_debug_output);
 
+    // GPUFL_ENGINE_COMBO=Trace,PcSampling,... runs an arbitrary engine set in
+    // one process (compatibility-matrix testing + the redefined Deep). When
+    // present it overrides the single-engine selection below. Trace/Monitor in
+    // the list select the activity-record layer (collectsKernelEvents()), not an
+    // engine object; the API engines are built in teardown-safe order
+    // (PcSampling LAST) so SASS/Range disable before the PC Sampling API.
+    combo_ = ParseEngineComboEnv();
+    if (!combo_.empty()) {
+        const auto has = [&](ProfilingEngine e) {
+            return std::find(combo_.begin(), combo_.end(), e) != combo_.end();
+        };
+        // PC / SASS read cubin binaries for source correlation; the single-engine
+        // plan only sets needs_cubin_capture for those engines, so force it on
+        // when the combo includes one (the plan was resolved from a single engine).
+        if (has(ProfilingEngine::PcSampling) || has(ProfilingEngine::SassMetrics)) {
+            resolved_plan_.needs_cubin_capture = true;
+        }
+        // A combo dictates its OWN activity set (collectsKernelEvents() + full
+        // trace activity). The single-engine SASS safe-mode gating
+        // (safe_sass_activity_defaults / sass_metrics_only) only makes sense for
+        // a lone SASS/Deep run; if the base engine happened to be SASS/Deep it
+        // would otherwise suppress Trace's mem/sync/marker/external activity in
+        // the combo. Clear it so a combo's activity is predictable regardless of
+        // the base engine.
+        resolved_plan_.sass_metrics_only = false;
+        resolved_plan_.safe_sass_activity_defaults = false;
+        resolved_plan_.allow_sass_kernel_activity = true;
+        resolved_plan_.allow_sass_marker_activity = true;
+        resolved_plan_.allow_sass_mem_transfer_activity = true;
+        resolved_plan_.allow_sass_memory2_activity = true;
+        resolved_plan_.allow_sass_sync_activity = true;
+        resolved_plan_.allow_sass_graph_activity = true;
+        resolved_plan_.allow_sass_external_correlation = true;
+        std::vector<std::unique_ptr<IProfilingEngine>> subs;
+#if GPUFL_HAS_PERFWORKS
+        if (has(ProfilingEngine::PmSampling))
+            subs.push_back(std::make_unique<PmSamplingEngine>());
+#endif
+        if (has(ProfilingEngine::SassMetrics))
+            subs.push_back(std::make_unique<SassMetricsEngine>());
+#if GPUFL_HAS_PERFWORKS
+        if (has(ProfilingEngine::RangeProfiler))
+            subs.push_back(std::make_unique<RangeProfilerEngine>());
+#endif
+        if (has(ProfilingEngine::PcSampling))
+            subs.push_back(std::make_unique<PcSamplingEngine>());
+
+        if (!subs.empty()) {
+            engine_ = std::make_unique<CompositeEngine>(std::move(subs));
+        }
+        GFL_LOG_DEBUG("[CuptiBackend] Engine: Composite combo (", combo_.size(),
+                      " entries; ", (engine_ ? "API engines armed" : "activity-only"),
+                      ")");
+    } else
     // Create the engine (no CUDA context needed yet)
     switch (opts_.profiling_engine) {
         case ProfilingEngine::PcSampling:
@@ -484,6 +575,19 @@ CUptiResult (*CuptiBackend::get_value())(CUpti_ActivityKind) {
 
 void CuptiBackend::start() {
     if (!initialized_) return;
+    // SASS / PC sampling don't get trustworthy kernel timing: SASS safe mode keeps
+    // kernel-activity OFF (it deadlocks), so its launches would be flushed as
+    // synthetic kernels whose "duration" is just the host-dispatch interval —
+    // meaningless. Suppress that synthetic fallback so these sessions show no
+    // misleading kernel rows. PC additionally enables CONCURRENT_KERNEL in its engine
+    // (pc_sampling_engine.cpp), so if REAL kernel records flow on this GPU they are
+    // joined + emitted normally — suppress only drops the un-joined orphans, never
+    // real rows. So PC shows real kernels when coexistence works, nothing when it
+    // doesn't — never fake. KERNEL_LAUNCH_META still flows for the per-scope
+    // Execution Signature, so a multi-pass merge is unaffected.
+    SetSuppressOrphanSyntheticKernels(
+        opts_.profiling_engine == ProfilingEngine::SassMetrics ||
+        opts_.profiling_engine == ProfilingEngine::PcSampling);
     kernel_activity_seen_.store(0, std::memory_order_relaxed);
     kernel_activity_emitted_.store(0, std::memory_order_relaxed);
     kernel_activity_throttled_.store(0, std::memory_order_relaxed);
@@ -815,6 +919,28 @@ void CuptiBackend::start() {
 }
 
 
+bool CuptiBackend::collectsKernelEvents() const {
+    if (!combo_.empty()) {
+        // Combo: collect kernel activity iff a kernel-collecting engine is in
+        // the set (Trace / PmSampling / RangeProfiler). PC sampling and SASS do
+        // not collect kernel activity on their own.
+        for (const ProfilingEngine e : combo_) {
+            if (e == ProfilingEngine::Trace ||
+                e == ProfilingEngine::PmSampling ||
+                e == ProfilingEngine::RangeProfiler) {
+                return true;
+            }
+        }
+        return false;
+    }
+    // Single engine — preserve prior behavior exactly:
+    //   PcSampling -> off; SASS / Deep -> off unless AllowSassKernelActivity;
+    //   Trace / PmSampling / RangeProfiler -> on.
+    if (opts_.profiling_engine == ProfilingEngine::PcSampling) return false;
+    if (IsSassProfilerMode()) return AllowSassKernelActivity();
+    return true;
+}
+
 void CuptiBackend::EmitCaptureCapabilities_() const {
     const Runtime* rt = runtime();
     if (!(rt && rt->logger)) return;
@@ -825,8 +951,7 @@ void CuptiBackend::EmitCaptureCapabilities_() const {
     const bool sassMode = IsSassProfilerMode();
     const bool pcSamplingMode =
         opts_.profiling_engine == ProfilingEngine::PcSampling;
-    const bool kernelActivity =
-        pcSamplingMode ? false : (!sassMode || AllowSassKernelActivity());
+    const bool kernelActivity = collectsKernelEvents();
     const bool syntheticKernels = !kernelActivity && (sassMode || pcSamplingMode);
     const bool cubinCapture = NeedsCubinCapture();
 
@@ -837,7 +962,27 @@ void CuptiBackend::EmitCaptureCapabilities_() const {
     // Capability emission happens after final engine shutdown so the report can
     // see late-flushed samples. Some engines drop their operational flag during
     // shutdown, so keep a path active if it was requested and produced data.
-    if (opts_.profiling_engine == ProfilingEngine::SassMetrics && engine_) {
+    if (comboActive()) {
+        if (const auto* comp =
+                dynamic_cast<const CompositeEngine*>(engine_.get())) {
+            for (const auto& sub : comp->engines()) {
+                if (!sub) continue;
+                const bool armed = sub->isOperational();
+                const bool produced = sub->producedData();
+                // The compatibility matrix, straight from the run: which
+                // sub-engines armed and which produced data for this combo.
+                GFL_LOG_ERROR("[Composite][matrix] ", sub->name(), " armed=",
+                              armed ? "yes" : "no", " produced=",
+                              produced ? "yes" : "no");
+                if (dynamic_cast<const SassMetricsEngine*>(sub.get()))
+                    sassActive = armed || produced;
+                else if (dynamic_cast<const PcSamplingEngine*>(sub.get()))
+                    pcActive = armed || produced;
+                else if (dynamic_cast<const PmSamplingEngine*>(sub.get()))
+                    pmActive = armed || produced;
+            }
+        }
+    } else if (opts_.profiling_engine == ProfilingEngine::SassMetrics && engine_) {
         sassActive = engine_->isOperational() || engine_->producedData();
     } else if (opts_.profiling_engine == ProfilingEngine::PcSampling && engine_) {
         pcActive = engine_->isOperational() || engine_->producedData();
@@ -873,7 +1018,20 @@ void CuptiBackend::EmitCaptureCapabilities_() const {
     bool sassHasData = false;
     bool pcHasData = false;
     bool pmHasData = false;
-    if (engine_) {
+    if (comboActive()) {
+        if (const auto* comp =
+                dynamic_cast<const CompositeEngine*>(engine_.get())) {
+            for (const auto& sub : comp->engines()) {
+                if (!sub) continue;
+                if (dynamic_cast<const SassMetricsEngine*>(sub.get()))
+                    sassHasData = sub->producedData();
+                else if (dynamic_cast<const PcSamplingEngine*>(sub.get()))
+                    pcHasData = sub->producedData();
+                else if (dynamic_cast<const PmSamplingEngine*>(sub.get()))
+                    pmHasData = sub->producedData();
+            }
+        }
+    } else if (engine_) {
         if (const auto* deep =
                 dynamic_cast<const PcSamplingWithSassEngine*>(engine_.get())) {
             sassHasData = deep->sassProducedData();
@@ -889,7 +1047,9 @@ void CuptiBackend::EmitCaptureCapabilities_() const {
     }
 
     std::string selected = ProfilingEngineWireName(opts_.profiling_engine);
-    if (opts_.profiling_engine == ProfilingEngine::Deep) {
+    if (comboActive()) {
+        selected = "nvidia.composite";
+    } else if (opts_.profiling_engine == ProfilingEngine::Deep) {
         if (sassActive) selected = "nvidia.sass_metrics";
         else if (pcActive) selected = "nvidia.pc_sampling";
         else selected = "nvidia.none";

--- a/include/gpufl/backends/nvidia/cupti_backend.cpp
+++ b/include/gpufl/backends/nvidia/cupti_backend.cpp
@@ -40,6 +40,7 @@
 #include "gpufl/core/env_vars.hpp"
 #include "gpufl/core/logger/logger.hpp"
 #include "gpufl/core/model/lifecycle_model.hpp"
+#include "gpufl/core/model/perf_metric_model.hpp"
 #include "gpufl/core/runtime.hpp"
 #include "gpufl/core/ring_buffer.hpp"
 #include "gpufl/core/stack_registry.hpp"
@@ -349,6 +350,8 @@ std::vector<ProfilingEngine> ParseEngineComboEnv() {
             else if (tok == "SassMetrics")   out.push_back(ProfilingEngine::SassMetrics);
             else if (tok == "PmSampling")    out.push_back(ProfilingEngine::PmSampling);
             else if (tok == "RangeProfiler") out.push_back(ProfilingEngine::RangeProfiler);
+            else if (tok == "RangeProfilerKernelReplay")
+                out.push_back(ProfilingEngine::RangeProfilerKernelReplay);
             else if (tok == "Deep")          out.push_back(ProfilingEngine::Deep);
             else
                 GFL_LOG_ERROR("[CuptiBackend] GPUFL_ENGINE_COMBO: unknown engine '",
@@ -391,6 +394,7 @@ struct EngineRequestSet {
     bool sass = false;
     bool pm = false;
     bool range = false;
+    bool range_kernel = false;
 
     bool needsCubin() const { return pc || sass; }
     bool ownsTimelineActivity() const { return trace || pm || range; }
@@ -407,6 +411,8 @@ EngineRequestSet BuildEngineRequestSet(
             out.sass = out.sass || engine == ProfilingEngine::SassMetrics;
             out.pm = out.pm || engine == ProfilingEngine::PmSampling;
             out.range = out.range || engine == ProfilingEngine::RangeProfiler;
+            out.range_kernel = out.range_kernel ||
+                engine == ProfilingEngine::RangeProfilerKernelReplay;
         }
         return out;
     }
@@ -419,6 +425,7 @@ EngineRequestSet BuildEngineRequestSet(
     out.pm = selected == ProfilingEngine::PmSampling ||
              selected == ProfilingEngine::Deep;
     out.range = selected == ProfilingEngine::RangeProfiler;
+    out.range_kernel = selected == ProfilingEngine::RangeProfilerKernelReplay;
     return out;
 }
 
@@ -437,6 +444,7 @@ struct EngineRuntimeState {
     EnginePathState pc;
     EnginePathState pm;
     EnginePathState range;
+    EnginePathState range_kernel;
 };
 
 EngineRuntimeState InspectEngineRuntimeState(const IProfilingEngine* engine,
@@ -464,8 +472,9 @@ EngineRuntimeState InspectEngineRuntimeState(const IProfilingEngine* engine,
             out.pc.observe(armed, produced);
         } else if (dynamic_cast<const PmSamplingEngine*>(sub)) {
             out.pm.observe(armed, produced);
-        } else if (dynamic_cast<const RangeProfilerEngine*>(sub)) {
-            out.range.observe(armed, produced);
+        } else if (const auto* range = dynamic_cast<const RangeProfilerEngine*>(sub)) {
+            if (range->kernelReplayMode()) out.range_kernel.observe(armed, produced);
+            else out.range.observe(armed, produced);
         }
     };
 
@@ -497,6 +506,9 @@ EngineRuntimeState InspectEngineRuntimeState(const IProfilingEngine* engine,
             break;
         case ProfilingEngine::RangeProfiler:
             out.range.observe(armed, produced);
+            break;
+        case ProfilingEngine::RangeProfilerKernelReplay:
+            out.range_kernel.observe(armed, produced);
             break;
         default:
             break;
@@ -561,6 +573,9 @@ void CuptiBackend::initialize(const MonitorOptions& opts) {
 #if GPUFL_HAS_PERFWORKS
         if (requests.range)
             subs.push_back(std::make_unique<RangeProfilerEngine>());
+        if (requests.range_kernel)
+            subs.push_back(std::make_unique<RangeProfilerEngine>(
+                RangeProfilerEngine::Mode::KernelReplay));
 #endif
         if (requests.pc)
             subs.push_back(std::make_unique<PcSamplingEngine>());
@@ -599,6 +614,17 @@ void CuptiBackend::initialize(const MonitorOptions& opts) {
 #else
             GFL_LOG_ERROR(
                 "[CuptiBackend] RangeProfiler engine requires "
+                "GPUFL_HAS_PERFWORKS; falling back to kernel-trace only");
+#endif
+            break;
+        case ProfilingEngine::RangeProfilerKernelReplay:
+#if GPUFL_HAS_PERFWORKS
+            engine_ = std::make_unique<RangeProfilerEngine>(
+                RangeProfilerEngine::Mode::KernelReplay);
+            GFL_LOG_DEBUG("[CuptiBackend] Engine: RangeProfilerKernelReplay");
+#else
+            GFL_LOG_ERROR(
+                "[CuptiBackend] RangeProfilerKernelReplay engine requires "
                 "GPUFL_HAS_PERFWORKS; falling back to kernel-trace only");
 #endif
             break;
@@ -1385,6 +1411,21 @@ void CuptiBackend::EmitCaptureCapabilities_() const {
                             ? "Range Profiler scope-level hardware counters were collected for this session."
                             : "Range Profiler was enabled but produced no decoded range counters this session.")
                       : "Range Profiler counters were not collected for this session.");
+    AddCapability(evt, "kernel_replay_counters",
+                  requests.range_kernel,
+                  engineState.range_kernel.active
+                      ? (engineState.range_kernel.has_data ? "collected" : "enabled_no_data")
+                      : (requests.range_kernel ? "skipped" : "not_requested"),
+                  engineState.range_kernel.active
+                      ? "cupti_range_profiler_kernel_replay" : "disabled",
+                  engineState.range_kernel.active
+                      ? (engineState.range_kernel.has_data ? "" : "enabled_but_no_ranges")
+                      : "not_selected_or_not_operational",
+                  engineState.range_kernel.active
+                      ? (engineState.range_kernel.has_data
+                            ? "Range Profiler kernel replay counters were collected for this session."
+                            : "Range Profiler kernel replay was enabled but produced no decoded kernel ranges this session.")
+                      : "Range Profiler kernel replay counters were not collected for this session.");
     AddCapability(evt, "source_correlation", engineState.pc.active,
                   engineState.pc.active
                       ? (sourceHasData ? "collected" : "enabled_no_data")
@@ -1466,7 +1507,17 @@ void CuptiBackend::stop() {
     // Stop the engine BEFORE flushing activity records.  PcSamplingEngine::stop()
     // disables the SamplingAPI session — while it's armed, cuptiActivityFlushAll
     // returns zero kernel records on driver 590+.
-    if (engine_) engine_->stop();
+    if (engine_) {
+        engine_->stop();
+        if (const Runtime* rt = runtime(); rt && rt->logger) {
+            for (auto& ev : engine_->takeKernelPerfEvents()) {
+                ev.pid = detail::GetPid();
+                ev.app = rt->app_name;
+                ev.session_id = rt->session_id;
+                rt->logger->write(model::KernelPerfMetricModel(ev));
+            }
+        }
+    }
 
     // Disable all activity kinds FIRST, before the flush. The previous
     // order (sync → flush → disable) left activity tracking enabled

--- a/include/gpufl/backends/nvidia/cupti_backend.hpp
+++ b/include/gpufl/backends/nvidia/cupti_backend.hpp
@@ -3,6 +3,7 @@
 #include <cuda_runtime.h>
 #include <cupti.h>
 
+#include <algorithm>
 #include <atomic>
 #include <memory>
 #include <mutex>
@@ -67,6 +68,14 @@ class CuptiBackend : public IMonitorBackend {
     // off; SASS off unless AllowSassKernelActivity). Drives both the handler's
     // requiredActivityKinds() and the capability report.
     bool collectsKernelEvents() const;
+    bool UsesRangeProfilerKernelReplay() const {
+        if (!combo_.empty()) {
+            return std::find(combo_.begin(), combo_.end(),
+                             ProfilingEngine::RangeProfilerKernelReplay) !=
+                   combo_.end();
+        }
+        return opts_.profiling_engine == ProfilingEngine::RangeProfilerKernelReplay;
+    }
     // True when CUPTI kernel ACTIVITY records won't be collected, so every
     // launch must be reported from its callback as a synthetic kernel (PC
     // Sampling, or SASS profiler safe mode without GPUFL_SASS_ALLOW_KERNEL_

--- a/include/gpufl/backends/nvidia/cupti_backend.hpp
+++ b/include/gpufl/backends/nvidia/cupti_backend.hpp
@@ -103,6 +103,9 @@ class CuptiBackend : public IMonitorBackend {
     void NoteMemoryActivityEmitted() {
         memory_activity_emitted_.fetch_add(1, std::memory_order_relaxed);
     }
+    void NoteMemTransferActivityEmitted() {
+        mem_transfer_activity_emitted_.fetch_add(1, std::memory_order_relaxed);
+    }
 
     // Whether the active engine consumes cubin binaries. Cubin capture
     // feeds two consumers, and both want the binary for the SAME three
@@ -248,6 +251,10 @@ class CuptiBackend : public IMonitorBackend {
     std::atomic<uint64_t> kernel_activity_seen_{0};
     std::atomic<uint64_t> kernel_activity_emitted_{0};
     std::atomic<uint64_t> kernel_activity_throttled_{0};
+    std::atomic<uint64_t> mem_transfer_activity_emitted_{0};
+    std::atomic<uint64_t> sync_activity_emitted_{0};
+    std::atomic<uint64_t> nvtx_marker_emitted_{0};
+    std::atomic<uint64_t> graph_activity_emitted_{0};
     std::atomic<uint64_t> memory_activity_emitted_{0};
     std::atomic<uint64_t> external_correlation_seen_{0};
     std::atomic<uint64_t> source_locator_seen_{0};

--- a/include/gpufl/backends/nvidia/cupti_backend.hpp
+++ b/include/gpufl/backends/nvidia/cupti_backend.hpp
@@ -55,6 +55,18 @@ class CuptiBackend : public IMonitorBackend {
     bool AllowSassKernelActivity() const {
         return resolved_plan_.allow_sass_kernel_activity;
     }
+    // True when an engine combo (GPUFL_ENGINE_COMBO) is active — the backend
+    // runs a CompositeEngine over an arbitrary engine list instead of a single
+    // engine. Used to measure the compatibility matrix and back the redefined
+    // Deep (the maximal validated-compatible set).
+    bool comboActive() const { return !combo_.empty(); }
+    // Single source of truth for "collect CUPTI kernel ACTIVITY records"
+    // (KERNEL + CONCURRENT_KERNEL). For a combo: true iff it includes a
+    // kernel-collecting engine (Trace / PmSampling / RangeProfiler). For a
+    // single engine: preserves prior behavior (Trace/PM/Range on; PcSampling
+    // off; SASS off unless AllowSassKernelActivity). Drives both the handler's
+    // requiredActivityKinds() and the capability report.
+    bool collectsKernelEvents() const;
     // True when CUPTI kernel ACTIVITY records won't be collected, so every
     // launch must be reported from its callback as a synthetic kernel (PC
     // Sampling, or SASS profiler safe mode without GPUFL_SASS_ALLOW_KERNEL_
@@ -187,6 +199,11 @@ class CuptiBackend : public IMonitorBackend {
     ProfilingRequest profiling_request_;
     DeviceFacts device_facts_;
     ResolvedProfilingPlan resolved_plan_;
+
+    // Non-empty when GPUFL_ENGINE_COMBO selected a CompositeEngine: the ordered
+    // list of sub-engines (teardown-safe order — PcSampling last). Empty =
+    // single-engine mode via opts_.profiling_engine.
+    std::vector<ProfilingEngine> combo_;
 
     // NOTE (Steps 4b-2 + 4c): the launch-meta AND sync-meta join maps + their
     // mutexes are GONE. All corr-keyed joins (kernel, memcpy/memset, and sync)

--- a/include/gpufl/backends/nvidia/engine/composite_engine.hpp
+++ b/include/gpufl/backends/nvidia/engine/composite_engine.hpp
@@ -2,6 +2,7 @@
 
 #include <memory>
 #include <optional>
+#include <iterator>
 #include <vector>
 
 #include "gpufl/backends/nvidia/engine/profiling_engine.hpp"
@@ -85,6 +86,17 @@ class CompositeEngine final : public IProfilingEngine {
         for (auto& e : engines_)
             if (e) { if (auto ev = e->takeLastPerfEvent()) return ev; }
         return std::nullopt;
+    }
+    std::vector<KernelPerfMetricEvent> takeKernelPerfEvents() override {
+        std::vector<KernelPerfMetricEvent> out;
+        for (auto& e : engines_) {
+            if (!e) continue;
+            auto events = e->takeKernelPerfEvents();
+            out.insert(out.end(),
+                       std::make_move_iterator(events.begin()),
+                       std::make_move_iterator(events.end()));
+        }
+        return out;
     }
     bool hasInsufficientPrivileges() const override {
         for (auto& e : engines_) if (e && e->hasInsufficientPrivileges()) return true;

--- a/include/gpufl/backends/nvidia/engine/composite_engine.hpp
+++ b/include/gpufl/backends/nvidia/engine/composite_engine.hpp
@@ -1,0 +1,109 @@
+#pragma once
+
+#include <memory>
+#include <optional>
+#include <vector>
+
+#include "gpufl/backends/nvidia/engine/profiling_engine.hpp"
+#include "gpufl/core/debug_logger.hpp"
+
+namespace gpufl {
+
+/**
+ * @brief Generalized composite: runs an ARBITRARY set of profiling sub-engines
+ * in one process.
+ *
+ * Generalizes the old fixed `PcSamplingWithSassEngine`. Two uses:
+ *   (1) measure which engine combinations actually coexist (the compatibility
+ *       matrix), and
+ *   (2) back the redefined `Deep` = the maximal validated-compatible set.
+ *
+ * Unlike the old composite it does **no** SASS-vs-PC arbitration: it simply
+ * starts every sub-engine and lets each arm-or-decline, so a combo's real
+ * behavior (coexist / one-declines / deadlock) is directly observable from the
+ * per-engine capability the backend emits.
+ *
+ * "Trace" (CUPTI activity records — kernel / memcpy / sync) is NOT a sub-engine
+ * here: it's the activity-record layer that `CuptiBackend` enables when the combo
+ * includes Trace (`collectsKernelEvents()`). This composite holds only the
+ * API-driven engines (PcSampling / SassMetrics / PmSampling / RangeProfiler).
+ *
+ * Lifecycle ordering: sub-engines are driven in a FIXED forward order for
+ * start, stop, and shutdown alike (the same convention the old composite used —
+ * NOT construct/reverse-destruct). The teardown-safety rule (a Profiler-API
+ * engine — SASS / Range — must be disabled BEFORE the PC-Sampling API) is
+ * satisfied by the backend supplying the list already ordered with PcSampling
+ * LAST. Forward-order stop then disables SASS/Range before PC.
+ */
+class CompositeEngine final : public IProfilingEngine {
+   public:
+    explicit CompositeEngine(std::vector<std::unique_ptr<IProfilingEngine>> engines)
+        : engines_(std::move(engines)) {}
+    ~CompositeEngine() override = default;
+
+    const char* name() const override { return "Composite"; }
+
+    bool initialize(const MonitorOptions& opts, const EngineContext& ctx) override {
+        for (auto& e : engines_) {
+            if (!e) continue;
+            const bool ok = e->initialize(opts, ctx);
+            GFL_LOG_DEBUG("[Composite] initialize ", e->name(), ok ? " ok" : " failed");
+        }
+        return true;
+    }
+
+    void start() override {
+        for (auto& e : engines_) if (e) e->start();
+    }
+    void stop() override {
+        for (auto& e : engines_) if (e) e->stop();
+    }
+    void shutdown() override {
+        for (auto& e : engines_) if (e) e->shutdown();
+    }
+
+    void onScopeStart(const char* n) override {
+        for (auto& e : engines_) if (e) e->onScopeStart(n);
+    }
+    void onScopeStop(const char* n) override {
+        for (auto& e : engines_) if (e) e->onScopeStop(n);
+    }
+    void onPerfScopeStart(const char* n) override {
+        for (auto& e : engines_) if (e) e->onPerfScopeStart(n);
+    }
+    void onPerfScopeStop(const char* n) override {
+        for (auto& e : engines_) if (e) e->onPerfScopeStop(n);
+    }
+    void drainData() override {
+        for (auto& e : engines_) if (e) e->drainData();
+    }
+    void flushBeforeCudaTeardown(const char* reason) override {
+        for (auto& e : engines_) if (e) e->flushBeforeCudaTeardown(reason);
+    }
+
+    std::optional<PerfMetricEvent> takeLastPerfEvent() override {
+        for (auto& e : engines_)
+            if (e) { if (auto ev = e->takeLastPerfEvent()) return ev; }
+        return std::nullopt;
+    }
+    bool hasInsufficientPrivileges() const override {
+        for (auto& e : engines_) if (e && e->hasInsufficientPrivileges()) return true;
+        return false;
+    }
+    bool isOperational() const override {
+        for (auto& e : engines_) if (e && e->isOperational()) return true;
+        return false;
+    }
+    bool producedData() const override {
+        for (auto& e : engines_) if (e && e->producedData()) return true;
+        return false;
+    }
+
+    /** The sub-engines, for per-engine capability reporting (which armed / produced). */
+    const std::vector<std::unique_ptr<IProfilingEngine>>& engines() const { return engines_; }
+
+   private:
+    std::vector<std::unique_ptr<IProfilingEngine>> engines_;
+};
+
+}  // namespace gpufl

--- a/include/gpufl/backends/nvidia/engine/pc_sampling_with_sass_engine.cpp
+++ b/include/gpufl/backends/nvidia/engine/pc_sampling_with_sass_engine.cpp
@@ -1,5 +1,7 @@
 #include "gpufl/backends/nvidia/engine/pc_sampling_with_sass_engine.hpp"
 
+#include "gpufl/core/env_vars.hpp"
+
 #include <cupti.h>
 
 #include <cstdlib>
@@ -34,7 +36,7 @@ namespace {
 // PC sampling is always the fallback, so a Deep session is never unsafe.
 bool ShouldAttemptSassInDeep() {
     // Manual escape hatch: force PC-sampling-only regardless of hardware.
-    if (const char* e = std::getenv("GPUFL_DEEP_PC_ONLY");
+    if (const char* e = std::getenv(gpufl::env::kDeepPcOnly);
         e && e[0] != '\0' && e[0] != '0') {
         return false;
     }
@@ -101,7 +103,7 @@ void PcSamplingWithSassEngine::start() {
         // there's nothing to disable (avoids the unsafe disable-PC-while-
         // Profiler-API-active teardown).
         bool tryBoth = false;
-        if (const char* e = std::getenv("GPUFL_DEEP_TRY_BOTH"))
+        if (const char* e = std::getenv(gpufl::env::kDeepTryBoth))
             tryBoth = (e[0] != '\0' && e[0] != '0');
 
         if (tryBoth && pc_) {

--- a/include/gpufl/backends/nvidia/engine/pm_sampling_engine.cpp
+++ b/include/gpufl/backends/nvidia/engine/pm_sampling_engine.cpp
@@ -129,6 +129,7 @@ bool PmSamplingEngine::InitializePmSampling_() {
     }
 
     GFL_LOG_DEBUG("[PmSamplingEngine] chip_name_ = ", ctx_.chip_name);
+    LogSinglePassSets_();
 
     CUpti_Profiler_GetCounterAvailability_Params ca = {
         CUpti_Profiler_GetCounterAvailability_Params_STRUCT_SIZE};
@@ -193,6 +194,87 @@ bool PmSamplingEngine::InitializePmSampling_() {
                   " interval_ns=", setConfig.samplingInterval,
                   " max_samples=", opts_.pm_sampling_max_samples);
     return true;
+}
+
+// List the chip's single-pass metric sets (the metric bundles collectible in one
+// pass, without kernel replay) and their metrics. The set names are chip-specific,
+// so they're queried at runtime. Read-only: chip-name queries, no host object, no
+// config / behavior change. Follows the CUPTI pm_sampling sample. Older CUPTI
+// (< 13.2) lacks the APIs, so this compiles to a no-op there.
+void PmSamplingEngine::LogSinglePassSets_() {
+#ifdef CUpti_Profiler_Host_GetSinglePassSets_Params_STRUCT_SIZE
+    if (ctx_.chip_name.empty()) return;
+
+    // Phase 1: count. Phase 2: fill the set-name list.
+    CUpti_Profiler_Host_GetSinglePassSets_Params sets = {
+        CUpti_Profiler_Host_GetSinglePassSets_Params_STRUCT_SIZE};
+    sets.pChipName = ctx_.chip_name.c_str();
+    if (LogCuptiErrorIfFailed(this->name(),
+                              "cuptiProfilerHostGetSinglePassSets(count)",
+                              cuptiProfilerHostGetSinglePassSets(&sets))) {
+        return;
+    }
+    if (sets.numOfSinglePassSets == 0) {
+        GFL_LOG_DEBUG("[PmSamplingEngine] chip ", ctx_.chip_name,
+                      " reports 0 single-pass metric sets");
+        return;
+    }
+    std::vector<const char*> setNames(sets.numOfSinglePassSets, nullptr);
+    sets.ppSinglePassSets = setNames.data();
+    if (LogCuptiErrorIfFailed(this->name(),
+                              "cuptiProfilerHostGetSinglePassSets(data)",
+                              cuptiProfilerHostGetSinglePassSets(&sets))) {
+        return;
+    }
+
+    GFL_LOG_DEBUG("[PmSamplingEngine] chip ", ctx_.chip_name,
+                  " single-pass metric sets: ", setNames.size());
+    for (const char* setName : setNames) {
+        if (!setName) continue;
+
+        // Phase 1: sizes. Phase 2: fill the packed metric-name buffer +
+        // per-metric start indices.
+        CUpti_Profiler_Host_GetMetricsInSinglePassSet_Params count = {
+            CUpti_Profiler_Host_GetMetricsInSinglePassSet_Params_STRUCT_SIZE};
+        count.pChipName = ctx_.chip_name.c_str();
+        count.pSinglePassSetName = setName;
+        if (LogCuptiErrorIfFailed(
+                this->name(),
+                "cuptiProfilerHostGetMetricsInSinglePassSet(count)",
+                cuptiProfilerHostGetMetricsInSinglePassSet(&count))) {
+            continue;
+        }
+        std::vector<uint8_t> buf(count.metricsBufferSize, 0);
+        std::vector<size_t> indices(count.numOfMetricsInSinglePassSet, 0);
+
+        CUpti_Profiler_Host_GetMetricsInSinglePassSet_Params data = {
+            CUpti_Profiler_Host_GetMetricsInSinglePassSet_Params_STRUCT_SIZE};
+        data.pChipName = ctx_.chip_name.c_str();
+        data.pSinglePassSetName = setName;
+        data.numOfMetricsInSinglePassSet = indices.size();
+        data.pMetricsIndicesBuffer = indices.data();
+        data.metricsBufferSize = buf.size();
+        data.pMetricsBuffer = buf.data();
+        if (LogCuptiErrorIfFailed(
+                this->name(),
+                "cuptiProfilerHostGetMetricsInSinglePassSet(data)",
+                cuptiProfilerHostGetMetricsInSinglePassSet(&data))) {
+            continue;
+        }
+
+        std::string joined;
+        for (size_t i = 0; i < indices.size(); ++i) {
+            if (indices[i] >= buf.size()) continue;
+            if (!joined.empty()) joined += ", ";
+            joined += reinterpret_cast<const char*>(&buf[indices[i]]);
+        }
+        GFL_LOG_DEBUG("[PmSamplingEngine]   single-pass set \"", setName,
+                      "\" (", indices.size(), " metrics): ", joined);
+    }
+#else
+    GFL_LOG_DEBUG("[PmSamplingEngine] single-pass-set query unavailable "
+                  "(CUPTI < 13.2)");
+#endif
 }
 
 bool PmSamplingEngine::BuildConfigImage_() {

--- a/include/gpufl/backends/nvidia/engine/pm_sampling_engine.hpp
+++ b/include/gpufl/backends/nvidia/engine/pm_sampling_engine.hpp
@@ -48,6 +48,11 @@ class PmSamplingEngine final : public IProfilingEngine {
 #if GPUFL_HAS_PERFWORKS
     bool InitializePmSampling_();
     bool BuildConfigImage_();
+    // Log the chip's single-pass metric sets (the metric bundles collectible
+    // in one pass) and their metrics. The set names are chip-specific, so
+    // they're queried at runtime. Read-only (chip query, no host object / no
+    // config change); CUPTI 13.2+.
+    void LogSinglePassSets_();
     bool CreateCounterDataImage_();
     void DecodeAndEmit_();
     void DisablePmSampling_();

--- a/include/gpufl/backends/nvidia/engine/profiling_engine.hpp
+++ b/include/gpufl/backends/nvidia/engine/profiling_engine.hpp
@@ -6,6 +6,7 @@
 #include <optional>
 #include <string>
 #include <unordered_map>
+#include <vector>
 
 #include "gpufl/backends/nvidia/cupti_common.hpp"
 #include "gpufl/core/events.hpp"
@@ -77,6 +78,11 @@ class IProfilingEngine {
     /** @brief Consume and return the last decoded perf-metric event. */
     virtual std::optional<PerfMetricEvent> takeLastPerfEvent() {
         return std::nullopt;
+    }
+
+    /** @brief Consume decoded kernel replay metric events, if any. */
+    virtual std::vector<KernelPerfMetricEvent> takeKernelPerfEvents() {
+        return {};
     }
 
     /**

--- a/include/gpufl/backends/nvidia/engine/range_profiler_engine.cpp
+++ b/include/gpufl/backends/nvidia/engine/range_profiler_engine.cpp
@@ -3,13 +3,13 @@
 #if GPUFL_HAS_PERFWORKS
 #include <cupti.h>
 #include <cupti_profiler_host.h>
-#include <cupti_profiler_target.h>
 #include <cupti_range_profiler.h>
-#include <nvperf_host.h>   // NVPW_CounterDataBuilder_* — deprecated but still
-                           // required in CUDA ≤13.x; no CUPTI Host equivalent yet
 #endif
 
+#include <algorithm>
 #include <cmath>
+#include <cstring>
+#include <iterator>
 
 #include "gpufl/backends/nvidia/cupti_utils.hpp"
 #include "gpufl/core/debug_logger.hpp"
@@ -41,17 +41,61 @@ void RangeProfilerEngine::start() {
 #if GPUFL_HAS_PERFWORKS
     attempted_.store(true, std::memory_order_relaxed);
     if (!perf_session_active_) {
-        InitPerfworksSession_();
+        InitPerfworksSession_(mode_ == Mode::Scope);
+    }
+    if (mode_ == Mode::KernelReplay && perf_session_active_) {
+        if (kernel_replay_running_) {
+            GFL_LOG_DEBUG("[RangeProfilerKernelReplay] start skipped: already running");
+            return;
+        }
+        CUpti_RangeProfiler_Start_Params p = {
+            CUpti_RangeProfiler_Start_Params_STRUCT_SIZE};
+        p.pRangeProfilerObject = range_profiler_object_;
+        if (LogCuptiErrorIfFailed(this->name(), "cuptiRangeProfilerStart",
+                                  cuptiRangeProfilerStart(&p))) {
+            return;
+        }
+        kernel_replay_running_ = true;
+        kernel_replay_decoded_ = false;
+        GFL_LOG_DEBUG("[RangeProfilerKernelReplay] started");
     }
 #else
     GFL_LOG_ERROR("[RangeProfilerEngine] Not built with GPUFL_HAS_PERFWORKS");
 #endif
 }
 
-void RangeProfilerEngine::stop() {}
+void RangeProfilerEngine::stop() {
+#if GPUFL_HAS_PERFWORKS
+    if (mode_ != Mode::KernelReplay || !perf_session_active_) return;
+    if (!kernel_replay_running_) {
+        GFL_LOG_DEBUG("[RangeProfilerKernelReplay] stop skipped: not running");
+        return;
+    }
+    CUpti_RangeProfiler_Stop_Params p = {
+        CUpti_RangeProfiler_Stop_Params_STRUCT_SIZE};
+    p.pRangeProfilerObject = range_profiler_object_;
+    CUptiResult result = cuptiRangeProfilerStop(&p);
+    kernel_replay_running_ = false;
+    if (LogCuptiErrorIfFailed(this->name(), "cuptiRangeProfilerStop",
+                              result)) {
+        return;
+    }
+    if (!p.isAllPassSubmitted) {
+        GFL_LOG_DEBUG("[RangeProfilerKernelReplay] stop returned "
+                      "isAllPassSubmitted=false");
+    }
+    if (!kernel_replay_decoded_) {
+        DecodeKernelReplayEvents_();
+        kernel_replay_decoded_ = true;
+    }
+#endif
+}
 
 void RangeProfilerEngine::shutdown() {
 #if GPUFL_HAS_PERFWORKS
+    if (mode_ == Mode::KernelReplay && kernel_replay_running_) {
+        stop();
+    }
     if (range_profiler_object_) {
         CUpti_RangeProfiler_Disable_Params p = {
             CUpti_RangeProfiler_Disable_Params_STRUCT_SIZE};
@@ -74,17 +118,19 @@ void RangeProfilerEngine::shutdown() {
                               cuptiProfilerDeInitialize(&dp));
         perf_session_active_ = false;
     }
+    kernel_replay_running_ = false;
 #endif
     operational_.store(false, std::memory_order_relaxed);
 }
 
 void RangeProfilerEngine::onPerfScopeStart(const char* name) {
 #if GPUFL_HAS_PERFWORKS
+    if (mode_ != Mode::Scope) return;
     attempted_.store(true, std::memory_order_relaxed);
     GFL_LOG_DEBUG("[RangeProfilerEngine] onPerfScopeStart name=",
                   (name ? name : "(null)"), " active=", perf_session_active_);
     if (!perf_session_active_) {
-        if (!InitPerfworksSession_()) return;
+        if (!InitPerfworksSession_(true)) return;
     }
     {
         CUpti_RangeProfiler_CounterDataImage_Initialize_Params p = {
@@ -121,6 +167,7 @@ void RangeProfilerEngine::onPerfScopeStart(const char* name) {
 
 void RangeProfilerEngine::onPerfScopeStop(const char* name) {
 #if GPUFL_HAS_PERFWORKS
+    if (mode_ != Mode::Scope) return;
     GFL_LOG_DEBUG("[RangeProfilerEngine] onPerfScopeStop name=",
                   (name ? name : "(null)"), " active=", perf_session_active_);
     if (!perf_session_active_) {
@@ -145,6 +192,7 @@ void RangeProfilerEngine::onPerfScopeStop(const char* name) {
         if (!p.isAllPassSubmitted) {
             GFL_LOG_DEBUG("[RangeProfiler] Additional replay passes required; "
                           "metrics may be partial in this run");
+            return;
         }
     }
     EndPerfPassAndDecode_();
@@ -166,11 +214,26 @@ std::optional<PerfMetricEvent> RangeProfilerEngine::takeLastPerfEvent() {
 #endif
 }
 
+std::vector<KernelPerfMetricEvent> RangeProfilerEngine::takeKernelPerfEvents() {
+#if GPUFL_HAS_PERFWORKS
+    std::lock_guard<std::mutex> lk(perf_mu_);
+    std::vector<KernelPerfMetricEvent> out;
+    out.swap(kernel_perf_events_);
+    return out;
+#else
+    return {};
+#endif
+}
+
 // ---- Private (Perfworks) ---------------------------------------------------
 
 #if GPUFL_HAS_PERFWORKS
 
 bool RangeProfilerEngine::InitPerfworksSession_() {
+    return InitPerfworksSession_(mode_ == Mode::Scope);
+}
+
+bool RangeProfilerEngine::InitPerfworksSession_(bool require_single_pass) {
     if (!ctx_.cuda_ctx) {
         GFL_LOG_ERROR("[RangeProfilerEngine] No CUDA context available");
         return false;
@@ -217,7 +280,17 @@ bool RangeProfilerEngine::InitPerfworksSession_() {
         }
     }
 
-    {
+    auto deinitHostObject = [&]() {
+        if (!perf_host_object_) return true;
+        CUpti_Profiler_Host_Deinitialize_Params p = {
+            CUpti_Profiler_Host_Deinitialize_Params_STRUCT_SIZE};
+        p.pHostObject = perf_host_object_;
+        perf_host_object_ = nullptr;
+        return !LogCuptiErrorIfFailed(this->name(), "cuptiProfilerHostDeinitialize",
+                                      cuptiProfilerHostDeinitialize(&p));
+    };
+
+    auto initHostObject = [&]() {
         CUpti_Profiler_Host_Initialize_Params hi = {
             CUpti_Profiler_Host_Initialize_Params_STRUCT_SIZE};
         hi.profilerType              = CUPTI_PROFILER_TYPE_RANGE_PROFILER;
@@ -228,105 +301,115 @@ bool RangeProfilerEngine::InitPerfworksSession_() {
             return false;
         }
         perf_host_object_ = hi.pHostObject;
-    }
-    {
+        return true;
+    };
+
+    auto addMetric = [&](const char* metricName) {
         CUpti_Profiler_Host_ConfigAddMetrics_Params am = {
             CUpti_Profiler_Host_ConfigAddMetrics_Params_STRUCT_SIZE};
         am.pHostObject    = perf_host_object_;
-        am.ppMetricNames  = kPerfMetricNames.data();
-        am.numMetrics     = kPerfMetricNames.size();
-        if (LogCuptiErrorIfFailed(this->name(),
-                                  "cuptiProfilerHostConfigAddMetrics",
-                                  cuptiProfilerHostConfigAddMetrics(&am))) {
-            return false;
+        am.ppMetricNames  = &metricName;
+        am.numMetrics     = 1;
+        CUptiResult res = cuptiProfilerHostConfigAddMetrics(&am);
+        if (res == CUPTI_SUCCESS) {
+            active_metric_names_.push_back(metricName);
+            GFL_LOG_DEBUG("[RangeProfilerEngine] accepted metric ", metricName);
+            return true;
         }
-    }
-    {
-        CUpti_Profiler_Host_GetConfigImageSize_Params gs = {
-            CUpti_Profiler_Host_GetConfigImageSize_Params_STRUCT_SIZE};
-        gs.pHostObject = perf_host_object_;
-        if (LogCuptiErrorIfFailed(this->name(),
-                                  "cuptiProfilerHostGetConfigImageSize",
-                                  cuptiProfilerHostGetConfigImageSize(&gs))) {
-            return false;
-        }
-        perf_config_image_.resize(gs.configImageSize);
-    }
-    {
-        CUpti_Profiler_Host_GetConfigImage_Params gc = {
-            CUpti_Profiler_Host_GetConfigImage_Params_STRUCT_SIZE};
-        gc.pHostObject      = perf_host_object_;
-        gc.configImageSize  = perf_config_image_.size();
-        gc.pConfigImage     = perf_config_image_.data();
-        if (LogCuptiErrorIfFailed(this->name(),
-                                  "cuptiProfilerHostGetConfigImage",
-                                  cuptiProfilerHostGetConfigImage(&gc))) {
-            return false;
-        }
-    }
+        GFL_LOG_DEBUG("[RangeProfilerEngine] skipping unsupported metric ",
+                      metricName, " result=", static_cast<int>(res));
+        return false;
+    };
 
-    // Build counter data prefix via NVPW_CounterDataBuilder_*.
-    // TODO: migrate to cuptiProfilerHostGetCounterDataPrefixImage* once the
-    //       CUDA toolkit provides those symbols (not available in CUDA ≤13.x).
-    std::vector<uint8_t> counterDataPrefix;
-    {
-        NVPW_InitializeHost_Params ihp = {NVPW_InitializeHost_Params_STRUCT_SIZE};
-        if (NVPW_InitializeHost(&ihp) != NVPA_STATUS_SUCCESS) {
-            GFL_LOG_ERROR("[RangeProfilerEngine] NVPW_InitializeHost failed");
-            return false;
-        }
-
-        NVPW_CounterDataBuilder_Create_Params cbcp = {
-            NVPW_CounterDataBuilder_Create_Params_STRUCT_SIZE};
-        cbcp.pChipName = ctx_.chip_name.c_str();
-        if (NVPW_CounterDataBuilder_Create(&cbcp) != NVPA_STATUS_SUCCESS) {
-            GFL_LOG_ERROR("[RangeProfilerEngine] NVPW_CounterDataBuilder_Create failed");
-            return false;
-        }
-        NVPA_CounterDataBuilder* builder = cbcp.pCounterDataBuilder;
-
+    auto buildConfigImage = [&](size_t& numPasses) {
         {
-            std::vector<NVPA_RawMetricRequest> reqs(kPerfMetricNames.size());
-            for (size_t i = 0; i < kPerfMetricNames.size(); ++i) {
-                reqs[i].structSize    = NVPA_RAW_METRIC_REQUEST_STRUCT_SIZE;
-                reqs[i].pMetricName   = kPerfMetricNames[i];
-                reqs[i].isolated      = 1;
-                reqs[i].keepInstances = 1;
+            CUpti_Profiler_Host_GetConfigImageSize_Params gs = {
+                CUpti_Profiler_Host_GetConfigImageSize_Params_STRUCT_SIZE};
+            gs.pHostObject = perf_host_object_;
+            if (LogCuptiErrorIfFailed(this->name(),
+                                      "cuptiProfilerHostGetConfigImageSize",
+                                      cuptiProfilerHostGetConfigImageSize(&gs))) {
+                return false;
             }
-            NVPW_CounterDataBuilder_AddMetrics_Params amp = {
-                NVPW_CounterDataBuilder_AddMetrics_Params_STRUCT_SIZE};
-            amp.pCounterDataBuilder = builder;
-            amp.pRawMetricRequests  = reqs.data();
-            amp.numMetricRequests   = kPerfMetricNames.size();
-            NVPW_CounterDataBuilder_AddMetrics(&amp);
+            perf_config_image_.assign(gs.configImageSize, 0);
         }
         {
-            NVPW_CounterDataBuilder_GetCounterDataPrefix_Params gcp = {
-                NVPW_CounterDataBuilder_GetCounterDataPrefix_Params_STRUCT_SIZE};
-            gcp.pCounterDataBuilder = builder;
-            gcp.bytesAllocated      = 0;
-            gcp.pBuffer             = nullptr;
-            NVPW_CounterDataBuilder_GetCounterDataPrefix(&gcp);
-            counterDataPrefix.resize(gcp.bytesCopied);
-            gcp.bytesAllocated = counterDataPrefix.size();
-            gcp.pBuffer        = counterDataPrefix.data();
-            NVPW_CounterDataBuilder_GetCounterDataPrefix(&gcp);
+            CUpti_Profiler_Host_GetConfigImage_Params gc = {
+                CUpti_Profiler_Host_GetConfigImage_Params_STRUCT_SIZE};
+            gc.pHostObject      = perf_host_object_;
+            gc.configImageSize  = perf_config_image_.size();
+            gc.pConfigImage     = perf_config_image_.data();
+            if (LogCuptiErrorIfFailed(this->name(),
+                                      "cuptiProfilerHostGetConfigImage",
+                                      cuptiProfilerHostGetConfigImage(&gc))) {
+                return false;
+            }
         }
         {
-            NVPW_CounterDataBuilder_Destroy_Params dp = {
-                NVPW_CounterDataBuilder_Destroy_Params_STRUCT_SIZE};
-            dp.pCounterDataBuilder = builder;
-            NVPW_CounterDataBuilder_Destroy(&dp);
+            CUpti_Profiler_Host_GetNumOfPasses_Params p = {
+                CUpti_Profiler_Host_GetNumOfPasses_Params_STRUCT_SIZE};
+            p.configImageSize = perf_config_image_.size();
+            p.pConfigImage    = perf_config_image_.data();
+            if (LogCuptiErrorIfFailed(this->name(),
+                                      "cuptiProfilerHostGetNumOfPasses",
+                                      cuptiProfilerHostGetNumOfPasses(&p))) {
+                return false;
+            }
+            numPasses = p.numOfPasses;
+            GFL_LOG_DEBUG("[RangeProfilerEngine] config requires ",
+                          numPasses, " pass(es)");
         }
+        return true;
+    };
+
+    if (!initHostObject()) return false;
+    active_metric_names_.clear();
+    for (const char* metricName : kPerfMetricNames) {
+        addMetric(metricName);
+    }
+    if (active_metric_names_.empty()) {
+        GFL_LOG_ERROR("[RangeProfilerEngine] no Range Profiler metrics were accepted");
+        return false;
     }
 
-    CUpti_Profiler_CounterDataImageOptions cdOpts = {
-        CUpti_Profiler_CounterDataImageOptions_STRUCT_SIZE};
-    cdOpts.pCounterDataPrefix    = counterDataPrefix.data();
-    cdOpts.counterDataPrefixSize = counterDataPrefix.size();
-    cdOpts.maxNumRanges          = 8;
-    cdOpts.maxNumRangeTreeNodes  = 8;
-    cdOpts.maxRangeNameLength    = 128;
+    size_t numPasses = 0;
+    if (!buildConfigImage(numPasses)) return false;
+    if (require_single_pass && numPasses > 1 && active_metric_names_.size() > 1) {
+        std::vector<const char*> candidateMetricNames = active_metric_names_;
+        GFL_LOG_DEBUG("[RangeProfilerEngine] metric group requires ",
+                      numPasses, " passes; searching for a single-pass metric");
+        bool foundSinglePassMetric = false;
+        for (const char* singlePassMetric : candidateMetricNames) {
+            if (!deinitHostObject()) return false;
+            if (!initHostObject()) return false;
+            active_metric_names_.clear();
+            if (!addMetric(singlePassMetric)) continue;
+            if (!buildConfigImage(numPasses)) return false;
+            if (numPasses <= 1) {
+                foundSinglePassMetric = true;
+                GFL_LOG_DEBUG("[RangeProfilerEngine] using single-pass metric ",
+                              singlePassMetric);
+                break;
+            }
+            GFL_LOG_DEBUG("[RangeProfilerEngine] metric ", singlePassMetric,
+                          " still requires ", numPasses, " passes");
+        }
+        if (!foundSinglePassMetric) {
+            GFL_LOG_ERROR("[RangeProfilerEngine] no accepted Range Profiler "
+                          "metric can be collected in one pass");
+            return false;
+        }
+    }
+    if (require_single_pass && numPasses > 1) {
+        GFL_LOG_ERROR("[RangeProfilerEngine] Range Profiler metric config requires ",
+                      numPasses, " passes; scope-hook profiling only supports "
+                      "single-pass metrics");
+        return false;
+    }
+
+    const size_t   maxNumRanges = mode_ == Mode::KernelReplay ? 1024 : 8;
+    const uint32_t maxNumRangeTreeNodes =
+        mode_ == Mode::KernelReplay ? 1024 : 8;
 
     {
         CUpti_RangeProfiler_Enable_Params p = {
@@ -342,10 +425,10 @@ bool RangeProfilerEngine::InitPerfworksSession_() {
         CUpti_RangeProfiler_GetCounterDataSize_Params p = {
             CUpti_RangeProfiler_GetCounterDataSize_Params_STRUCT_SIZE};
         p.pRangeProfilerObject = range_profiler_object_;
-        p.pMetricNames         = kPerfMetricNames.data();
-        p.numMetrics           = kPerfMetricNames.size();
-        p.maxNumOfRanges       = cdOpts.maxNumRanges;
-        p.maxNumRangeTreeNodes = cdOpts.maxNumRangeTreeNodes;
+        p.pMetricNames         = active_metric_names_.data();
+        p.numMetrics           = active_metric_names_.size();
+        p.maxNumOfRanges       = maxNumRanges;
+        p.maxNumRangeTreeNodes = maxNumRangeTreeNodes;
         if (LogCuptiErrorIfFailed(
                 "RangeProfiler", "cuptiRangeProfilerGetCounterDataSize",
                 cuptiRangeProfilerGetCounterDataSize(&p))) {
@@ -374,9 +457,12 @@ bool RangeProfilerEngine::InitPerfworksSession_() {
         p.pConfig                = perf_config_image_.data();
         p.counterDataImageSize   = perf_counter_data_image_.size();
         p.pCounterDataImage      = perf_counter_data_image_.data();
-        p.range                  = CUPTI_UserRange;
-        p.replayMode             = CUPTI_UserReplay;
-        p.maxRangesPerPass       = 1;
+        p.range                  = mode_ == Mode::KernelReplay
+                                   ? CUPTI_AutoRange : CUPTI_UserRange;
+        p.replayMode             = mode_ == Mode::KernelReplay
+                                   ? CUPTI_KernelReplay : CUPTI_UserReplay;
+        p.maxRangesPerPass       = mode_ == Mode::KernelReplay
+                                   ? maxNumRanges : 1;
         p.numNestingLevels       = 1;
         p.minNestingLevel        = 1;
         p.passIndex              = 0;
@@ -432,8 +518,8 @@ void RangeProfilerEngine::EndPerfPassAndDecode_() {
         return;
     }
 
-    std::vector<const char*> metricNames = kPerfMetricNames;
-    std::vector<double>      values(kPerfMetricNames.size(), -1.0);
+    std::vector<const char*> metricNames = active_metric_names_;
+    std::vector<double>      values(active_metric_names_.size(), -1.0);
 
     CUpti_Profiler_Host_EvaluateToGpuValues_Params p = {
         CUpti_Profiler_Host_EvaluateToGpuValues_Params_STRUCT_SIZE};
@@ -458,25 +544,146 @@ void RangeProfilerEngine::EndPerfPassAndDecode_() {
 
     std::lock_guard<std::mutex> lk(perf_mu_);
     perf_last_event_ = PerfMetricEvent{};
-    if (!values.empty() && std::isfinite(values[0]))
-        perf_last_event_.sm_throughput_pct = values[0];
-    if (values.size() > 1)
-        perf_last_event_.l1_hit_rate_pct =
-            std::isfinite(values[1]) ? values[1] : -1.0;
-    if (values.size() > 2)
-        perf_last_event_.l2_hit_rate_pct =
-            std::isfinite(values[2]) ? values[2] : -1.0;
-    if (values.size() > 3)
-        perf_last_event_.dram_read_bytes =
-            (values[3] >= 0.0) ? static_cast<uint64_t>(values[3]) : 0;
-    if (values.size() > 4)
-        perf_last_event_.dram_write_bytes =
-            (values[4] >= 0.0) ? static_cast<uint64_t>(values[4]) : 0;
-    if (values.size() > 5 && std::isfinite(values[5]))
-        perf_last_event_.tensor_active_pct = values[5];
+    for (size_t i = 0; i < metricNames.size() && i < values.size(); ++i) {
+        const char* metricName = metricNames[i];
+        const double value = values[i];
+        if (std::strcmp(metricName, "sm__throughput.avg.pct_of_peak_sustained_elapsed") == 0) {
+            if (std::isfinite(value)) perf_last_event_.sm_throughput_pct = value;
+        } else if (std::strcmp(metricName, "l1tex__t_sector_hit_rate.pct") == 0) {
+            perf_last_event_.l1_hit_rate_pct = std::isfinite(value) ? value : -1.0;
+        } else if (std::strcmp(metricName, "lts__t_sector_hit_rate.pct") == 0) {
+            perf_last_event_.l2_hit_rate_pct = std::isfinite(value) ? value : -1.0;
+        } else if (std::strcmp(metricName, "dram__bytes_read.sum") == 0) {
+            perf_last_event_.dram_read_bytes =
+                (value >= 0.0) ? static_cast<int64_t>(value) : -1;
+        } else if (std::strcmp(metricName, "dram__bytes_write.sum") == 0) {
+            perf_last_event_.dram_write_bytes =
+                (value >= 0.0) ? static_cast<int64_t>(value) : -1;
+        } else if (std::strcmp(metricName, "sm__pipe_tensor_cycles_active.avg.pct_of_peak_sustained_active") == 0) {
+            if (std::isfinite(value)) perf_last_event_.tensor_active_pct = value;
+        }
+    }
     perf_has_event_ = true;
     produced_data_.store(true, std::memory_order_relaxed);
     GFL_LOG_DEBUG("[RangeProfilerEngine] Decoded metrics, perf_has_event_=true");
+}
+
+void RangeProfilerEngine::DecodeKernelReplayEvents_() {
+    if (!perf_host_object_ || !range_profiler_object_) {
+        GFL_LOG_DEBUG("[RangeProfilerKernelReplay] decode skipped: "
+                      "profiler object is null");
+        return;
+    }
+    {
+        CUpti_RangeProfiler_DecodeData_Params p = {
+            CUpti_RangeProfiler_DecodeData_Params_STRUCT_SIZE};
+        p.pRangeProfilerObject = range_profiler_object_;
+        if (LogCuptiErrorIfFailed(this->name(),
+                                  "cuptiRangeProfilerDecodeData",
+                                  cuptiRangeProfilerDecodeData(&p))) {
+            return;
+        }
+        if (p.numOfRangeDropped > 0) {
+            GFL_LOG_DEBUG("[RangeProfilerKernelReplay] Dropped ranges: ",
+                          p.numOfRangeDropped);
+        }
+    }
+
+    size_t numRanges = 0;
+    {
+        CUpti_RangeProfiler_GetCounterDataInfo_Params p = {
+            CUpti_RangeProfiler_GetCounterDataInfo_Params_STRUCT_SIZE};
+        p.pCounterDataImage    = perf_counter_data_image_.data();
+        p.counterDataImageSize = perf_counter_data_image_.size();
+        if (LogCuptiErrorIfFailed(this->name(),
+                                  "cuptiRangeProfilerGetCounterDataInfo",
+                                  cuptiRangeProfilerGetCounterDataInfo(&p))) {
+            return;
+        }
+        numRanges = p.numTotalRanges;
+    }
+    if (numRanges == 0) {
+        GFL_LOG_DEBUG("[RangeProfilerKernelReplay] no ranges decoded");
+        return;
+    }
+
+    std::vector<KernelPerfMetricEvent> decoded;
+    decoded.reserve(numRanges);
+    std::vector<const char*> metricNames = active_metric_names_;
+    std::vector<double> values(active_metric_names_.size(), -1.0);
+
+    for (size_t rangeIndex = 0; rangeIndex < numRanges; ++rangeIndex) {
+        std::fill(values.begin(), values.end(), -1.0);
+        const char* rangeName = "";
+        {
+            CUpti_RangeProfiler_CounterData_GetRangeInfo_Params p = {
+                CUpti_RangeProfiler_CounterData_GetRangeInfo_Params_STRUCT_SIZE};
+            p.pCounterDataImage    = perf_counter_data_image_.data();
+            p.counterDataImageSize = perf_counter_data_image_.size();
+            p.rangeIndex           = rangeIndex;
+            p.rangeDelimiter       = "/";
+            if (!LogCuptiErrorIfFailed(
+                    this->name(), "cuptiRangeProfilerCounterDataGetRangeInfo",
+                    cuptiRangeProfilerCounterDataGetRangeInfo(&p))) {
+                rangeName = p.rangeName ? p.rangeName : "";
+            }
+        }
+        {
+            CUpti_Profiler_Host_EvaluateToGpuValues_Params p = {
+                CUpti_Profiler_Host_EvaluateToGpuValues_Params_STRUCT_SIZE};
+            p.pHostObject          = perf_host_object_;
+            p.pCounterDataImage    = perf_counter_data_image_.data();
+            p.counterDataImageSize = perf_counter_data_image_.size();
+            p.rangeIndex           = rangeIndex;
+            p.ppMetricNames        = metricNames.data();
+            p.numMetrics           = metricNames.size();
+            p.pMetricValues        = values.data();
+            if (LogCuptiErrorIfFailed(
+                    this->name(), "cuptiProfilerHostEvaluateToGpuValues",
+                    cuptiProfilerHostEvaluateToGpuValues(&p))) {
+                continue;
+            }
+        }
+
+        KernelPerfMetricEvent ev;
+        ev.device_id = static_cast<int>(ctx_.device_id);
+        ev.range_index = rangeIndex;
+        ev.range_name = rangeName;
+        ev.kernel_name = rangeName;
+        ev.launch_ordinal = static_cast<uint32_t>(rangeIndex + 1);
+        for (size_t i = 0; i < metricNames.size() && i < values.size(); ++i) {
+            const char* metricName = metricNames[i];
+            const double value = values[i];
+            if (std::strcmp(metricName, "sm__throughput.avg.pct_of_peak_sustained_elapsed") == 0) {
+                if (std::isfinite(value)) ev.sm_throughput_pct = value;
+            } else if (std::strcmp(metricName, "l1tex__t_sector_hit_rate.pct") == 0) {
+                ev.l1_hit_rate_pct = std::isfinite(value) ? value : -1.0;
+            } else if (std::strcmp(metricName, "lts__t_sector_hit_rate.pct") == 0) {
+                ev.l2_hit_rate_pct = std::isfinite(value) ? value : -1.0;
+            } else if (std::strcmp(metricName, "dram__bytes_read.sum") == 0) {
+                ev.dram_read_bytes =
+                    (value >= 0.0) ? static_cast<int64_t>(value) : -1;
+            } else if (std::strcmp(metricName, "dram__bytes_write.sum") == 0) {
+                ev.dram_write_bytes =
+                    (value >= 0.0) ? static_cast<int64_t>(value) : -1;
+            } else if (std::strcmp(metricName, "sm__pipe_tensor_cycles_active.avg.pct_of_peak_sustained_active") == 0) {
+                if (std::isfinite(value)) ev.tensor_active_pct = value;
+            }
+        }
+        decoded.push_back(std::move(ev));
+    }
+
+    {
+        std::lock_guard<std::mutex> lk(perf_mu_);
+        kernel_perf_events_.insert(kernel_perf_events_.end(),
+                                   std::make_move_iterator(decoded.begin()),
+                                   std::make_move_iterator(decoded.end()));
+    }
+    if (!decoded.empty()) {
+        produced_data_.store(true, std::memory_order_relaxed);
+        GFL_LOG_DEBUG("[RangeProfilerKernelReplay] decoded ",
+                      decoded.size(), " kernel range event(s)");
+    }
 }
 
 #endif  // GPUFL_HAS_PERFWORKS

--- a/include/gpufl/backends/nvidia/engine/range_profiler_engine.cpp
+++ b/include/gpufl/backends/nvidia/engine/range_profiler_engine.cpp
@@ -39,6 +39,7 @@ bool RangeProfilerEngine::initialize(const MonitorOptions& opts,
 
 void RangeProfilerEngine::start() {
 #if GPUFL_HAS_PERFWORKS
+    attempted_.store(true, std::memory_order_relaxed);
     if (!perf_session_active_) {
         InitPerfworksSession_();
     }
@@ -74,10 +75,12 @@ void RangeProfilerEngine::shutdown() {
         perf_session_active_ = false;
     }
 #endif
+    operational_.store(false, std::memory_order_relaxed);
 }
 
 void RangeProfilerEngine::onPerfScopeStart(const char* name) {
 #if GPUFL_HAS_PERFWORKS
+    attempted_.store(true, std::memory_order_relaxed);
     GFL_LOG_DEBUG("[RangeProfilerEngine] onPerfScopeStart name=",
                   (name ? name : "(null)"), " active=", perf_session_active_);
     if (!perf_session_active_) {
@@ -385,6 +388,7 @@ bool RangeProfilerEngine::InitPerfworksSession_() {
     }
 
     perf_session_active_ = true;
+    operational_.store(true, std::memory_order_relaxed);
     GFL_LOG_DEBUG("[RangeProfilerEngine] Session initialized for chip: ",
                   ctx_.chip_name);
     return true;
@@ -471,6 +475,7 @@ void RangeProfilerEngine::EndPerfPassAndDecode_() {
     if (values.size() > 5 && std::isfinite(values[5]))
         perf_last_event_.tensor_active_pct = values[5];
     perf_has_event_ = true;
+    produced_data_.store(true, std::memory_order_relaxed);
     GFL_LOG_DEBUG("[RangeProfilerEngine] Decoded metrics, perf_has_event_=true");
 }
 

--- a/include/gpufl/backends/nvidia/engine/range_profiler_engine.hpp
+++ b/include/gpufl/backends/nvidia/engine/range_profiler_engine.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <atomic>
 #include <mutex>
 #include <optional>
 #include <vector>
@@ -29,6 +30,13 @@ class RangeProfilerEngine final : public IProfilingEngine {
     void onPerfScopeStop(const char* name)  override;
 
     std::optional<PerfMetricEvent> takeLastPerfEvent() override;
+    bool isOperational() const override {
+        return operational_.load(std::memory_order_relaxed) ||
+               attempted_.load(std::memory_order_relaxed);
+    }
+    bool producedData() const override {
+        return produced_data_.load(std::memory_order_relaxed);
+    }
 
    private:
 #if GPUFL_HAS_PERFWORKS
@@ -48,6 +56,9 @@ class RangeProfilerEngine final : public IProfilingEngine {
 
     MonitorOptions opts_;
     EngineContext  ctx_;
+    std::atomic<bool> operational_{false};
+    std::atomic<bool> attempted_{false};
+    std::atomic<bool> produced_data_{false};
 };
 
 }  // namespace gpufl

--- a/include/gpufl/backends/nvidia/engine/range_profiler_engine.hpp
+++ b/include/gpufl/backends/nvidia/engine/range_profiler_engine.hpp
@@ -16,9 +16,18 @@ namespace gpufl {
 
 class RangeProfilerEngine final : public IProfilingEngine {
    public:
-    RangeProfilerEngine() = default;
+    enum class Mode {
+        Scope,
+        KernelReplay,
+    };
+
+    explicit RangeProfilerEngine(Mode mode = Mode::Scope) : mode_(mode) {}
     ~RangeProfilerEngine() override { shutdown(); }
-    const char* name() const override { return "RangeProfilerEngine"; }
+    const char* name() const override {
+        return mode_ == Mode::KernelReplay
+            ? "RangeProfilerKernelReplayEngine"
+            : "RangeProfilerEngine";
+    }
 
     bool initialize(const MonitorOptions& opts,
                     const EngineContext& ctx) override;
@@ -30,6 +39,7 @@ class RangeProfilerEngine final : public IProfilingEngine {
     void onPerfScopeStop(const char* name)  override;
 
     std::optional<PerfMetricEvent> takeLastPerfEvent() override;
+    std::vector<KernelPerfMetricEvent> takeKernelPerfEvents() override;
     bool isOperational() const override {
         return operational_.load(std::memory_order_relaxed) ||
                attempted_.load(std::memory_order_relaxed);
@@ -37,23 +47,31 @@ class RangeProfilerEngine final : public IProfilingEngine {
     bool producedData() const override {
         return produced_data_.load(std::memory_order_relaxed);
     }
+    bool kernelReplayMode() const { return mode_ == Mode::KernelReplay; }
 
    private:
 #if GPUFL_HAS_PERFWORKS
     bool InitPerfworksSession_();
+    bool InitPerfworksSession_(bool require_single_pass);
     void EndPerfPassAndDecode_();
+    void DecodeKernelReplayEvents_();
 
     bool                       perf_session_active_  = false;
     mutable std::mutex         perf_mu_;
     std::vector<uint8_t>       perf_counter_data_image_;
     std::vector<uint8_t>       perf_config_image_;
     std::vector<uint8_t>       perf_scratch_buffer_;
+    std::vector<const char*>    active_metric_names_;
     CUpti_RangeProfiler_Object* range_profiler_object_ = nullptr;
     CUpti_Profiler_Host_Object* perf_host_object_      = nullptr;
     PerfMetricEvent             perf_last_event_;
     bool                        perf_has_event_       = false;
+    std::vector<KernelPerfMetricEvent> kernel_perf_events_;
+    bool                        kernel_replay_running_ = false;
+    bool                        kernel_replay_decoded_ = false;
 #endif
 
+    Mode mode_ = Mode::Scope;
     MonitorOptions opts_;
     EngineContext  ctx_;
     std::atomic<bool> operational_{false};

--- a/include/gpufl/backends/nvidia/engine/sass_metrics_engine.cpp
+++ b/include/gpufl/backends/nvidia/engine/sass_metrics_engine.cpp
@@ -1,5 +1,7 @@
 #include "gpufl/backends/nvidia/engine/sass_metrics_engine.hpp"
 
+#include "gpufl/core/env_vars.hpp"
+
 #include <cupti.h>
 #include <cupti_pcsampling.h>
 #include <cupti_profiler_target.h>
@@ -137,7 +139,7 @@ bool CcMatchesToken(const ComputeCapability& cc, const char* begin,
 // over-exclude when the capability query failed).
 bool ArchExcludedForSass(const ComputeCapability& cc) {
     if (!cc.valid()) return false;
-    const char* env = std::getenv("GPUFL_SASS_EXCLUDE_ARCHS");
+    const char* env = std::getenv(gpufl::env::kSassExcludeArchs);
     const char* list = env ? env : kDefaultSassExcludeArchs;
     if (!list || !*list) return false;
 
@@ -160,14 +162,14 @@ bool ShouldUseLazyPatching() {
     // Isolation test: keep main-like SASS start timing and kernel activity, but
     // switch lazy patching off by default to test whether eager patching causes
     // the all-zero SASS counter behavior.
-    return EnvFlagEnabled("GPUFL_SASS_LAZY_PATCHING");
+    return EnvFlagEnabled(gpufl::env::kSassLazyPatching);
 }
 
 bool ShouldDeferScopeFlush() {
     // Diagnostic mode: keep SASS armed across scope boundaries and flush only
     // at session stop/shutdown. This separates "SASS + activity" issues from
     // "disable/flush raced a concurrent framework launch" issues.
-    return EnvFlagEnabled("GPUFL_SASS_DEFER_SCOPE_FLUSH");
+    return EnvFlagEnabled(gpufl::env::kSassDeferScopeFlush);
 }
 }  // namespace
 

--- a/include/gpufl/backends/nvidia/kernel_launch_handler.cpp
+++ b/include/gpufl/backends/nvidia/kernel_launch_handler.cpp
@@ -217,21 +217,15 @@ KernelLaunchHandler::requiredCallbacks() const {
 
 std::vector<CUpti_ActivityKind> KernelLaunchHandler::requiredActivityKinds()
     const {
-    if (backend_ && backend_->GetOptions().profiling_engine ==
-                        ProfilingEngine::PcSampling) {
+    // Single source of truth for whether CUPTI kernel ACTIVITY is collected:
+    // CuptiBackend::collectsKernelEvents() (covers single engines AND combos).
+    // When false (PC sampling, or SASS safe mode), launch callbacks provide
+    // synthetic kernel rows instead.
+    if (backend_ && !backend_->collectsKernelEvents()) {
         GFL_LOG_DEBUG(
-            "[KernelLaunchHandler] CUPTI kernel activity disabled in PC "
-            "Sampling mode; launch callbacks will provide synthetic kernel "
+            "[KernelLaunchHandler] CUPTI kernel activity disabled for this "
+            "engine selection; launch callbacks will provide synthetic kernel "
             "rows.");
-        return {};
-    }
-
-    if (backend_ && !backend_->AllowSassKernelActivity()) {
-        GFL_LOG_DEBUG(
-            "[KernelLaunchHandler] CUPTI kernel activity disabled in SASS "
-            "profiler safe mode; launch callbacks will provide synthetic "
-            "kernel rows. Set GPUFL_SASS_ALLOW_KERNEL_ACTIVITY=1 to test "
-            "CONCURRENT_KERNEL explicitly.");
         return {};
     }
 

--- a/include/gpufl/backends/nvidia/kernel_launch_handler.cpp
+++ b/include/gpufl/backends/nvidia/kernel_launch_handler.cpp
@@ -1,5 +1,7 @@
 #include "gpufl/backends/nvidia/kernel_launch_handler.hpp"
 
+#include "gpufl/core/env_vars.hpp"
+
 #include <algorithm>  // std::min(initializer_list) — see occupancy calc below
 #include <cstdio>
 #include <cstdlib>
@@ -324,8 +326,8 @@ void KernelLaunchHandler::handle(CUpti_CallbackDomain domain,
             std::snprintf(metaRec.user_scope, sizeof(metaRec.user_scope), "%s",
                           fullPath.c_str());
             metaRec.scope_depth = stack.size();
-        } else if (const char* injectedApp = std::getenv("GPUFL_APP_NAME")) {
-            if (std::getenv("GPUFL_INJECT") && injectedApp[0] != '\0') {
+        } else if (const char* injectedApp = std::getenv(gpufl::env::kAppName)) {
+            if (std::getenv(gpufl::env::kInject) && injectedApp[0] != '\0') {
                 std::string processScope = "process:";
                 processScope += injectedApp;
                 std::snprintf(metaRec.user_scope, sizeof(metaRec.user_scope),

--- a/include/gpufl/backends/nvidia/kernel_launch_handler.cpp
+++ b/include/gpufl/backends/nvidia/kernel_launch_handler.cpp
@@ -452,10 +452,20 @@ bool KernelLaunchHandler::handleActivityRecord(const CUpti_Activity* record,
 
     const auto* k = reinterpret_cast<const CUpti_ActivityKernel11*>(record);
     backend_->kernel_activity_seen_.fetch_add(1, std::memory_order_relaxed);
+    const char* kernelName = k->name ? k->name : "";
+    const bool looksLikeReplayWait =
+        std::strcmp(kernelName, "WaitNs") == 0 &&
+        k->gridX == 1 && k->gridY == 1 && k->gridZ == 1 &&
+        k->blockX == 1 && k->blockY == 1 && k->blockZ == 1;
+    if (backend_->UsesRangeProfilerKernelReplay() && looksLikeReplayWait) {
+        GFL_LOG_DEBUG("[KernelLaunchHandler] skipping RangeProfilerKernelReplay "
+                      "internal wait kernel corr=", k->correlationId);
+        return false;
+    }
 
     // Diagnostic: log every real activity record as it arrives.
     GFL_LOG_DEBUG("[KernelLaunchHandler] ACTIVITY_RECORD corr=",
-                  k->correlationId, " name=", k->name,
+                  k->correlationId, " name=", kernelName,
                   " start=", k->start, " end=", k->end,
                   " dur=", k->end - k->start);
 
@@ -480,7 +490,7 @@ bool KernelLaunchHandler::handleActivityRecord(const CUpti_Activity* record,
     // thread. %.*s bounds the source read against a non-terminated name.
     std::snprintf(out.name, sizeof(out.name), "%.*s",
                   static_cast<int>(sizeof(out.name) - 1),
-                  k->name ? k->name : "");
+                  kernelName);
     out.cpu_start_ns = baseCpuNs + static_cast<int64_t>(k->start - baseCuptiTs);
     out.duration_ns = static_cast<int64_t>(k->end - k->start);
     out.dyn_shared = k->dynamicSharedMemory;

--- a/include/gpufl/backends/nvidia/mem_transfer_handler.cpp
+++ b/include/gpufl/backends/nvidia/mem_transfer_handler.cpp
@@ -91,6 +91,7 @@ MemTransferHandler::requiredCallbacks() const {
 
 std::vector<CUpti_ActivityKind> MemTransferHandler::requiredActivityKinds()
     const {
+    if (backend_ && !backend_->collectsKernelEvents()) return {};
     if (backend_ && !backend_->AllowSassMemTransferActivity()) return {};
     return {CUPTI_ACTIVITY_KIND_MEMCPY, CUPTI_ACTIVITY_KIND_MEMCPY2,
             CUPTI_ACTIVITY_KIND_MEMSET};
@@ -261,7 +262,7 @@ bool MemTransferHandler::handleActivityRecord(const CUpti_Activity* record,
         // (joinLaunchMeta in monitor.cpp, keyed by corr_id) — no meta_mu_ here.
         // (Step 4b-2.)
         g_monitorBuffer.Push(out);
-        backend_->NoteMemoryActivityEmitted();
+        backend_->NoteMemTransferActivityEmitted();
         return true;
     }
 
@@ -281,7 +282,7 @@ bool MemTransferHandler::handleActivityRecord(const CUpti_Activity* record,
         // (joinLaunchMeta in monitor.cpp, keyed by corr_id) — no meta_mu_ here.
         // (Step 4b-2.)
         g_monitorBuffer.Push(out);
-        backend_->NoteMemoryActivityEmitted();
+        backend_->NoteMemTransferActivityEmitted();
         return true;
     }
 

--- a/include/gpufl/backends/nvidia/profiling_plan.hpp
+++ b/include/gpufl/backends/nvidia/profiling_plan.hpp
@@ -4,6 +4,7 @@
 #include <cstdlib>
 #include <cstring>
 
+#include "gpufl/core/env_vars.hpp"
 #include "gpufl/core/monitor.hpp"
 
 namespace gpufl {
@@ -46,21 +47,21 @@ struct EnvOverrides {
 
     static EnvOverrides FromProcess() {
         EnvOverrides env;
-        env.sass_metrics_only = Enabled("GPUFL_SASS_METRICS_ONLY");
-        env.sass_force_safe_activity = Enabled("GPUFL_SASS_FORCE_SAFE_ACTIVITY");
-        env.sass_allow_full_activity = Enabled("GPUFL_SASS_ALLOW_FULL_ACTIVITY");
-        env.sass_allow_kernel_activity = Enabled("GPUFL_SASS_ALLOW_KERNEL_ACTIVITY");
-        env.sass_allow_marker_activity = Enabled("GPUFL_SASS_ALLOW_MARKER_ACTIVITY");
+        env.sass_metrics_only = Enabled(gpufl::env::kSassMetricsOnly);
+        env.sass_force_safe_activity = Enabled(gpufl::env::kSassForceSafeActivity);
+        env.sass_allow_full_activity = Enabled(gpufl::env::kSassAllowFullActivity);
+        env.sass_allow_kernel_activity = Enabled(gpufl::env::kSassAllowKernelActivity);
+        env.sass_allow_marker_activity = Enabled(gpufl::env::kSassAllowMarkerActivity);
         env.sass_allow_mem_transfer_activity =
-            Enabled("GPUFL_SASS_ALLOW_MEM_TRANSFER_ACTIVITY");
-        env.sass_allow_memory2_activity = Enabled("GPUFL_SASS_ALLOW_MEMORY2_ACTIVITY");
-        env.sass_allow_memory_activity = Enabled("GPUFL_SASS_ALLOW_MEMORY_ACTIVITY");
-        env.sass_allow_sync_activity = Enabled("GPUFL_SASS_ALLOW_SYNC_ACTIVITY");
-        env.sass_allow_graph_activity = Enabled("GPUFL_SASS_ALLOW_GRAPH_ACTIVITY");
+            Enabled(gpufl::env::kSassAllowMemTransferActivity);
+        env.sass_allow_memory2_activity = Enabled(gpufl::env::kSassAllowMemory2Activity);
+        env.sass_allow_memory_activity = Enabled(gpufl::env::kSassAllowMemoryActivity);
+        env.sass_allow_sync_activity = Enabled(gpufl::env::kSassAllowSyncActivity);
+        env.sass_allow_graph_activity = Enabled(gpufl::env::kSassAllowGraphActivity);
         env.sass_allow_external_correlation =
-            Enabled("GPUFL_SASS_ALLOW_EXTERNAL_CORRELATION");
-        env.disable_cubin_capture = Enabled("GPUFL_DISABLE_CUBIN_CAPTURE");
-        env.sass_disable_cubin_capture = Enabled("GPUFL_SASS_DISABLE_CUBIN_CAPTURE");
+            Enabled(gpufl::env::kSassAllowExternalCorrelation);
+        env.disable_cubin_capture = Enabled(gpufl::env::kDisableCubinCapture);
+        env.sass_disable_cubin_capture = Enabled(gpufl::env::kSassDisableCubinCapture);
         return env;
     }
 };

--- a/include/gpufl/core/config_file_loader.cpp
+++ b/include/gpufl/core/config_file_loader.cpp
@@ -26,6 +26,8 @@ void ConfigFileLoader::apply(InitOptions& opts, const std::string& path) {
         else if (v == "SassMetrics")   opts.profiling_engine = ProfilingEngine::SassMetrics;
         else if (v == "PmSampling")    opts.profiling_engine = ProfilingEngine::PmSampling;
         else if (v == "RangeProfiler") opts.profiling_engine = ProfilingEngine::RangeProfiler;
+        else if (v == "RangeProfilerKernelReplay")
+            opts.profiling_engine = ProfilingEngine::RangeProfilerKernelReplay;
         else if (v == "Deep")          opts.profiling_engine = ProfilingEngine::Deep;
     }
 

--- a/include/gpufl/core/dictionary_manager.cpp
+++ b/include/gpufl/core/dictionary_manager.cpp
@@ -1,5 +1,7 @@
 #include "gpufl/core/dictionary_manager.hpp"
 
+#include "gpufl/core/env_vars.hpp"
+
 #include <chrono>
 #include <cstdio>
 #include <cstdlib>
@@ -273,7 +275,7 @@ void DictionaryManager::flushDisassembly(Logger& logger,
             // when both the executable path and arguments contain spaces
             // (e.g., "C:\Program Files\...").
             char cmd[640];
-            const char* cudaPath = std::getenv("CUDA_PATH");
+            const char* cudaPath = std::getenv(gpufl::env::kCudaPath);
             if (cudaPath && cudaPath[0]) {
                 std::snprintf(cmd, sizeof(cmd),
                               "\"\"%s\\bin\\nvdisasm.exe\" --print-code \"%s\"\"",

--- a/include/gpufl/core/env_vars.hpp
+++ b/include/gpufl/core/env_vars.hpp
@@ -1,0 +1,120 @@
+#pragma once
+
+// ─────────────────────────────────────────────────────────────────────────
+// Central registry of every environment-variable NAME GPUFlight reads or sets.
+//
+// One place, so each name lives exactly once — no more the same "GPUFL_…"
+// string typed as a raw literal in five files and silently drifting. Read or
+// set env through these constants, never a bare string literal:
+//
+//     if (const char* v = std::getenv(gpufl::env::kApiKey)) { ... }
+//
+// Names only — the VALUES some of these carry (e.g. "EAGER" for
+// kCudaModuleLoading, the "comprehensive"/"light"/… profile presets in
+// inject/inject_entry.hpp) live with their own logic, not here.
+//
+// Pure-OS lookups the code also does (PATH, HOME, USERPROFILE, HOMEDRIVE,
+// HOMEPATH) are intentionally left as literals at their call sites: they're OS
+// contracts, not GPUFlight knobs.
+// ─────────────────────────────────────────────────────────────────────────
+
+namespace gpufl::env {
+
+// ── Kill switch / config / credentials ─────────────────────────────────────
+// Master off switch — truthy => gpufl::init() returns early (no CUPTI / NVML).
+constexpr const char* kDisabled     = "GPUFL_DISABLED";
+// Path to a local JSON config file (InitOptions.config_file fallback).
+constexpr const char* kConfigFile   = "GPUFL_CONFIG_FILE";
+// Backend base URL / bearer token / API path prefix — read by init()'s remote
+// config probe, the inject-lib post-run upload, and the `gpufl upload` command.
+constexpr const char* kBackendUrl   = "GPUFL_BACKEND_URL";
+constexpr const char* kApiKey       = "GPUFL_API_KEY";
+constexpr const char* kApiPath      = "GPUFL_API_PATH";
+// Fallback URL for the remote named-config fetch when kBackendUrl is unset.
+constexpr const char* kRemoteConfig = "GPUFL_REMOTE_CONFIG";
+
+// ── Launcher ↔ inject-lib protocol ──────────────────────────────────────────
+// `gpufl trace` sets these in the child env before fork+exec; the inject lib's
+// entry point reads them to drive gpufl::init(). (Moved here from
+// inject/inject_entry.hpp so every env name lives in one place.)
+//
+// Sentinel — the inject lib returns silently unless this is "1", so a stray
+// LD_PRELOAD into a shell/utility can't accidentally fire CUPTI.
+constexpr const char* kInject               = "GPUFL_INJECT";
+// Session display name (default: basename of the launched command).
+constexpr const char* kAppName              = "GPUFL_APP_NAME";
+// Local NDJSON output directory (becomes InitOptions.log_path).
+constexpr const char* kLogDir               = "GPUFL_LOG_DIR";
+// Profile preset: "comprehensive" | "light" | "monitoring-only" (the matching
+// VALUE constants are kProfile* in inject/inject_entry.hpp).
+constexpr const char* kInjectProfile        = "GPUFL_INJECT_PROFILE";
+// Opt-in ("1"): inject lib runs uploadLogs() right after shutdown(), shipping
+// the session NDJSON with the kApiKey / kBackendUrl / kApiPath creds.
+constexpr const char* kInjectUpload         = "GPUFL_INJECT_UPLOAD";
+// Write end of an inherited pipe; the inject lib writes one byte after
+// shutdown() so the launcher knows uploads drained. Empty = no signal.
+constexpr const char* kInjectCompletionFd   = "GPUFL_INJECT_COMPLETION_FD";
+// Opt-in ("1"): run gpufl::init() from the inject lib's ld.so constructor
+// (before main / cuInit). Off by default — pre-cuInit CUPTI subscribe segfaults
+// on no-CUDA targets; normally InitializeInjection drives init after cuInit.
+constexpr const char* kInjectUseConstructor = "GPUFL_INJECT_USE_CONSTRUCTOR";
+
+// ── Inject-lib timing knobs (tuning / debugging the injection lifecycle) ────
+constexpr const char* kInjectShutdownDelayMs = "GPUFL_INJECT_SHUTDOWN_DELAY_MS";
+constexpr const char* kInjectSyncWaitMs      = "GPUFL_INJECT_SYNC_WAIT_MS";
+constexpr const char* kInjectLaunchWaitMs    = "GPUFL_INJECT_LAUNCH_WAIT_MS";
+constexpr const char* kInjectProcessScope    = "GPUFL_INJECT_PROCESS_SCOPE";
+constexpr const char* kInjectInitDelayMs     = "GPUFL_INJECT_INIT_DELAY_MS";
+
+// ── Profiling engine selection ──────────────────────────────────────────────
+// Override the resolved ProfilingEngine; gpufl::init() is the single string→enum
+// parser. Canonical values: Monitor | Trace | PcSampling | SassMetrics |
+// PmSampling | RangeProfiler | Deep.
+constexpr const char* kProfilingEngine    = "GPUFL_PROFILING_ENGINE";
+// Opt-in (1/true/yes/on): force CUDA_MODULE_LOADING=EAGER for SASS / Deep.
+constexpr const char* kEagerModuleLoading = "GPUFL_EAGER_MODULE_LOADING";
+
+// ── Multi-pass profiling (set per pass by the launcher's multi-pass driver) ─
+// One analysis = N passes sharing kAnalysisId; each pass is labeled with its
+// 0-based kPassIndex out of kPassCount. init() reads them into job_start.
+constexpr const char* kAnalysisId = "GPUFL_ANALYSIS_ID";
+constexpr const char* kPassIndex  = "GPUFL_PASS_INDEX";
+constexpr const char* kPassCount  = "GPUFL_PASS_COUNT";
+
+// ── Deep engine knobs ───────────────────────────────────────────────────────
+constexpr const char* kDeepPcOnly  = "GPUFL_DEEP_PC_ONLY";
+constexpr const char* kDeepTryBoth = "GPUFL_DEEP_TRY_BOTH";
+
+// ── SASS metrics knobs ──────────────────────────────────────────────────────
+constexpr const char* kSassMetricsOnly              = "GPUFL_SASS_METRICS_ONLY";
+constexpr const char* kSassForceSafeActivity        = "GPUFL_SASS_FORCE_SAFE_ACTIVITY";
+constexpr const char* kSassAllowFullActivity        = "GPUFL_SASS_ALLOW_FULL_ACTIVITY";
+constexpr const char* kSassAllowKernelActivity      = "GPUFL_SASS_ALLOW_KERNEL_ACTIVITY";
+constexpr const char* kSassAllowMarkerActivity      = "GPUFL_SASS_ALLOW_MARKER_ACTIVITY";
+constexpr const char* kSassAllowMemTransferActivity = "GPUFL_SASS_ALLOW_MEM_TRANSFER_ACTIVITY";
+constexpr const char* kSassAllowMemory2Activity     = "GPUFL_SASS_ALLOW_MEMORY2_ACTIVITY";
+constexpr const char* kSassAllowMemoryActivity      = "GPUFL_SASS_ALLOW_MEMORY_ACTIVITY";
+constexpr const char* kSassAllowSyncActivity        = "GPUFL_SASS_ALLOW_SYNC_ACTIVITY";
+constexpr const char* kSassAllowGraphActivity       = "GPUFL_SASS_ALLOW_GRAPH_ACTIVITY";
+constexpr const char* kSassAllowExternalCorrelation = "GPUFL_SASS_ALLOW_EXTERNAL_CORRELATION";
+constexpr const char* kDisableCubinCapture          = "GPUFL_DISABLE_CUBIN_CAPTURE";
+constexpr const char* kSassDisableCubinCapture      = "GPUFL_SASS_DISABLE_CUBIN_CAPTURE";
+constexpr const char* kSassExcludeArchs             = "GPUFL_SASS_EXCLUDE_ARCHS";
+constexpr const char* kSassLazyPatching            = "GPUFL_SASS_LAZY_PATCHING";
+constexpr const char* kSassDeferScopeFlush         = "GPUFL_SASS_DEFER_SCOPE_FLUSH";
+
+// ── Standalone monitor daemon (daemon/monitor) ──────────────────────────────
+constexpr const char* kMonitorApp        = "GPUFL_MONITOR_APP";
+constexpr const char* kMonitorLogDir     = "GPUFL_MONITOR_LOG_DIR";
+constexpr const char* kMonitorIntervalMs = "GPUFL_MONITOR_INTERVAL_MS";
+
+// ── External / platform names GPUFlight reads or sets ───────────────────────
+// Not our knobs (CUDA-driver / dynamic-loader contracts) but referenced from
+// specific spots — centralized so the exact spelling lives in one place.
+constexpr const char* kCudaModuleLoading   = "CUDA_MODULE_LOADING";
+constexpr const char* kCudaInjection64Path = "CUDA_INJECTION64_PATH";
+constexpr const char* kNvtxInjection64Path = "NVTX_INJECTION64_PATH";
+constexpr const char* kCudaPath            = "CUDA_PATH";
+constexpr const char* kLdPreload           = "LD_PRELOAD";
+
+}  // namespace gpufl::env

--- a/include/gpufl/core/env_vars.hpp
+++ b/include/gpufl/core/env_vars.hpp
@@ -71,6 +71,10 @@ constexpr const char* kInjectInitDelayMs     = "GPUFL_INJECT_INIT_DELAY_MS";
 // parser. Canonical values: Monitor | Trace | PcSampling | SassMetrics |
 // PmSampling | RangeProfiler | Deep.
 constexpr const char* kProfilingEngine    = "GPUFL_PROFILING_ENGINE";
+// Compatibility-matrix testing / generalized composite: run an arbitrary set of
+// engines in ONE process — comma-separated canonical names — overriding the
+// single-engine selection. e.g. GPUFL_ENGINE_COMBO=Trace,PcSampling
+constexpr const char* kEngineCombo        = "GPUFL_ENGINE_COMBO";
 // Opt-in (1/true/yes/on): force CUDA_MODULE_LOADING=EAGER for SASS / Deep.
 constexpr const char* kEagerModuleLoading = "GPUFL_EAGER_MODULE_LOADING";
 

--- a/include/gpufl/core/events.hpp
+++ b/include/gpufl/core/events.hpp
@@ -537,16 +537,37 @@ struct PerfMetricEvent {
     int64_t end_ns = 0;
     int device_id = 0;
 
-    // Hardware counters (-1.0 = not available for this GPU/metric)
+    // Hardware counters (-1/-1.0 = not available for this GPU/metric)
     double sm_throughput_pct = -1.0;   // SM active % of peak
     double l1_hit_rate_pct = -1.0;     // L1 global load hit rate
     double l2_hit_rate_pct = -1.0;     // L2 read hit rate
-    uint64_t dram_read_bytes = 0;      // DRAM read bytes
-    uint64_t dram_write_bytes = 0;     // DRAM write bytes
+    int64_t dram_read_bytes = -1;      // DRAM read bytes
+    int64_t dram_write_bytes = -1;     // DRAM write bytes
     double tensor_active_pct = -1.0;   // Tensor core active % (-1 if N/A)
 
     std::string user_scope;
     int scope_depth = 0;
+};
+
+struct KernelPerfMetricEvent {
+    int pid = 0;
+    std::string app;
+    std::string session_id;
+    int device_id = 0;
+    size_t range_index = 0;
+    std::string range_name;
+
+    // Candidate join fields. KernelReplay auto-ranges usually expose a kernel
+    // range name, but not the CUPTI activity correlation id.
+    std::string kernel_name;
+    uint32_t launch_ordinal = 0;
+
+    double sm_throughput_pct = -1.0;
+    double l1_hit_rate_pct = -1.0;
+    double l2_hit_rate_pct = -1.0;
+    int64_t dram_read_bytes = -1;
+    int64_t dram_write_bytes = -1;
+    double tensor_active_pct = -1.0;
 };
 
 /**

--- a/include/gpufl/core/events.hpp
+++ b/include/gpufl/core/events.hpp
@@ -130,6 +130,26 @@ struct SassConfigEvent {
     std::vector<std::string> skipped_metrics;     // metrics CUPTI rejected for this GPU
 };
 
+// Per-scope Execution Signature (P2 multi-pass determinism guard input).
+// Accumulated from KERNEL_LAUNCH_META — which fires in EVERY engine mode, so
+// every isolated pass (even SASS, where kernel-activity is off) has the full
+// per-launch inventory. `signature` hashes the sorted MULTISET of
+// (mangled kernel name, grid, block, dyn_smem) -> launch count within the scope
+// (mangled is intentional: byte-identical across passes, so no demangle is
+// needed here). The backend compares this fingerprint per scope across the
+// passes of one analysis: equal => the launch pattern is deterministic and SASS
+// metrics from one pass may be merged onto another pass's timing for that
+// scope; different (e.g. cuDNN autotune changed grid/block/count) => abort the
+// SASS merge for that scope. Emitted once per scope at session end.
+struct ExecutionSignatureEvent {
+    std::string session_id;
+    int64_t     ts_ns = 0;
+    std::string scope_name;        // full user-scope path; "" = global / no scope
+    uint64_t    signature = 0;     // FNV-1a 64 over the sorted launch multiset
+    uint64_t    launch_count = 0;  // total kernel launches attributed to the scope
+    uint32_t    distinct_kernels = 0;  // distinct (name,grid,block,smem) keys
+};
+
 struct CaptureCapability {
     std::string feature;
     bool requested = false;

--- a/include/gpufl/core/events.hpp
+++ b/include/gpufl/core/events.hpp
@@ -95,6 +95,24 @@ struct InitEvent {
     // lives next to the InitEvent build site (gpufl.cpp).
     std::string session_kind;
     std::string profiling_engine;
+    // Multi-pass profiling grouping (P1 of the multi-pass workstream).
+    // A single "analysis" = N separately-launched passes (one CUPTI engine
+    // each, isolated to dodge the SASS/kernel-activity deadlock + cross-
+    // perturbation) that the backend stitches back into one kernel view.
+    // The launcher's multi-pass driver sets GPUFL_ANALYSIS_ID/PASS_INDEX/
+    // PASS_COUNT in each child; gpufl::init() reads them into these fields.
+    //   analysis_id : stable id shared by every pass of one analysis
+    //                 (empty for an ordinary single-pass run — then
+    //                 pass_index/pass_count are NOT emitted).
+    //   pass_index  : 0-based position of this pass within the analysis.
+    //   pass_count  : total passes planned for the analysis (lets the
+    //                 backend detect a missing/failed pass).
+    // All three are emitted to job_start only when analysis_id is non-empty,
+    // so single runs are byte-identical to pre-P1 (and pass_index==0 is
+    // never ambiguous with "unset").
+    std::string analysis_id;
+    int pass_index = 0;
+    int pass_count = 0;
 };
 
 struct ShutdownEvent {

--- a/include/gpufl/core/gpufl.cpp
+++ b/include/gpufl/core/gpufl.cpp
@@ -504,6 +504,24 @@ bool init(const InitOptions& opts) {
     ie.session_kind = ProfilingEngineSessionKind(mOpts.profiling_engine);
     ie.profiling_engine = ProfilingEngineWireName(mOpts.profiling_engine);
 
+    // Multi-pass grouping (P1): the launcher's multi-pass driver tags each
+    // child with GPUFL_ANALYSIS_ID + its 0-based GPUFL_PASS_INDEX and the
+    // GPUFL_PASS_COUNT total so the backend can stitch the isolated passes
+    // into one analysis. Read straight from the env here (same pattern as the
+    // GPUFL_PROFILING_ENGINE override above). Absent → an ordinary single-pass
+    // run: analysis_id stays empty and the three fields are omitted from
+    // job_start (see InitEventModel), keeping single runs wire-identical.
+    if (const char* envAnalysis = std::getenv("GPUFL_ANALYSIS_ID");
+        envAnalysis && *envAnalysis) {
+        ie.analysis_id = envAnalysis;
+        if (const char* envIdx = std::getenv("GPUFL_PASS_INDEX"))
+            ie.pass_index = std::atoi(envIdx);
+        if (const char* envCnt = std::getenv("GPUFL_PASS_COUNT"))
+            ie.pass_count = std::atoi(envCnt);
+        GFL_LOG_DEBUG("Multi-pass: analysis_id=", ie.analysis_id,
+                      " pass ", ie.pass_index, "/", ie.pass_count);
+    }
+
     rt_ptr->logger->write(model::InitEventModel(ie));
 
     // Configure the sampler with collectors / interval. This does NOT

--- a/include/gpufl/core/gpufl.cpp
+++ b/include/gpufl/core/gpufl.cpp
@@ -776,8 +776,14 @@ void ScopedMonitor::init_(const ScopeMeta& meta) {
 
     // Scope callbacks are useful for both tracing and profiling backends.
     Monitor::BeginProfilerScope(name_.c_str());
+    // Perf scope (Range Profiler / Perfworks). Also fire it when an engine combo
+    // (GPUFL_ENGINE_COMBO) is active even with a Trace base — otherwise a
+    // Trace+RangeProfiler combo would never trigger Range's perf scope. Harmless
+    // no-op for engines that don't use perf scopes (PC / PM).
+    const char* comboEnv = std::getenv(gpufl::env::kEngineCombo);
+    const bool comboActive = comboEnv && comboEnv[0] != '\0';
     if (g_opts.profiling_engine != ProfilingEngine::Monitor &&
-        g_opts.profiling_engine != ProfilingEngine::Trace) {
+        (g_opts.profiling_engine != ProfilingEngine::Trace || comboActive)) {
         Monitor::BeginPerfScope(name_.c_str());
     }
 
@@ -827,8 +833,10 @@ ScopedMonitor::~ScopedMonitor() {
     Monitor::PushScopeRow(row);
 
     Monitor::EndProfilerScope(name_.c_str());
+    const char* comboEnv = std::getenv(gpufl::env::kEngineCombo);
+    const bool comboActive = comboEnv && comboEnv[0] != '\0';
     if (g_opts.profiling_engine != ProfilingEngine::Monitor &&
-        g_opts.profiling_engine != ProfilingEngine::Trace) {
+        (g_opts.profiling_engine != ProfilingEngine::Trace || comboActive)) {
         Monitor::EndPerfScope(
             name_.c_str());  // triggers EndPerfPassAndDecode first
         if (IMonitorBackend* b = Monitor::GetBackend()) {

--- a/include/gpufl/core/gpufl.cpp
+++ b/include/gpufl/core/gpufl.cpp
@@ -1,5 +1,7 @@
 #include "gpufl.hpp"
 
+#include "gpufl/core/env_vars.hpp"
+
 #include <algorithm>
 #include <atomic>
 #include <cctype>
@@ -219,7 +221,7 @@ namespace {
 // so the two layers stay interchangeable. Empty / unset / anything else
 // → false.
 bool envDisabled_() {
-    const char* v = std::getenv("GPUFL_DISABLED");
+    const char* v = std::getenv(gpufl::env::kDisabled);
     if (!v) return false;
     std::string s(v);
     // Trim ASCII whitespace.
@@ -257,7 +259,7 @@ bool init(const InitOptions& opts) {
     {
         std::string configPath = g_opts.config_file;
         if (configPath.empty()) {
-            if (const char* env = std::getenv("GPUFL_CONFIG_FILE")) configPath = env;
+            if (const char* env = std::getenv(gpufl::env::kConfigFile)) configPath = env;
         }
         if (!configPath.empty()) {
             ConfigFileLoader::apply(g_opts, configPath);
@@ -269,15 +271,15 @@ bool init(const InitOptions& opts) {
         std::string key  = g_opts.api_key;
         std::string apiPath = g_opts.api_path;
         if (url.empty()) {
-            if (const char* e = std::getenv("GPUFL_BACKEND_URL")) url = e;
+            if (const char* e = std::getenv(gpufl::env::kBackendUrl)) url = e;
             // Legacy name — accept for one release to ease migration.
-            else if (const char* e2 = std::getenv("GPUFL_REMOTE_CONFIG")) url = e2;
+            else if (const char* e2 = std::getenv(gpufl::env::kRemoteConfig)) url = e2;
         }
         if (key.empty()) {
-            if (const char* e = std::getenv("GPUFL_API_KEY")) key = e;
+            if (const char* e = std::getenv(gpufl::env::kApiKey)) key = e;
         }
         if (apiPath.empty()) {
-            if (const char* e = std::getenv("GPUFL_API_PATH")) apiPath = e;
+            if (const char* e = std::getenv(gpufl::env::kApiPath)) apiPath = e;
         }
         // Normalize once — every downstream consumer (HttpLogSink wiring
         // below, the version-discovery probe) just appends after this.
@@ -368,7 +370,7 @@ bool init(const InitOptions& opts) {
     // Accepts exactly the six canonical engine names. Unrecognized
     // values are logged and ignored (the engine stays at whatever
     // g_opts set above) rather than silently doing nothing.
-    if (const char* envEngine = std::getenv("GPUFL_PROFILING_ENGINE")) {
+    if (const char* envEngine = std::getenv(gpufl::env::kProfilingEngine)) {
         const std::string val(envEngine);
         bool matched = true;
         if (val == "Monitor")                  mOpts.profiling_engine = ProfilingEngine::Monitor;
@@ -422,15 +424,15 @@ bool init(const InitOptions& opts) {
     // gpufl.init(); this covers the pure-C++ path.
     if (mOpts.profiling_engine == ProfilingEngine::SassMetrics ||
         mOpts.profiling_engine == ProfilingEngine::Deep) {
-        const char* knobEnv = std::getenv("GPUFL_EAGER_MODULE_LOADING");
+        const char* knobEnv = std::getenv(gpufl::env::kEagerModuleLoading);
         const std::string knob = knobEnv ? knobEnv : "";
         const bool optedIn = (knob == "1" || knob == "true" ||
                               knob == "yes" || knob == "on");
-        if (optedIn && std::getenv("CUDA_MODULE_LOADING") == nullptr) {
+        if (optedIn && std::getenv(gpufl::env::kCudaModuleLoading) == nullptr) {
 #if defined(_WIN32)
-            _putenv_s("CUDA_MODULE_LOADING", "EAGER");
+            _putenv_s(gpufl::env::kCudaModuleLoading, "EAGER");
 #else
-            setenv("CUDA_MODULE_LOADING", "EAGER", /*overwrite=*/0);
+            setenv(gpufl::env::kCudaModuleLoading, "EAGER", /*overwrite=*/0);
 #endif
             GFL_LOG_DEBUG("[gpufl] CUDA_MODULE_LOADING=EAGER set "
                           "(GPUFL_EAGER_MODULE_LOADING opt-in) for SASS/Deep.");
@@ -511,12 +513,12 @@ bool init(const InitOptions& opts) {
     // GPUFL_PROFILING_ENGINE override above). Absent → an ordinary single-pass
     // run: analysis_id stays empty and the three fields are omitted from
     // job_start (see InitEventModel), keeping single runs wire-identical.
-    if (const char* envAnalysis = std::getenv("GPUFL_ANALYSIS_ID");
+    if (const char* envAnalysis = std::getenv(gpufl::env::kAnalysisId);
         envAnalysis && *envAnalysis) {
         ie.analysis_id = envAnalysis;
-        if (const char* envIdx = std::getenv("GPUFL_PASS_INDEX"))
+        if (const char* envIdx = std::getenv(gpufl::env::kPassIndex))
             ie.pass_index = std::atoi(envIdx);
-        if (const char* envCnt = std::getenv("GPUFL_PASS_COUNT"))
+        if (const char* envCnt = std::getenv(gpufl::env::kPassCount))
             ie.pass_count = std::atoi(envCnt);
         GFL_LOG_DEBUG("Multi-pass: analysis_id=", ie.analysis_id,
                       " pass ", ie.pass_index, "/", ie.pass_count);

--- a/include/gpufl/core/gpufl.cpp
+++ b/include/gpufl/core/gpufl.cpp
@@ -388,6 +388,8 @@ bool init(const InitOptions& opts) {
         else if (val == "SassMetrics")         mOpts.profiling_engine = ProfilingEngine::SassMetrics;
         else if (val == "PmSampling")          mOpts.profiling_engine = ProfilingEngine::PmSampling;
         else if (val == "RangeProfiler")       mOpts.profiling_engine = ProfilingEngine::RangeProfiler;
+        else if (val == "RangeProfilerKernelReplay")
+            mOpts.profiling_engine = ProfilingEngine::RangeProfilerKernelReplay;
         else if (val == "Deep")                mOpts.profiling_engine = ProfilingEngine::Deep;
         else matched = false;
         if (matched) {

--- a/include/gpufl/core/gpufl.cpp
+++ b/include/gpufl/core/gpufl.cpp
@@ -233,6 +233,15 @@ bool envDisabled_() {
     return s == "1" || s == "true" || s == "yes" || s == "on";
 }
 
+bool windowsInjectedProcess_() {
+#if defined(_WIN32)
+    const char* injected = std::getenv(gpufl::env::kInject);
+    return injected && std::string(injected) == "1";
+#else
+    return false;
+#endif
+}
+
 }  // namespace
 
 bool init(const InitOptions& opts) {
@@ -497,9 +506,12 @@ bool init(const InitOptions& opts) {
     if (rt_ptr->collector) {
         ie.devices = rt_ptr->collector->sampleAll();
     }
-    if (rt_ptr->static_info_collector) {
+    const bool skipStaticInfoDuringInject = windowsInjectedProcess_();
+    if (rt_ptr->static_info_collector && !skipStaticInfoDuringInject) {
         ie.gpu_static_device_infos =
             rt_ptr->static_info_collector->sampleStaticInfo();
+    } else if (skipStaticInfoDuringInject) {
+        GFL_LOG_DEBUG("Skipping CUDA static GPU inventory during Windows injection init.");
     }
     ie.host = rt_ptr->host_collector->sample();
 

--- a/include/gpufl/core/model/lifecycle_model.cpp
+++ b/include/gpufl/core/model/lifecycle_model.cpp
@@ -81,6 +81,22 @@ std::string SassConfigModel::buildJson() const {
     return oss.str();
 }
 
+std::string ExecutionSignatureModel::buildJson() const {
+    std::ostringstream oss;
+    oss << "{\"version\":1,\"type\":\"execution_signature\""
+        << ",\"session_id\":\"" << jsonEscape(e_.session_id) << "\""
+        << ",\"ts_ns\":"        << e_.ts_ns
+        << ",\"scope_name\":\"" << jsonEscape(e_.scope_name) << "\""
+        // signature is a full-width uint64 hash — emit as a STRING so a JSON
+        // number consumer (JS doubles lose precision above 2^53) can't corrupt
+        // it. The backend parses it back to an unsigned 64-bit value.
+        << ",\"signature\":\""  << e_.signature << "\""
+        << ",\"launch_count\":" << e_.launch_count
+        << ",\"distinct_kernels\":" << e_.distinct_kernels
+        << "}";
+    return oss.str();
+}
+
 std::string CaptureCapabilitiesModel::buildJson() const {
     std::ostringstream oss;
     oss << "{\"version\":1,\"type\":\"capture_capabilities\""

--- a/include/gpufl/core/model/lifecycle_model.cpp
+++ b/include/gpufl/core/model/lifecycle_model.cpp
@@ -38,6 +38,15 @@ std::string InitEventModel::buildJson() const {
         oss << ",\"profiling_engine\":\"" << jsonEscape(e_.profiling_engine) << "\"";
     }
 
+    // Multi-pass grouping — emitted together, only for multi-pass runs.
+    // A single-pass run leaves analysis_id empty and the job_start wire is
+    // byte-identical to pre-P1 (so pass_index==0 is never confused with unset).
+    if (!e_.analysis_id.empty()) {
+        oss << ",\"analysis_id\":\"" << jsonEscape(e_.analysis_id) << "\""
+            << ",\"pass_index\":" << e_.pass_index
+            << ",\"pass_count\":" << e_.pass_count;
+    }
+
     oss << "}";
     return oss.str();
 }

--- a/include/gpufl/core/model/lifecycle_model.hpp
+++ b/include/gpufl/core/model/lifecycle_model.hpp
@@ -37,4 +37,14 @@ private:
     const CaptureCapabilitiesEvent& e_;
 };
 
+struct ExecutionSignatureModel final : IJsonSerializable {
+    explicit ExecutionSignatureModel(const ExecutionSignatureEvent& e) : e_(e) {}
+    std::string buildJson() const override;
+    // Scope-attributed per-pass kernel-launch fingerprint — grouped with the
+    // other per-scope profiling data (profile_sample_batch) on the Scope channel.
+    Channel channel() const override { return Channel::Scope; }
+private:
+    const ExecutionSignatureEvent& e_;
+};
+
 }  // namespace gpufl::model

--- a/include/gpufl/core/model/perf_metric_model.cpp
+++ b/include/gpufl/core/model/perf_metric_model.cpp
@@ -30,4 +30,26 @@ std::string PerfMetricModel::buildJson() const {
     return oss.str();
 }
 
+std::string KernelPerfMetricModel::buildJson() const {
+    std::ostringstream oss;
+    oss << std::fixed << std::setprecision(4);
+    oss << "{\"type\":\"kernel_perf_metric_event\""
+        << ",\"pid\":"           << e_.pid
+        << ",\"app\":\""         << jsonEscape(e_.app)        << "\""
+        << ",\"session_id\":\""  << jsonEscape(e_.session_id) << "\""
+        << ",\"device_id\":"     << e_.device_id
+        << ",\"range_index\":"   << e_.range_index
+        << ",\"range_name\":\""  << jsonEscape(e_.range_name) << "\""
+        << ",\"kernel_name\":\"" << jsonEscape(e_.kernel_name) << "\""
+        << ",\"launch_ordinal\":" << e_.launch_ordinal
+        << ",\"sm_throughput_pct\":" << e_.sm_throughput_pct
+        << ",\"l1_hit_rate_pct\":"   << e_.l1_hit_rate_pct
+        << ",\"l2_hit_rate_pct\":"   << e_.l2_hit_rate_pct
+        << ",\"dram_read_bytes\":"   << e_.dram_read_bytes
+        << ",\"dram_write_bytes\":"  << e_.dram_write_bytes
+        << ",\"tensor_active_pct\":" << e_.tensor_active_pct
+        << "}";
+    return oss.str();
+}
+
 }  // namespace gpufl::model

--- a/include/gpufl/core/model/perf_metric_model.hpp
+++ b/include/gpufl/core/model/perf_metric_model.hpp
@@ -13,4 +13,12 @@ private:
     const PerfMetricEvent& e_;
 };
 
+struct KernelPerfMetricModel final : IJsonSerializable {
+    explicit KernelPerfMetricModel(const KernelPerfMetricEvent& e) : e_(e) {}
+    std::string buildJson() const override;
+    Channel channel() const override { return Channel::Device; }
+private:
+    const KernelPerfMetricEvent& e_;
+};
+
 }  // namespace gpufl::model

--- a/include/gpufl/core/monitor.cpp
+++ b/include/gpufl/core/monitor.cpp
@@ -4,6 +4,7 @@
 #include <atomic>
 #include <chrono>
 #include <cstring>
+#include <map>
 #include <mutex>
 #include <stack>
 #include <thread>
@@ -22,6 +23,7 @@
 #include "gpufl/core/model/synchronization_event_model.hpp"
 #include "gpufl/core/model/memory_alloc_event_model.hpp"
 #include "gpufl/core/model/graph_launch_event_model.hpp"
+#include "gpufl/core/model/lifecycle_model.hpp"
 #include "gpufl/core/monitor_adapter.hpp"
 #include "gpufl/core/ring_buffer.hpp"
 #include "gpufl/core/runtime.hpp"
@@ -238,6 +240,49 @@ static void flushBatches(Logger& logger, const std::string& session_id) {
 // field the join and the synthetic-kernel path need, so no parallel struct.
 static std::unordered_map<uint64_t, ActivityRecord> g_launchMetaByCorr;
 
+// ── Execution Signature (P2 multi-pass determinism guard) ──────────────────
+// Per-scope multiset of (mangled kernel name + launch dims) -> launch count,
+// built from the KERNEL_LAUNCH_META records below (which fire in EVERY engine
+// mode, so every isolated pass — even SASS, where kernel-activity is off — has
+// the full launch inventory). Collector-thread-only: accumulated as launch
+// metas are consumed from the ring and emitted at session end after the
+// collector joins — same single-consumer contract as g_launchMetaByCorr, no
+// lock. std::map keeps keys sorted so the hash is order-independent (the
+// MULTISET property: benign async launch reordering must not change it). Scope
+// key = full user_scope path ("" = global); perf-scope reconciliation is the
+// deferred P2 backend scope work.
+static std::map<std::string, std::map<std::string, uint64_t>>
+    g_execSignatureByScope;
+
+// FNV-1a 64-bit over the canonical multiset encoding.
+static uint64_t Fnv1a64(const std::string& s) {
+    uint64_t h = 1469598103934665603ULL;
+    for (const unsigned char c : s) {
+        h ^= c;
+        h *= 1099511628211ULL;
+    }
+    return h;
+}
+
+// Accumulate one kernel launch into its scope's signature multiset. `rec` is a
+// KERNEL_LAUNCH_META carrying final launch dims (has_details). The key uses the
+// MANGLED name — byte-identical across passes, so no demangle is needed for the
+// cross-pass comparison. \x1f separates fields (never appears in names/dims).
+static void accumulateExecSignature(const ActivityRecord& rec) {
+    std::string key = rec.name;
+    key += '\x1f';
+    key += std::to_string(rec.grid_x);  key += ',';
+    key += std::to_string(rec.grid_y);  key += ',';
+    key += std::to_string(rec.grid_z);  key += '\x1f';
+    key += std::to_string(rec.block_x); key += ',';
+    key += std::to_string(rec.block_y); key += ',';
+    key += std::to_string(rec.block_z); key += '\x1f';
+    key += std::to_string(rec.dyn_shared);
+    const std::string scope =
+        (rec.user_scope[0] != '\0') ? rec.user_scope : std::string();
+    ++g_execSignatureByScope[scope][key];
+}
+
 // Worker-local sync-stack join map (Step 4c). The corr->stack join that ran
 // under CuptiBackend::sync_meta_mu_ in BufferCompleted now happens here on the
 // single collector thread, lock-free. Populated by SYNC_META records (sync
@@ -395,6 +440,40 @@ static void drainSyntheticKernels(Runtime* rt) {
     g_launchMetaByCorr.clear();
 }
 
+// Emit one execution_signature record per scope at session end — runs after the
+// ring is fully drained (every KERNEL_LAUNCH_META accumulated). Called on the
+// collector thread (post-loop) and again from Shutdown's post-join drain;
+// idempotent via clear(). std::map iteration is sorted, so the hash is a stable
+// function of the multiset. See g_execSignatureByScope.
+static void emitExecutionSignatures(Runtime* rt) {
+    if (g_execSignatureByScope.empty()) return;
+    if (!(rt && rt->logger)) return;
+    const int64_t ts = detail::GetTimestampNs();
+    for (const auto& [scope, kernels] : g_execSignatureByScope) {
+        std::string buf;
+        uint64_t launch_count = 0;
+        for (const auto& [k, cnt] : kernels) {  // sorted (std::map) -> stable hash
+            buf += k;
+            buf += '=';
+            buf += std::to_string(cnt);
+            buf += ';';
+            launch_count += cnt;
+        }
+        ExecutionSignatureEvent ev;
+        ev.session_id       = rt->session_id;
+        ev.ts_ns            = ts;
+        ev.scope_name       = scope;
+        ev.signature        = Fnv1a64(buf);
+        ev.launch_count     = launch_count;
+        ev.distinct_kernels = static_cast<uint32_t>(kernels.size());
+        rt->logger->write(model::ExecutionSignatureModel(ev));
+        GFL_LOG_DEBUG("[execSignature] scope='", scope, "' launches=",
+                      launch_count, " distinct=", kernels.size(),
+                      " sig=", ev.signature);
+    }
+    g_execSignatureByScope.clear();
+}
+
 // Consume + route ONE record from the ring buffer; returns false when empty.
 // File-scope (was a lambda inside CollectorLoop) so Monitor::Shutdown can
 // re-drain on the MAIN thread after joining the collector. On Windows
@@ -418,11 +497,21 @@ static bool collectorProcessNext() {
             // metas always have has_details=false, so duplicate-corr mem callbacks
             // resolve to the first/runtime one — its user-facing scope label.)
             auto it = g_launchMetaByCorr.find(rec.corr_id);
+            bool countForSignature = false;
             if (it == g_launchMetaByCorr.end()) {
                 g_launchMetaByCorr.emplace(rec.corr_id, rec);
+                // First record for this launch — count it once for the exec
+                // signature IF it already carries grid/block (a kernel launch).
+                // Dim-less metas (e.g. memcpy) are not kernel launches and are
+                // never counted.
+                countForSignature = rec.has_details;
             } else if (!it->second.has_details && rec.has_details) {
                 it->second = rec;
+                // Details arrived on the launch's 2nd callback (same corr) —
+                // count now; the emplace above skipped it for lack of dims.
+                countForSignature = true;
             }
+            if (countForSignature) accumulateExecSignature(rec);
             return true;
         }
         if (rec.type == TraceType::KERNEL_API_EXIT) {
@@ -703,6 +792,7 @@ void CollectorLoop() {
     // synthetic kernel rows it emits are included in this last flush.
     if (Runtime* rt = runtime(); rt && rt->logger) {
         drainSyntheticKernels(rt);
+        emitExecutionSignatures(rt);
         flushBatches(*rt->logger, rt->session_id);
     }
     GFL_LOG_DEBUG("[CollectorLoop] END");
@@ -720,6 +810,7 @@ void Monitor::Initialize(const MonitorOptions& opts) {
     // session left behind so corr ids can't collide across init/shutdown cycles.
     g_launchMetaByCorr.clear();
     g_syncStackByCorr.clear();  // Step 4c: same cross-session hygiene for syncs.
+    g_execSignatureByScope.clear();  // P2 exec-signature: drop prior session's multiset.
     g_kernelBatchId  = 0;
     g_memcpyBatchId  = 0;
     g_scopeBatch.clear();
@@ -784,6 +875,7 @@ void Monitor::Shutdown() {
             // (Windows process-exit can tear the collector down early). No-op
             // when CollectorLoop already drained them — the map is cleared.
             drainSyntheticKernels(rt);
+            emitExecutionSignatures(rt);
             flushBatches(*rt->logger, rt->session_id);
         }
         GFL_LOG_DEBUG("Monitor::Shutdown: post-join drained=", drained);

--- a/include/gpufl/core/monitor.cpp
+++ b/include/gpufl/core/monitor.cpp
@@ -393,8 +393,25 @@ static void emitKernelRecord(const ActivityRecord& rec,
 // nvidia-only SM properties this core TU must not reach for); we just carry it.
 // Idempotent: clears the map, so the second call from Monitor::Shutdown's
 // post-join drain is a no-op.
+// Set by the active backend at start() — see SetSuppressOrphanSyntheticKernels
+// in monitor.hpp. Engines where kernel-activity is intentionally off (SASS safe
+// mode) set this so we don't emit misleading synthetic kernel rows.
+static bool g_suppressOrphanSyntheticKernels = false;
+void SetSuppressOrphanSyntheticKernels(bool suppress) {
+    g_suppressOrphanSyntheticKernels = suppress;
+}
+
 static void drainSyntheticKernels(Runtime* rt) {
     if (g_launchMetaByCorr.empty()) return;
+    if (g_suppressOrphanSyntheticKernels) {
+        // SASS safe mode: kernel-activity is OFF (it deadlocks), so EVERY launch is
+        // orphaned here. A synthetic row's only "duration" would be the host-dispatch
+        // interval between consecutive launches — meaningless as GPU time — so drop
+        // them rather than emit misleading kernel rows. The Execution Signature was
+        // already accumulated from these metas during processing, so merge is unaffected.
+        g_launchMetaByCorr.clear();
+        return;
+    }
     if (!(rt && rt->logger)) return;
     const int64_t flushNs = detail::GetTimestampNs();
 

--- a/include/gpufl/core/monitor.cpp
+++ b/include/gpufl/core/monitor.cpp
@@ -61,6 +61,24 @@ static const std::string& DemangleKernelNameCached(const char* raw) {
         g_kernelNameDemangleCache.emplace(raw, gpufl::core::DemangleName(raw));
     return ins->second;
 }
+
+// Collector-thread cache for demangling the "name@source" function keys that
+// PC sampling interns. The PC_SAMPLE branch in collectorProcessNext runs only
+// on the collector thread (and on the main thread after the collector joins at
+// shutdown) — the same single-consumer contract as g_kernelNameDemangleCache,
+// so no lock. CUPTI hands PC/SASS function names MANGLED; demangling here gives
+// every engine ONE canonical kernel identity (matching Trace's already-
+// demangled kernel_dict) that the backend multi-pass merge can join on. NOTE:
+// SASS interns on the USER thread (PushProfileSamples) and uses its OWN burst-
+// local cache so this map stays single-threaded — do not share it from there.
+static std::unordered_map<std::string, std::string> g_functionKeyDemangleCache;
+static const std::string& DemangleFunctionKeyCached(const std::string& key) {
+    auto it = g_functionKeyDemangleCache.find(key);
+    if (it != g_functionKeyDemangleCache.end()) return it->second;
+    auto [ins, _] = g_functionKeyDemangleCache.emplace(
+        key, gpufl::core::DemangleFunctionKey(key));
+    return ins->second;
+}
 // Deferred kernel detail rows — written after the kernel batch so the
 // backend's UPDATE (match by corr_id) always finds the INSERT first.
 static std::vector<KernelDetailRow> g_pendingDetails;
@@ -516,10 +534,12 @@ static bool collectorProcessNext() {
                 kind = 1;  // "sass_metric"
             }
 
+            // Demangle the name part so PC sampling's function identity matches
+            // Trace's already-demangled kernel_dict for the cross-pass merge.
             const std::string func_key =
                 std::string(rec.function_name) + "@" + rec.source_file;
             const uint32_t function_id =
-                g_dictManager.internFunction(func_key);
+                g_dictManager.internFunction(DemangleFunctionKeyCached(func_key));
             // For PC sampling rows metric_name is empty; use reason_name so the
             // stall reason string is interned into metric_dict and reachable via
             // metric_id on the backend.  For SASS rows metric_name is always set.
@@ -884,12 +904,27 @@ void Monitor::PushProfileSamples(
     // takes g_scopeBatchMu (via lock_guard, not recursive), so re-entry
     // would deadlock.  CollectorLoop's 250 ms periodic drain handles flush.
     std::lock_guard lk(g_scopeBatchMu);
+    // Burst-local demangle cache (this runs on the USER thread). CUPTI hands
+    // SASS function names MANGLED; demangling makes SASS's function identity
+    // match Trace's already-demangled kernel_dict for the cross-pass merge.
+    // Local (not the collector-thread g_functionKeyDemangleCache) so the maps
+    // stay single-threaded and race-free; a burst shares few unique keys across
+    // its per-(pc_offset,metric) rows, so one map per drain dedups cheaply.
+    std::unordered_map<std::string, std::string> demangle_cache;
+    auto demangledKey =
+        [&demangle_cache](const std::string& key) -> const std::string& {
+        auto it = demangle_cache.find(key);
+        if (it != demangle_cache.end()) return it->second;
+        return demangle_cache
+            .emplace(key, gpufl::core::DemangleFunctionKey(key))
+            .first->second;
+    };
     for (const auto& s : samples) {
         ProfileSampleBatchRow row;
         row.ts_ns          = s.ts_ns;
         row.corr_id        = s.corr_id;
         row.device_id      = s.device_id;
-        row.function_id    = g_dictManager.internFunction(s.function_key);
+        row.function_id    = g_dictManager.internFunction(demangledKey(s.function_key));
         row.pc_offset      = s.pc_offset;
         row.metric_id      = g_dictManager.internMetric(s.metric_name);
         row.metric_value   = s.metric_value;

--- a/include/gpufl/core/monitor.hpp
+++ b/include/gpufl/core/monitor.hpp
@@ -207,6 +207,15 @@ struct PmSampleInput {
     double value = 0.0;
 };
 
+// Session-level switch (set by the active backend at start): when true the
+// collector DROPS orphaned launch metas at shutdown instead of emitting them as
+// synthetic kernel rows. Used for engines where kernel-activity is intentionally
+// off and the synthetic host-dispatch durations would mislead — SASS safe mode,
+// where real kernel activity deadlocks (NVIDIA CUPTI/driver bug). The Execution
+// Signature is accumulated separately, so a multi-pass merge is unaffected.
+// Default false: normal / PC modes keep best-effort synthesis.
+void SetSuppressOrphanSyntheticKernels(bool suppress);
+
 /**
  * @brief The central monitoring engine.
  */

--- a/include/gpufl/core/monitor.hpp
+++ b/include/gpufl/core/monitor.hpp
@@ -94,6 +94,7 @@ enum class ProfilingEngine {
     RangeProfiler,  // + Hardware throughput counters: SM / memory / tensor
                     // utilization, L1/L2 hit rates, DRAM bandwidth.
                     // (CUPTI Range Profiler; requires GPUFL_HAS_PERFWORKS)
+    RangeProfilerKernelReplay,  // Kernel-owned counters via AutoRange + KernelReplay.
     Deep,           // PcSampling + SassMetrics in a single run — the
                     // deepest single-session profile. (Was PcSamplingWithSass.)
 };
@@ -106,6 +107,8 @@ inline const char* ProfilingEngineWireName(const ProfilingEngine engine) {
         case ProfilingEngine::SassMetrics:   return "nvidia.sass_metrics";
         case ProfilingEngine::PmSampling:    return "nvidia.pm_sampling";
         case ProfilingEngine::RangeProfiler: return "nvidia.range_profiler";
+        case ProfilingEngine::RangeProfilerKernelReplay:
+            return "nvidia.range_profiler_kernel_replay";
         case ProfilingEngine::Deep:          return "nvidia.pc_sampling_with_sass";
     }
     return "nvidia.unknown";
@@ -120,6 +123,7 @@ inline const char* ProfilingEngineSessionKind(const ProfilingEngine engine) {
         case ProfilingEngine::SassMetrics:
         case ProfilingEngine::PmSampling:
         case ProfilingEngine::RangeProfiler:
+        case ProfilingEngine::RangeProfilerKernelReplay:
         case ProfilingEngine::Deep:
             return "trace";
     }

--- a/include/gpufl/core/stack_trace.cpp
+++ b/include/gpufl/core/stack_trace.cpp
@@ -197,3 +197,25 @@ std::string GetCallStack(int skipFrames) {
 }  // namespace gpufl
 
 #endif
+
+// ── Platform-agnostic helpers ──────────────────────────────────────────────
+// Defined once outside the per-OS guards above; they delegate to whichever
+// DemangleName() the active platform branch compiled.
+namespace gpufl {
+namespace core {
+
+std::string DemangleFunctionKey(const std::string& function_key) {
+    const std::string::size_type at = function_key.find('@');
+    if (at == std::string::npos) {
+        // No "@source" tail — demangle the whole key.
+        return DemangleName(function_key.c_str());
+    }
+    // Demangle only the name part; re-attach the "@source_file" tail verbatim
+    // so the (possibly '@'-free but otherwise arbitrary) source path survives
+    // exactly. Mangled names never contain '@', so the first '@' is the split.
+    const std::string name = function_key.substr(0, at);
+    return DemangleName(name.c_str()) + function_key.substr(at);
+}
+
+}  // namespace core
+}  // namespace gpufl

--- a/include/gpufl/core/stack_trace.hpp
+++ b/include/gpufl/core/stack_trace.hpp
@@ -48,4 +48,20 @@ std::string GetCallStack(int skipFrames = 1);
  * demangling fails or the input is not a mangled symbol.
  */
 std::string DemangleName(const char* mangled);
+
+/**
+ * Demangle the kernel-name portion of a "name@source_file" function key.
+ *
+ * SASS and PC-sampling intern their per-symbol identity as
+ * `function_name + "@" + source_file`, where `function_name` arrives
+ * MANGLED from CUPTI (e.g. "_Z18distinct_kernel_26Pfi@/path/foo.cu").
+ * Trace's kernel_dict names are already demangled (DemangleName on the
+ * activity-record path), so without demangling here the very same kernel
+ * carries two different identity strings across passes and the backend
+ * multi-pass merge can never join them. Splits at the FIRST '@' (Itanium /
+ * MSVC mangled names contain none), demangles the left part via
+ * DemangleName, and re-appends the "@source_file" tail verbatim. A key with
+ * no '@' is demangled whole.
+ */
+std::string DemangleFunctionKey(const std::string& function_key);
 }  // namespace gpufl::core

--- a/include/gpufl/gpufl.hpp
+++ b/include/gpufl/gpufl.hpp
@@ -107,6 +107,8 @@ struct InitOptions {
     //                   ~100× costlier on pre-sm_120 GPUs)
     //   PmSampling    — time-series hardware PM samples
     //   RangeProfiler — scope-level hardware throughput counters
+    //   RangeProfilerKernelReplay
+    //                 - kernel-level hardware counters via CUPTI KernelReplay
     //   Deep          — PcSampling + SassMetrics in one run
     ProfilingEngine profiling_engine = ProfilingEngine::Monitor;
 

--- a/include/gpufl/inject/inject_entry.cpp
+++ b/include/gpufl/inject/inject_entry.cpp
@@ -446,6 +446,12 @@ void doInjectInit() {
         // the launcher's chosen dir.
         opts.log_path = std::string(v) + "/app.log";
     }
+#ifdef _WIN32
+    // Windows CUDA injection can leave the process through CRT/driver teardown
+    // paths where the final logger close is not reliable. Keep each NDJSON line
+    // durable even if a clean shutdown/compress step is missed.
+    opts.flush_logs_always = true;
+#endif
     // gpufl::init() reads the rest of the GPUFL_* env vars itself,
     // including GPUFL_PROFILING_ENGINE — it is the single string->enum
     // engine parser (see gpufl.cpp). It also reads backend_url, api_key,

--- a/include/gpufl/inject/inject_entry.cpp
+++ b/include/gpufl/inject/inject_entry.cpp
@@ -19,6 +19,8 @@
 
 #include "gpufl/inject/inject_entry.hpp"
 
+#include "gpufl/core/env_vars.hpp"
+
 #include <atomic>
 #include <chrono>
 #include <condition_variable>
@@ -96,14 +98,14 @@ uint64_t nextProcessScopeId() {
 }
 
 std::string processScopeName() {
-    if (const char* app = std::getenv(gpufl::inject::kEnvAppName)) {
+    if (const char* app = std::getenv(gpufl::env::kAppName)) {
         if (app[0] != '\0') return std::string("process:") + app;
     }
     return "process:gpufl_injected_target";
 }
 
 bool engineNeedsPerfScope() {
-    const char* engine = std::getenv(gpufl::inject::kEnvProfilingEngine);
+    const char* engine = std::getenv(gpufl::env::kProfilingEngine);
     if (!engine || engine[0] == '\0') return true;
     return std::strcmp(engine, "Monitor") != 0 && std::strcmp(engine, "Trace") != 0;
 }
@@ -169,7 +171,7 @@ void sleepMs(int milliseconds) {
 
 void writeCompletionByteIfRequested() {
 #ifndef _WIN32
-    const char* fd_str = envOrNull(gpufl::inject::kEnvCompletionFd);
+    const char* fd_str = envOrNull(gpufl::env::kInjectCompletionFd);
     if (!fd_str) return;
     int fd = std::atoi(fd_str);
     if (fd <= 0) return;
@@ -199,7 +201,7 @@ void shutdownAndSignal() {
     gpufl::detail::setProcessExitTeardown(true);
 #endif
     if (g_init_ok.load(std::memory_order_acquire)) {
-        sleepMs(envIntOrDefault("GPUFL_INJECT_SHUTDOWN_DELAY_MS", 0));
+        sleepMs(envIntOrDefault(gpufl::env::kInjectShutdownDelayMs, 0));
         GFL_LOG_DEBUG("inject: endProcessScope()");
         endProcessScope();
         GFL_LOG_DEBUG("inject: gpufl::shutdown()");
@@ -215,9 +217,9 @@ void shutdownAndSignal() {
         if (g_do_upload.load(std::memory_order_relaxed) && !g_log_path.empty()) {
             gpufl::UploadOptions uopts;
             uopts.log_path = g_log_path;
-            if (const char* v = envOrNull("GPUFL_BACKEND_URL")) uopts.backend_url = v;
-            if (const char* v = envOrNull("GPUFL_API_KEY"))     uopts.api_key = v;
-            if (const char* v = envOrNull("GPUFL_API_PATH"))    uopts.api_path = v;
+            if (const char* v = envOrNull(gpufl::env::kBackendUrl)) uopts.backend_url = v;
+            if (const char* v = envOrNull(gpufl::env::kApiKey))     uopts.api_key = v;
+            if (const char* v = envOrNull(gpufl::env::kApiPath))    uopts.api_path = v;
             uopts.report_progress = false;  // don't pollute the target's stderr
             (void)gpufl::uploadLogs(uopts);
         }
@@ -252,11 +254,11 @@ void waitForDeferredInitForMs(const int wait_ms) {
 }
 
 void waitAtCudaSyncBoundary() {
-    waitForDeferredInitForMs(envIntOrDefault("GPUFL_INJECT_SYNC_WAIT_MS", 15000));
+    waitForDeferredInitForMs(envIntOrDefault(gpufl::env::kInjectSyncWaitMs, 15000));
 }
 
 void waitAtCudaLaunchBoundary() {
-    waitForDeferredInitForMs(envIntOrDefault("GPUFL_INJECT_LAUNCH_WAIT_MS", 15000));
+    waitForDeferredInitForMs(envIntOrDefault(gpufl::env::kInjectLaunchWaitMs, 15000));
 }
 #endif  // !_WIN32
 
@@ -412,12 +414,12 @@ void doInjectInit() {
     // Sentinel guard — set by the launcher. Without it, treat the
     // preload as accidental (e.g. `LD_PRELOAD=...:libgpufl_inject.so`
     // leaking into a shell) and return silently.
-    const char* sentinel = envOrNull(gpufl::inject::kEnvSentinel);
+    const char* sentinel = envOrNull(gpufl::env::kInject);
     if (!sentinel || std::strcmp(sentinel, "1") != 0) return;
 
     // Pick the profile preset.
     gpufl::InitOptions opts;
-    if (const char* p = envOrNull(gpufl::inject::kEnvProfile)) {
+    if (const char* p = envOrNull(gpufl::env::kInjectProfile)) {
         if (std::strcmp(p, gpufl::inject::kProfileLight) == 0) {
             opts = gpufl::light_mode_default_options();
         } else if (std::strcmp(p, gpufl::inject::kProfileMonitoringOnly) == 0) {
@@ -434,10 +436,10 @@ void doInjectInit() {
     // Layered overrides — env vars beat preset defaults but lose to
     // gpufl::init()'s own remote-config / programmatic tuning that
     // happens downstream of this struct.
-    if (const char* v = envOrNull(gpufl::inject::kEnvAppName)) {
+    if (const char* v = envOrNull(gpufl::env::kAppName)) {
         opts.app_name = v;
     }
-    if (const char* v = envOrNull(gpufl::inject::kEnvLogDir)) {
+    if (const char* v = envOrNull(gpufl::env::kLogDir)) {
         // Init expects a file path; the launcher provides the dir,
         // we tack on app.log so log_rotator's three NDJSON channels
         // (app.device.log / app.scope.log / app.system.log) land in
@@ -451,12 +453,12 @@ void doInjectInit() {
 
     // Capture what the atexit upload path needs (see shutdownAndSignal).
     g_log_path = opts.log_path;
-    if (const char* u = envOrNull(gpufl::inject::kEnvUpload)) {
+    if (const char* u = envOrNull(gpufl::env::kInjectUpload)) {
         g_do_upload.store(std::strcmp(u, "1") == 0, std::memory_order_relaxed);
     }
 
     if (gpufl::init(opts)) {
-        if (envIntOrDefault("GPUFL_INJECT_PROCESS_SCOPE", 1) != 0) {
+        if (envIntOrDefault(gpufl::env::kInjectProcessScope, 1) != 0) {
             beginProcessScope();
         }
         g_init_ok.store(true, std::memory_order_release);
@@ -491,7 +493,7 @@ void startDeferredInjectInit() {
         // injection path. CUPTI subscription/activity setup can report
         // success there but later deliver no callbacks. Step out of that
         // callback frame before touching CUPTI.
-        sleepMs(envIntOrDefault("GPUFL_INJECT_INIT_DELAY_MS", 1));
+        sleepMs(envIntOrDefault(gpufl::env::kInjectInitDelayMs, 1));
         try {
             std::call_once(g_init_once, doInjectInit);
         } catch (...) {
@@ -556,7 +558,7 @@ GPUFL_INJECT_EXPORT int InitializeInjectionNvtx2(
 // been verified to tolerate pre-cuInit subscribe.
 #ifndef _WIN32
 [[gnu::constructor]] static void gpuflInjectCtor() {
-    const char* opt_in = std::getenv("GPUFL_INJECT_USE_CONSTRUCTOR");
+    const char* opt_in = std::getenv(gpufl::env::kInjectUseConstructor);
     if (!opt_in || std::strcmp(opt_in, "1") != 0) return;
     std::call_once(g_init_once, doInjectInit);
 }

--- a/include/gpufl/inject/inject_entry.hpp
+++ b/include/gpufl/inject/inject_entry.hpp
@@ -30,6 +30,19 @@ constexpr const char* kEnvProfile = "GPUFL_INJECT_PROFILE";
 // "RangeProfiler" | "Deep". Empty = use the profile's default engine.
 constexpr const char* kEnvProfilingEngine = "GPUFL_PROFILING_ENGINE";
 
+// Multi-pass profiling grouping (P1). The launcher's multi-pass driver runs
+// the SAME workload once per pass (one isolated CUPTI engine each) and tags
+// every child with these so the backend can stitch the passes into a single
+// "analysis". gpufl::init() reads them straight from the env (it is the single
+// parser, like kEnvProfilingEngine) into the job_start event. Unset on an
+// ordinary single-pass `gpufl trace` run.
+//   kEnvAnalysisId : stable id shared by all passes of one analysis.
+//   kEnvPassIndex  : this pass's 0-based position within the analysis.
+//   kEnvPassCount  : total passes planned (backend detects a missing pass).
+constexpr const char* kEnvAnalysisId = "GPUFL_ANALYSIS_ID";
+constexpr const char* kEnvPassIndex  = "GPUFL_PASS_INDEX";
+constexpr const char* kEnvPassCount  = "GPUFL_PASS_COUNT";
+
 // Opt-in: when "1", the inject lib runs gpufl::uploadLogs() right after
 // gpufl::shutdown() returns (and before signalling completion), shipping
 // the session's NDJSON to the backend. Creds come from the standard

--- a/include/gpufl/inject/inject_entry.hpp
+++ b/include/gpufl/inject/inject_entry.hpp
@@ -1,72 +1,19 @@
 #pragma once
 
-// Env-var names and profile constants shared between the launcher binary
-// (`gpufl trace`) and the injection shared library (`libgpufl_inject.so`).
-// The launcher sets these in the child env before fork+exec; the inject
-// lib's constructor reads them to drive gpufl::init().
+// Profile-preset VALUE constants shared between the launcher binary
+// (`gpufl trace --profile`) and the injection shared library.
+//
+// NOTE: the environment-variable NAME constants that used to live here (kEnv*)
+// moved to gpufl/core/env_vars.hpp (namespace gpufl::env) so every env-var name
+// lives in exactly one place — read/set env through those. This file now holds
+// only the profile-preset string VALUES below (selected via env::kInjectProfile).
 
 namespace gpufl::inject {
 
-// Sentinel — the inject lib's constructor returns silently if this is
-// not "1" in the environment. Stops accidental LD_PRELOAD into shells
-// or system utilities from firing CUPTI.
-constexpr const char* kEnvSentinel = "GPUFL_INJECT";
-
-// Session display name. Default: basename of the launched command.
-constexpr const char* kEnvAppName = "GPUFL_APP_NAME";
-
-// Local NDJSON output directory (will get an `app.log` appended for
-// gpufl::InitOptions.log_path).
-constexpr const char* kEnvLogDir = "GPUFL_LOG_DIR";
-
-// Profile preset: "comprehensive" (default) | "light" | "monitoring-only".
-// Maps to one of the `*_default_options()` factories in gpufl.hpp.
-constexpr const char* kEnvProfile = "GPUFL_INJECT_PROFILE";
-
-// Override the profiling engine. The launcher validates the value and
-// forwards it verbatim; gpufl::init() is the single parser for this var
-// (see gpufl.cpp), so the inject lib does NOT parse it. Canonical values:
-// "Monitor" | "Trace" | "PcSampling" | "SassMetrics" | "PmSampling" |
-// "RangeProfiler" | "Deep". Empty = use the profile's default engine.
-constexpr const char* kEnvProfilingEngine = "GPUFL_PROFILING_ENGINE";
-
-// Multi-pass profiling grouping (P1). The launcher's multi-pass driver runs
-// the SAME workload once per pass (one isolated CUPTI engine each) and tags
-// every child with these so the backend can stitch the passes into a single
-// "analysis". gpufl::init() reads them straight from the env (it is the single
-// parser, like kEnvProfilingEngine) into the job_start event. Unset on an
-// ordinary single-pass `gpufl trace` run.
-//   kEnvAnalysisId : stable id shared by all passes of one analysis.
-//   kEnvPassIndex  : this pass's 0-based position within the analysis.
-//   kEnvPassCount  : total passes planned (backend detects a missing pass).
-constexpr const char* kEnvAnalysisId = "GPUFL_ANALYSIS_ID";
-constexpr const char* kEnvPassIndex  = "GPUFL_PASS_INDEX";
-constexpr const char* kEnvPassCount  = "GPUFL_PASS_COUNT";
-
-// Opt-in: when "1", the inject lib runs gpufl::uploadLogs() right after
-// gpufl::shutdown() returns (and before signalling completion), shipping
-// the session's NDJSON to the backend. Creds come from the standard
-// GPUFL_API_KEY / GPUFL_BACKEND_URL / GPUFL_API_PATH env vars (the same
-// ones gpufl::init() reads). Set by the launcher's `--upload` flag, which
-// pre-checks that the key + url are present before exec.
-constexpr const char* kEnvUpload = "GPUFL_INJECT_UPLOAD";
-
-// Phase 2: write end of an anonymous pipe inherited via fork. Inject
-// lib writes a single byte after gpufl::shutdown() returns so the
-// launcher knows uploads are drained. Empty = no completion signal.
-constexpr const char* kEnvCompletionFd = "GPUFL_INJECT_COMPLETION_FD";
-
-// Opt-in: when set to "1", the inject lib's __attribute__((constructor))
-// runs gpufl::init() at ld.so time (before main, before cuInit). Default
-// off because the Phase 0.1 spike showed CUPTI subscribe before cuInit
-// segfaults on no-CUDA targets. With this off, only InitializeInjection
-// (called by libcuda after cuInit) drives init.
-constexpr const char* kEnvUseConstructor = "GPUFL_INJECT_USE_CONSTRUCTOR";
-
 // Profile-name string values (must stay in sync with the launcher's
-// `--profile` flag parsing).
-constexpr const char* kProfileComprehensive = "comprehensive";
-constexpr const char* kProfileLight         = "light";
+// `--profile` flag parsing in cli_parse.cpp).
+constexpr const char* kProfileComprehensive  = "comprehensive";
+constexpr const char* kProfileLight          = "light";
 constexpr const char* kProfileMonitoringOnly = "monitoring-only";
 
 }  // namespace gpufl::inject

--- a/include/gpufl/report/text_report.cpp
+++ b/include/gpufl/report/text_report.cpp
@@ -33,6 +33,17 @@ std::string fmtBytes(uint64_t n) {
     return std::to_string(n) + " B";
 }
 
+std::string fmtMaybeBytes(int64_t n) {
+    return n >= 0 ? fmtBytes(static_cast<uint64_t>(n)) : "n/a";
+}
+
+std::string fmtMaybePct(double v) {
+    if (v < 0 || !std::isfinite(v)) return "n/a";
+    std::ostringstream oss;
+    oss << std::fixed << std::setprecision(1) << v << "%";
+    return oss.str();
+}
+
 std::string fmtDuration(double ms) {
     std::ostringstream oss;
     if (ms >= 1000.0)      oss << std::fixed << std::setprecision(2) << (ms / 1000.0) << " s";
@@ -363,6 +374,21 @@ void TextReport::parseDeviceLog(const std::vector<JsonValue>& records,
             }
         } else if (type == "kernel_detail") {
             details[rec.value<unsigned>("corr_id", 0u)] = rec;
+        } else if (type == "kernel_perf_metric_event") {
+            PerfMetricRecord pm;
+            pm.target_kind = "Kernel";
+            pm.name = rec.value<std::string>("kernel_name", "");
+            if (pm.name.empty()) pm.name = rec.value<std::string>("range_name", "");
+            pm.range_name = rec.value<std::string>("range_name", "");
+            pm.launch_ordinal = rec.value<unsigned>("launch_ordinal", 0u);
+            pm.device_id = rec.value<int>("device_id", 0);
+            pm.sm_throughput_pct = rec.value<double>("sm_throughput_pct", -1.0);
+            pm.l1_hit_rate_pct = rec.value<double>("l1_hit_rate_pct", -1.0);
+            pm.l2_hit_rate_pct = rec.value<double>("l2_hit_rate_pct", -1.0);
+            pm.dram_read_bytes = rec.value<int64_t>("dram_read_bytes", -1);
+            pm.dram_write_bytes = rec.value<int64_t>("dram_write_bytes", -1);
+            pm.tensor_active_pct = rec.value<double>("tensor_active_pct", -1.0);
+            if (!pm.name.empty()) perf_metrics_.push_back(std::move(pm));
         } else if (type == "memcpy_event_batch") {
             auto ci = buildColumnIndex(rec["columns"]);
             int64_t base = rec.value<int64_t>("base_time_ns", 0);
@@ -473,6 +499,21 @@ void TextReport::parseScopeLog(const std::vector<JsonValue>& records,
                     lookupOr(scope_name_dict, scope_id, "scope_"),
                 });
             }
+        } else if (type == "perf_metric_event") {
+            PerfMetricRecord pm;
+            pm.target_kind = "Scope";
+            pm.name = rec.value<std::string>("name", "");
+            if (pm.name.empty()) pm.name = rec.value<std::string>("user_scope", "");
+            pm.device_id = rec.value<int>("device_id", 0);
+            pm.start_ns = rec.value<int64_t>("start_ns", 0);
+            pm.end_ns = rec.value<int64_t>("end_ns", 0);
+            pm.sm_throughput_pct = rec.value<double>("sm_throughput_pct", -1.0);
+            pm.l1_hit_rate_pct = rec.value<double>("l1_hit_rate_pct", -1.0);
+            pm.l2_hit_rate_pct = rec.value<double>("l2_hit_rate_pct", -1.0);
+            pm.dram_read_bytes = rec.value<int64_t>("dram_read_bytes", -1);
+            pm.dram_write_bytes = rec.value<int64_t>("dram_write_bytes", -1);
+            pm.tensor_active_pct = rec.value<double>("tensor_active_pct", -1.0);
+            if (!pm.name.empty()) perf_metrics_.push_back(std::move(pm));
         } else if (type == "sass_config") {
             sass_active_ = true;
         }
@@ -539,6 +580,7 @@ std::string TextReport::generate() const {
     writeMemcpySummary(out);
     writeSystemMetrics(out);
     writeScopeSummary(out);
+    writePerfMetricsSummary(out);
     writePmSamplingSummary(out);
     writeProfileAnalysis(out);
     return out.str();
@@ -1029,6 +1071,51 @@ void TextReport::writeScopeSummary(std::ostringstream& out) const {
                    "Use GPU Time to compare kernel perf.\n";
         }
     }
+}
+
+void TextReport::writePerfMetricsSummary(std::ostringstream& out) const {
+    if (perf_metrics_.empty()) return;
+
+    out << "\n" << SEP << "\n  Range Profiler Counters\n" << SEP << "\n";
+    out << "  Total Counter Rows:   " << perf_metrics_.size() << "\n\n";
+
+    std::vector<const PerfMetricRecord*> rows;
+    rows.reserve(perf_metrics_.size());
+    for (const auto& r : perf_metrics_) rows.push_back(&r);
+    std::sort(rows.begin(), rows.end(), [](const auto* a, const auto* b) {
+        auto score = [](const PerfMetricRecord* r) {
+            return r->sm_throughput_pct >= 0 ? r->sm_throughput_pct : 0.0;
+        };
+        return score(a) > score(b);
+    });
+    if (top_n_ > 0 && static_cast<int>(rows.size()) > top_n_) rows.resize(top_n_);
+
+    out << "  " << std::left << std::setw(8) << "Target"
+        << std::setw(32) << "Name"
+        << std::right << std::setw(10) << "SM"
+        << std::setw(10) << "L1"
+        << std::setw(10) << "L2"
+        << std::setw(10) << "Tensor"
+        << std::setw(14) << "DRAM R"
+        << std::setw(14) << "DRAM W" << "\n";
+    out << "  " << std::string(108, '-') << "\n";
+
+    for (const auto* r : rows) {
+        const std::string display_name =
+            r->target_kind == "Kernel" ? shortenKernelName(r->name) : r->name;
+        out << "  " << std::left << std::setw(8) << r->target_kind
+            << std::setw(32) << truncate(display_name, 30)
+            << std::right << std::setw(10) << fmtMaybePct(r->sm_throughput_pct)
+            << std::setw(10) << fmtMaybePct(r->l1_hit_rate_pct)
+            << std::setw(10) << fmtMaybePct(r->l2_hit_rate_pct)
+            << std::setw(10) << fmtMaybePct(r->tensor_active_pct)
+            << std::setw(14) << fmtMaybeBytes(r->dram_read_bytes)
+            << std::setw(14) << fmtMaybeBytes(r->dram_write_bytes)
+            << "\n";
+    }
+
+    out << "\n  Note: Scope rows come from RangeProfiler; kernel rows come from "
+           "RangeProfilerKernelReplay.\n";
 }
 
 

--- a/include/gpufl/report/text_report.hpp
+++ b/include/gpufl/report/text_report.hpp
@@ -113,6 +113,22 @@ class TextReport {
         std::string scope_name;
     };
 
+    struct PerfMetricRecord {
+        std::string target_kind;
+        std::string name;
+        std::string range_name;
+        uint32_t launch_ordinal = 0;
+        int device_id = 0;
+        int64_t start_ns = 0;
+        int64_t end_ns = 0;
+        double sm_throughput_pct = -1.0;
+        double l1_hit_rate_pct = -1.0;
+        double l2_hit_rate_pct = -1.0;
+        int64_t dram_read_bytes = -1;
+        int64_t dram_write_bytes = -1;
+        double tensor_active_pct = -1.0;
+    };
+
     struct SessionInfo {
         std::string app_name;
         std::string session_id;
@@ -155,6 +171,7 @@ class TextReport {
     std::vector<ScopeEventRecord> scope_events_;
     std::vector<ProfileSampleRecord> profile_samples_;
     std::vector<PmSampleRecord> pm_samples_;
+    std::vector<PerfMetricRecord> perf_metrics_;
     std::vector<CaptureCapabilityRecord> capture_capabilities_;
     std::string requested_engine_;
     std::string selected_engine_;
@@ -191,6 +208,7 @@ class TextReport {
     void writeMemcpySummary(std::ostringstream& out) const;
     void writeSystemMetrics(std::ostringstream& out) const;
     void writeScopeSummary(std::ostringstream& out) const;
+    void writePerfMetricsSummary(std::ostringstream& out) const;
     void writePmSamplingSummary(std::ostringstream& out) const;
     void writeProfileAnalysis(std::ostringstream& out) const;
 };

--- a/python/bindings.cpp
+++ b/python/bindings.cpp
@@ -75,6 +75,8 @@ PYBIND11_MODULE(_gpufl_client, m) {
         .value("SassMetrics",   gpufl::ProfilingEngine::SassMetrics)
         .value("PmSampling",    gpufl::ProfilingEngine::PmSampling)
         .value("RangeProfiler", gpufl::ProfilingEngine::RangeProfiler)
+        .value("RangeProfilerKernelReplay",
+               gpufl::ProfilingEngine::RangeProfilerKernelReplay)
         .value("Deep",          gpufl::ProfilingEngine::Deep)
         .export_values();
 
@@ -91,6 +93,7 @@ PYBIND11_MODULE(_gpufl_client, m) {
         .def_readwrite("enable_debug_output",   &gpufl::InitOptions::enable_debug_output)
         .def_readwrite("enable_stack_trace",    &gpufl::InitOptions::enable_stack_trace)
         .def_readwrite("enable_source_collection", &gpufl::InitOptions::enable_source_collection)
+        .def_readwrite("flush_logs_always",     &gpufl::InitOptions::flush_logs_always)
         // feature gates — surfaced on the InitOptions class so
         // power users can tweak them via the dataclass-style API.
         .def_readwrite("enable_external_correlation", &gpufl::InitOptions::enable_external_correlation)
@@ -155,7 +158,8 @@ PYBIND11_MODULE(_gpufl_client, m) {
                      uint32_t pm_sampling_max_samples,
                      std::string pm_sampling_preset,
                      std::vector<std::string> pm_sampling_metrics,
-                     bool pm_sampling_scope_only) -> bool {
+                     bool pm_sampling_scope_only,
+                     bool flush_logs_always) -> bool {
 
         gpufl::InitOptions opts;
         opts.app_name              = app_name;
@@ -167,6 +171,7 @@ PYBIND11_MODULE(_gpufl_client, m) {
         opts.enable_debug_output   = enable_debug_output;
         opts.enable_stack_trace    = enable_stack_trace;
         opts.enable_source_collection = enable_source_collection;
+        opts.flush_logs_always     = flush_logs_always;
         opts.profiling_engine      = profiling_engine;
         opts.config_file           = config_file;
         opts.backend_url           = std::move(backend_url);
@@ -205,7 +210,8 @@ PYBIND11_MODULE(_gpufl_client, m) {
        py::arg("pm_sampling_max_samples")     = 4096,
        py::arg("pm_sampling_preset")          = "overview",
        py::arg("pm_sampling_metrics")         = std::vector<std::string>{},
-       py::arg("pm_sampling_scope_only")      = true);
+       py::arg("pm_sampling_scope_only")      = true,
+       py::arg("flush_logs_always")           = false);
 
     m.def("system_start", [](std::string name) { gpufl::systemStart(std::move(name)); },
         py::arg("name") = "system");

--- a/python/gpufl/__init__.py
+++ b/python/gpufl/__init__.py
@@ -548,7 +548,7 @@ def init(*args, backend_url=None, api_key=None, remote_upload=None,
             stacklevel=2)
         kwargs['continuous_system_sampling'] = kwargs.pop('sampling_auto_start')
 
-    # ── Multi-pass analysis grouping (embedded / P3 targeting) ──────────
+    # ── Multi-pass analysis grouping ──────────
     # Let an embedded job self-tag as one pass of an analysis group without
     # going through the launcher's --passes driver. gpufl::init() reads
     # GPUFL_ANALYSIS_ID / _PASS_INDEX / _PASS_COUNT straight from the
@@ -1110,7 +1110,7 @@ def clean_logs(log_path=None, log_prefix=None, *, dry_run=False):
     return removed
 
 
-# ── Targeting: bounded multi-pass profiling for embedded jobs (P3) ───────────
+# ── Targeting: bounded multi-pass profiling for embedded jobs ───────────
 # Defined in a submodule (keeps __init__ lean); imported here, after Scope /
 # session exist, so `gpufl.targeting(...)` resolves. The submodule lazy-imports
 # Scope/session at call time, so this import is cycle-free.

--- a/python/gpufl/__init__.py
+++ b/python/gpufl/__init__.py
@@ -436,7 +436,8 @@ def _apply_eager_module_loading(profiling_engine):
 _original_init = init
 
 def init(*args, backend_url=None, api_key=None, remote_upload=None,
-         enabled=True, **kwargs):
+         enabled=True, analysis_id=None, pass_index=None, pass_count=None,
+         **kwargs):
     """Initialize GPUFlight.
 
     Configuration precedence (low → high). Each layer may override the
@@ -477,6 +478,27 @@ def init(*args, backend_url=None, api_key=None, remote_upload=None,
             ``on``) forces the same behavior regardless of this kwarg —
             that way you can disable gpufl for a one-off run without
             editing code: ``GPUFL_DISABLED=1 python train.py``.
+        analysis_id: Tag this run as one pass of a multi-pass "analysis
+            group" so the backend merges it with its sibling passes. Run
+            the SAME targeted workload once per engine with a shared
+            ``analysis_id`` and a distinct ``pass_index``; the dashboard's
+            Analysis Group view then shows the merged cross-engine result
+            (timing from the Trace pass, stalls from PcSampling, SASS rows
+            from SassMetrics). Sets ``GPUFL_ANALYSIS_ID`` for the C++ core
+            (an explicit value wins over a pre-set env var). None → an
+            ordinary single run that is not grouped.
+
+            Note: CUPTI allows only ONE profiling engine per process, so a
+            multi-engine deep-dive is several runs (one engine each),
+            NOT one process — bound each run to the hot region (e.g. break
+            the loop after a few iterations, or load a checkpoint) so a
+            long job isn't re-run end to end.
+        pass_index: 0-based position of this run within the analysis group.
+            Only meaningful alongside ``analysis_id``. Sets
+            ``GPUFL_PASS_INDEX``.
+        pass_count: Total passes planned for the analysis group (lets the
+            backend flag a missing/failed pass). Only meaningful alongside
+            ``analysis_id``. Sets ``GPUFL_PASS_COUNT``.
         **kwargs: All other InitOptions fields passed to C++ init.
 
     Returns:
@@ -525,6 +547,23 @@ def init(*args, backend_url=None, api_key=None, remote_upload=None,
             DeprecationWarning,
             stacklevel=2)
         kwargs['continuous_system_sampling'] = kwargs.pop('sampling_auto_start')
+
+    # ── Multi-pass analysis grouping (embedded / P3 targeting) ──────────
+    # Let an embedded job self-tag as one pass of an analysis group without
+    # going through the launcher's --passes driver. gpufl::init() reads
+    # GPUFL_ANALYSIS_ID / _PASS_INDEX / _PASS_COUNT straight from the
+    # environment (see include/gpufl/core/gpufl.cpp + env_vars.hpp); writing
+    # them via os.environ here makes them visible to that getenv at C++ init
+    # in this same process. An explicit kwarg overwrites a pre-set env var
+    # (the launcher path), so embedded and launcher use don't both apply.
+    # pass_index/pass_count are only honored by the core when analysis_id is
+    # set, so we gate them the same way.
+    if analysis_id is not None:
+        os.environ['GPUFL_ANALYSIS_ID'] = str(analysis_id)
+        if pass_index is not None:
+            os.environ['GPUFL_PASS_INDEX'] = str(int(pass_index))
+        if pass_count is not None:
+            os.environ['GPUFL_PASS_COUNT'] = str(int(pass_count))
 
     # Resolve env-var fallbacks. Doing this in Python lets explicit
     # kwargs win over env; the C++ layer also does env fallback for
@@ -1071,8 +1110,14 @@ def clean_logs(log_path=None, log_prefix=None, *, dry_run=False):
     return removed
 
 
+# ── Targeting: bounded multi-pass profiling for embedded jobs (P3) ───────────
+# Defined in a submodule (keeps __init__ lean); imported here, after Scope /
+# session exist, so `gpufl.targeting(...)` resolves. The submodule lazy-imports
+# Scope/session at call time, so this import is cycle-free.
+from ._targeting import targeting  # noqa: E402
+
 __all__ = [
-    "Scope", "init", "shutdown", "session", "clean_logs",
+    "Scope", "init", "shutdown", "session", "clean_logs", "targeting",
     "system_start", "system_stop",
     "BackendKind", "InitOptions", "ProfilingEngine",
     "upload_logs", "UploadOptions", "UploadResult",

--- a/python/gpufl/__init__.py
+++ b/python/gpufl/__init__.py
@@ -223,6 +223,7 @@ except ImportError as e:
         SassMetrics   = "SassMetrics"
         PmSampling    = "PmSampling"
         RangeProfiler = "RangeProfiler"
+        RangeProfilerKernelReplay = "RangeProfilerKernelReplay"
         Deep          = "Deep"
 
     class InitOptions:

--- a/python/gpufl/_targeting.py
+++ b/python/gpufl/_targeting.py
@@ -1,0 +1,157 @@
+"""Targeted multi-pass profiling for long embedded jobs (P3).
+
+A multi-day training job can't be re-run end-to-end per engine, and CUPTI
+runs only ONE profiling engine per process (re-init is unsupported). So a
+multi-engine deep-dive of a hot scope is **N short runs — one engine each,
+sharing an analysis_id** — orchestrated as separate PROCESSES, not several
+engines in one live ``with`` block.
+
+You name the engines in ONE place — the launcher — which spawns one process
+per engine and auto-assigns the ``analysis_id`` + ``pass_index`` +
+``pass_count`` + engine (via the ``GPUFL_*`` env vars the C++ core reads)::
+
+    gpufl trace --passes Trace,RangeProfiler,PcSampling -- python train.py
+
+Your script stays **engine-agnostic** — ``targeting()`` inherits its assigned
+engine and analysis-group labels from the environment; you only describe the
+WINDOW (which scope, how many iterations)::
+
+    import gpufl
+
+    with gpufl.targeting("attn_block", iters=20, warmup=5) as run:
+        for batch in run.steps(loader):     # auto-stops after warmup+iters
+            train_step(batch)
+
+Each launcher pass re-runs the same script with a different engine, bounded
+to the window, and the dashboard's Analysis Group view merges them for the
+"attn_block" scope — no ``pass_index`` / ``pass_count`` bookkeeping in your
+code. (Hot scope early in training → the bounded window keeps each pass
+short; a scope deep in a long run wants a checkpoint loaded just before it.)
+
+**Standalone (no launcher)** — pass ``engine=`` explicitly (otherwise the run
+is Monitor-only, no kernel profiling); to self-group several runs without the
+launcher, pass a shared ``analysis_id=`` and a distinct ``pass_index=`` per
+run. Prefer the launcher, which does all of that for you.
+
+When gpufl is disabled (``GPUFL_DISABLED=1``, or init failed / no GPU) the run
+degrades to a pass-through: every item is yielded, no scope is opened, and the
+window NEVER truncates the loop — toggling gpufl off leaves training unchanged.
+"""
+
+from contextlib import contextmanager
+
+
+class TargetingRun:
+    """Handle yielded by :func:`gpufl.targeting`. Brackets each step's hot
+    region with the target scope and closes the profiling window after
+    ``warmup + iters`` measured steps.
+
+    Use :meth:`steps` to wrap an iterable (auto-stops the loop), or
+    :meth:`step` per iteration for hand-written loops (check :attr:`done`).
+    """
+
+    def __init__(self, scope, tag, iters, warmup, scope_factory, enabled=True):
+        self._scope = scope
+        self._tag = tag
+        # iters=None → no auto-stop: scope every step until the loop ends.
+        self._iters = iters
+        self._warmup = warmup or 0
+        self._scope_factory = scope_factory  # injected gpufl.Scope (no import cycle)
+        self._enabled = enabled
+        self._measured = 0
+        self._warmups_done = 0
+        self.done = False
+
+    @contextmanager
+    def step(self):
+        """Bracket one step's hot region with the target scope.
+
+        Warmup steps open a ``<scope>_warmup`` sub-scope (excluded from the
+        measured window); measured steps open ``<scope>``. After the window
+        closes (or when disabled), this is a zero-overhead pass-through that
+        opens no scope and never counts — so trailing iterations are free
+        and the loop is never truncated when gpufl is off.
+        """
+        if not self._enabled or self.done:
+            yield self
+            return
+        in_warmup = self._warmups_done < self._warmup
+        name = f"{self._scope}_warmup" if in_warmup else self._scope
+        with self._scope_factory(name, self._tag):
+            yield self
+        if in_warmup:
+            self._warmups_done += 1
+        else:
+            self._measured += 1
+            if self._iters is not None and self._measured >= self._iters:
+                self.done = True
+
+    def steps(self, iterable):
+        """Yield items from ``iterable``, bracketing each with :meth:`step`,
+        and STOP once the window closes (``warmup + iters`` steps). Use it as
+        the loop iterable so the run self-bounds::
+
+            for batch in run.steps(loader):
+                train_step(batch)
+        """
+        for item in iterable:
+            with self.step():
+                yield item
+            if self.done:
+                return
+
+    @property
+    def measured(self):
+        """Number of measured (non-warmup) steps profiled so far."""
+        return self._measured
+
+
+@contextmanager
+def targeting(scope, *, iters=20, warmup=3, tag="",
+              engine=None, analysis_id=None, pass_index=None, pass_count=None,
+              **kwargs):
+    """Profile a targeted scope as ONE pass of a multi-pass analysis.
+
+    Context manager. Composes :func:`gpufl.session` (init + shutdown + optional
+    upload) with a bounded per-step scope window. **Normally run under the
+    launcher** — ``gpufl trace --passes Trace,RangeProfiler,PcSampling --
+    python train.py`` — which assigns the engine and the analysis-group labels
+    per pass; then this call only describes the WINDOW. See the module
+    docstring for the full recipe.
+
+    Args:
+        scope: Name of the hot region (the merge key — use the SAME name for
+            every pass of one analysis group).
+        iters: Measured steps to profile before auto-stopping the window.
+            None → no auto-stop (scope every step until the loop ends). Keep it
+            IDENTICAL across the passes of one analysis so the per-scope
+            Execution Signature matches and the backend merges them.
+        warmup: Cold-start steps run before the measured window (bracketed in a
+            ``<scope>_warmup`` sub-scope, excluded from the merge).
+        tag: Optional scope category tag.
+
+        engine / analysis_id / pass_index / pass_count: **Launcher-set; omit
+            them under ``gpufl trace --passes``.** Provide them only for a
+            STANDALONE run (no launcher): ``engine=`` picks this run's engine
+            (else Monitor-only), and a shared ``analysis_id=`` + distinct
+            ``pass_index=`` per run self-group several runs without the
+            launcher.
+        **kwargs: Forwarded to :func:`gpufl.init` (``app_name``, ``log_path``,
+            ``backend_url``, ``api_key``, ``enable_stack_trace``, …).
+
+    Yields:
+        A :class:`TargetingRun` — call ``run.steps(iterable)`` (auto-stops) or
+        ``run.step()`` per iteration.
+    """
+    # Lazy import to avoid an import cycle (gpufl.__init__ imports this module
+    # at load time; Scope/session exist by the time this is CALLED).
+    from . import Scope, session
+
+    # engine=None → leave it to the launcher's GPUFL_PROFILING_ENGINE env
+    # override (applied inside the C++ init), so the script is engine-agnostic.
+    if engine is not None:
+        kwargs['profiling_engine'] = engine
+
+    with session(analysis_id=analysis_id, pass_index=pass_index,
+                 pass_count=pass_count, **kwargs) as ok:
+        yield TargetingRun(scope, tag, iters, warmup, Scope, enabled=bool(ok))

--- a/python/gpufl/_targeting.py
+++ b/python/gpufl/_targeting.py
@@ -1,4 +1,4 @@
-"""Targeted multi-pass profiling for long embedded jobs (P3).
+"""Targeted multi-pass profiling for long embedded jobs.
 
 A multi-day training job can't be re-run end-to-end per engine, and CUPTI
 runs only ONE profiling engine per process (re-init is unsupported). So a

--- a/python/gpufl/analyzer/analyzer.py
+++ b/python/gpufl/analyzer/analyzer.py
@@ -180,11 +180,22 @@ class GpuFlightSession:
 
             if not scope_df.empty and 'type' in scope_df.columns:
                 self.scopes = scope_df
-                self.perf   = scope_df[scope_df['type'] == 'perf_metric_event'].copy()
+                perf_frames = [scope_df[scope_df['type'] == 'perf_metric_event'].copy()]
+                if not device_df.empty and 'type' in device_df.columns:
+                    perf_frames.append(device_df[device_df['type'] == 'kernel_perf_metric_event'].copy())
+                self.perf = pd.concat(
+                    [f for f in perf_frames if not f.empty],
+                    ignore_index=True,
+                    sort=False,
+                ) if any(not f.empty for f in perf_frames) else pd.DataFrame()
                 self.pm_samples = scope_df[scope_df['type'] == 'pm_sample'].copy() if 'pm_sample' in set(scope_df['type']) else pd.DataFrame()
             else:
                 self.scopes = pd.DataFrame()
-                self.perf   = pd.DataFrame()
+                self.perf = (
+                    device_df[device_df['type'] == 'kernel_perf_metric_event'].copy()
+                    if not device_df.empty and 'type' in device_df.columns
+                    else pd.DataFrame()
+                )
                 self.pm_samples = pd.DataFrame()
 
             self.system         = system_df
@@ -503,12 +514,27 @@ class GpuFlightSession:
                     })
         pm_df = pd.DataFrame(pm_rows)
 
-        # ── perf_metric_event (scope log — still per-event, not batched) ──────
+        # ── perf_metric_event / kernel_perf_metric_event (per-event counters) ─
         perf_df = pd.DataFrame()
         if not scope_df.empty and 'type' in scope_df.columns:
             perf_rows = scope_df[scope_df['type'] == 'perf_metric_event']
             if not perf_rows.empty:
                 perf_df = perf_rows.copy()
+                perf_df['kind'] = 'scope'
+                if 'name' not in perf_df.columns and 'user_scope' in perf_df.columns:
+                    perf_df['name'] = perf_df['user_scope']
+        if not device_df.empty and 'type' in device_df.columns:
+            kernel_perf_rows = device_df[device_df['type'] == 'kernel_perf_metric_event']
+            if not kernel_perf_rows.empty:
+                kernel_perf = kernel_perf_rows.copy()
+                kernel_perf['kind'] = 'kernel'
+                if 'name' not in kernel_perf.columns:
+                    kernel_perf['name'] = kernel_perf.get('kernel_name')
+                if 'name' in kernel_perf.columns and 'kernel_name' in kernel_perf.columns:
+                    kernel_perf['name'] = kernel_perf['name'].fillna(kernel_perf['kernel_name'])
+                if 'name' in kernel_perf.columns and 'range_name' in kernel_perf.columns:
+                    kernel_perf['name'] = kernel_perf['name'].fillna(kernel_perf['range_name'])
+                perf_df = pd.concat([perf_df, kernel_perf], ignore_index=True, sort=False)
 
         # ── device_metric_batch (system log) ──────────────────────────────────
         dm_rows = []
@@ -595,6 +621,22 @@ class GpuFlightSession:
             self.memcpy = m
 
         if not self.perf.empty:
+            if 'kind' not in self.perf.columns:
+                if 'type' in self.perf.columns:
+                    self.perf['kind'] = self.perf['type'].map({
+                        'kernel_perf_metric_event': 'kernel',
+                        'perf_metric_event': 'scope',
+                    }).fillna('scope')
+                else:
+                    self.perf['kind'] = 'scope'
+            if 'name' not in self.perf.columns:
+                self.perf['name'] = None
+            if 'kernel_name' in self.perf.columns:
+                self.perf['name'] = self.perf['name'].fillna(self.perf['kernel_name'])
+            if 'range_name' in self.perf.columns:
+                self.perf['name'] = self.perf['name'].fillna(self.perf['range_name'])
+            if 'user_scope' in self.perf.columns:
+                self.perf['name'] = self.perf['name'].fillna(self.perf['user_scope'])
             for col in [
                 'start_ns', 'end_ns',
                 'sm_throughput_pct', 'l1_hit_rate_pct', 'l2_hit_rate_pct',
@@ -1321,14 +1363,15 @@ class GpuFlightSession:
 
     def _print_perf_metric_hint(self):
         self.console.print(
-            "[yellow]No perf_metric_event records found in scope log.[/yellow]\n"
+            "[yellow]No perf metric counter records found in logs.[/yellow]\n"
             "  To collect hardware-counter perf metrics:\n"
             "    1. [bold]profiling_engine[/bold]: pass "
-            "[cyan]ProfilingEngine.RangeProfiler[/cyan] to "
+            "[cyan]ProfilingEngine.RangeProfiler[/cyan] or "
+            "[cyan]ProfilingEngine.RangeProfilerKernelReplay[/cyan] to "
             "[cyan]gpufl.init()[/cyan].\n"
-            "    2. [bold]Scopes required[/bold]: wrap GPU work in "
+            "    2. [bold]Scopes[/bold]: RangeProfiler emits on scope close; wrap GPU work in "
             "[cyan]with gpufl.Scope(\"name\"):[/cyan] blocks — perf "
-            "metrics emit on scope close.\n"
+            "metrics emit on scope close. Kernel replay emits per replayed kernel range.\n"
             "    3. [bold]Mutually exclusive with PC sampling[/bold]: "
             "RangeProfiler and PcSampling both use hardware perf "
             "counters; pick one per session.\n"
@@ -1395,6 +1438,10 @@ class GpuFlightSession:
             if col in p.columns:
                 # Backend uses -1.0 sentinel for unavailable counters.
                 p.loc[p[col] < 0, col] = float('nan')
+        for col in ['dram_read_bytes', 'dram_write_bytes']:
+            if col in p.columns:
+                p[col] = pd.to_numeric(p[col], errors='coerce')
+                p.loc[p[col] < 0, col] = float('nan')
 
         def avg_if_exists(col: str):
             return p[col].dropna().mean() if col in p.columns else float('nan')
@@ -1425,7 +1472,10 @@ class GpuFlightSession:
             if col not in p.columns:
                 p[col] = float('nan')
 
-        agg = p.groupby('name', dropna=False).agg(
+        if 'kind' not in p.columns:
+            p['kind'] = 'scope'
+
+        agg = p.groupby(['kind', 'name'], dropna=False).agg(
             count=('name', 'count'),
             sm=('sm_throughput_pct', 'mean'),
             l1=('l1_hit_rate_pct', 'mean'),
@@ -1435,8 +1485,9 @@ class GpuFlightSession:
             dram_w=('dram_write_bytes', 'mean'),
         ).sort_values('count', ascending=False).head(top_n)
 
-        table = Table(title=f"Perf Metrics by Scope — Top {top_n}")
-        table.add_column("Scope", style="cyan")
+        table = Table(title=f"Perf Metrics by Target - Top {top_n}")
+        table.add_column("Target", style="cyan")
+        table.add_column("Name", style="cyan")
         table.add_column("Events", justify="right")
         table.add_column("SM%", justify="right")
         table.add_column("L1%", justify="right")
@@ -1445,9 +1496,10 @@ class GpuFlightSession:
         table.add_column("DRAM Read", justify="right")
         table.add_column("DRAM Write", justify="right")
 
-        for scope_name, row in agg.iterrows():
+        for (kind, target_name), row in agg.iterrows():
             table.add_row(
-                str(scope_name),
+                str(kind),
+                str(target_name),
                 str(int(row['count'])),
                 fmt_pct(row['sm']),
                 fmt_pct(row['l1']),

--- a/python/gpufl/report/text_report.py
+++ b/python/gpufl/report/text_report.py
@@ -75,6 +75,7 @@ class TextReport:
             self._section_memcpy_summary(),
             self._section_system_metrics(),
             self._section_scope_summary(),
+            self._section_perf_metrics_summary(),
             self._section_pm_sampling_summary(),
             self._section_profile_analysis(),
         ]
@@ -528,6 +529,90 @@ class TextReport:
             "  Note: PM Sampling rows are hardware-counter timeline samples. "
             "They are aggregated by scope here; use analyzer.inspect_pm_sampling() "
             "for the raw table."
+        )
+        return lines
+
+    def _section_perf_metrics_summary(self) -> list[str]:
+        perf = getattr(self.session, "perf", pd.DataFrame())
+        if perf.empty:
+            return []
+
+        p = perf.copy()
+        if "name" not in p.columns:
+            p["name"] = None
+        if "kernel_name" in p.columns:
+            p["name"] = p["name"].fillna(p["kernel_name"])
+        if "range_name" in p.columns:
+            p["name"] = p["name"].fillna(p["range_name"])
+        if "user_scope" in p.columns:
+            p["name"] = p["name"].fillna(p["user_scope"])
+        if "kind" not in p.columns:
+            if "type" in p.columns:
+                p["kind"] = p["type"].map({
+                    "kernel_perf_metric_event": "kernel",
+                    "perf_metric_event": "scope",
+                }).fillna("scope")
+            else:
+                p["kind"] = "scope"
+
+        metric_cols = [
+            "sm_throughput_pct", "l1_hit_rate_pct", "l2_hit_rate_pct",
+            "tensor_active_pct", "dram_read_bytes", "dram_write_bytes",
+        ]
+        for col in metric_cols:
+            if col not in p.columns:
+                p[col] = float("nan")
+            p[col] = pd.to_numeric(p[col], errors="coerce")
+            p.loc[p[col] < 0, col] = float("nan")
+
+        p = p[p["name"].notna()].copy()
+        if p.empty:
+            return []
+
+        agg = (
+            p.groupby(["kind", "name"], dropna=False)
+            .agg(
+                count=("name", "count"),
+                sm=("sm_throughput_pct", "mean"),
+                l1=("l1_hit_rate_pct", "mean"),
+                l2=("l2_hit_rate_pct", "mean"),
+                tensor=("tensor_active_pct", "mean"),
+                dram_r=("dram_read_bytes", "mean"),
+                dram_w=("dram_write_bytes", "mean"),
+            )
+            .sort_values("sm", ascending=False, na_position="last")
+            .head(self.top_n)
+        )
+
+        def fmt_pct(v):
+            return f"{v:.1f}%" if pd.notna(v) else "n/a"
+
+        def short(value, limit):
+            text = str(value)
+            return text if len(text) <= limit else text[:limit - 3] + "..."
+
+        lines = ["", _SEP, "  Range Profiler Counters", _SEP]
+        lines.append(f"  Total Counter Rows:   {len(p)}")
+        lines.append("")
+        lines.append(
+            f"  {'Target':<8}{'Name':<32}{'SM':>10}{'L1':>10}{'L2':>10}"
+            f"{'Tensor':>10}{'DRAM R':>14}{'DRAM W':>14}"
+        )
+        lines.append("  " + "-" * 108)
+        for (kind, name), row in agg.iterrows():
+            lines.append(
+                f"  {str(kind):<8}{short(name, 30):<32}"
+                f"{fmt_pct(row['sm']):>10}"
+                f"{fmt_pct(row['l1']):>10}"
+                f"{fmt_pct(row['l2']):>10}"
+                f"{fmt_pct(row['tensor']):>10}"
+                f"{(_fmt_bytes(row['dram_r']) if pd.notna(row['dram_r']) else 'n/a'):>14}"
+                f"{(_fmt_bytes(row['dram_w']) if pd.notna(row['dram_w']) else 'n/a'):>14}"
+            )
+        lines.append("")
+        lines.append(
+            "  Note: Scope rows come from RangeProfiler; kernel rows come from "
+            "RangeProfilerKernelReplay."
         )
         return lines
 

--- a/scripts/windows/run_capability_matrix.ps1
+++ b/scripts/windows/run_capability_matrix.ps1
@@ -20,10 +20,12 @@ if (-not $Combos -or $Combos.Count -eq 0) {
         "PcSampling",
         "PmSampling",
         "RangeProfiler",
+        "RangeProfilerKernelReplay",
         "Trace,PmSampling",
         "Trace,PcSampling",
         "PmSampling,PcSampling",
-        "Trace,RangeProfiler"
+        "Trace,RangeProfiler",
+        "Trace,RangeProfilerKernelReplay"
     )
 }
 if ($IncludeSass) {

--- a/scripts/windows/run_capability_matrix.ps1
+++ b/scripts/windows/run_capability_matrix.ps1
@@ -1,0 +1,229 @@
+param(
+    [string]$ExePath,
+    [int]$TimeoutSeconds = 120,
+    [string[]]$Combos,
+    [switch]$IncludeSass
+)
+
+$ErrorActionPreference = "Stop"
+
+$RepoRoot = Resolve-Path (Join-Path $PSScriptRoot "..\..")
+if (-not $ExePath) {
+    $ExePath = Join-Path $RepoRoot "build\example\cuda\Release\multi_engine_demo.exe"
+}
+$ExePath = (Resolve-Path $ExePath).Path
+$WorkDir = Split-Path $ExePath
+
+if (-not $Combos -or $Combos.Count -eq 0) {
+    $Combos = @(
+        "Trace",
+        "PcSampling",
+        "PmSampling",
+        "RangeProfiler",
+        "Trace,PmSampling",
+        "Trace,PcSampling",
+        "PmSampling,PcSampling",
+        "Trace,RangeProfiler"
+    )
+}
+if ($IncludeSass) {
+    $Combos += @(
+        "SassMetrics",
+        "Trace,SassMetrics"
+    )
+}
+
+$principal = New-Object Security.Principal.WindowsPrincipal([Security.Principal.WindowsIdentity]::GetCurrent())
+$isAdmin = $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+if (-not $isAdmin) {
+    Write-Warning "This PowerShell is not elevated. Some CUPTI engines may be skipped or produce no data."
+}
+
+$stamp = Get-Date -Format "yyyyMMdd_HHmmss"
+$RunRoot = Join-Path $RepoRoot "runs\capability_matrix_$stamp"
+New-Item -ItemType Directory -Force -Path $RunRoot | Out-Null
+
+function Get-CapabilityLines {
+    param(
+        [string]$Root,
+        [datetime]$Since
+    )
+    if (-not (Test-Path $Root)) { return @() }
+    $files = Get-ChildItem -Path $Root -Recurse -File -ErrorAction SilentlyContinue |
+        Where-Object { $_.Name -match '\.(log|txt)(\.gz)?$' } |
+        Where-Object { $_.LastWriteTime -ge $Since }
+    $hits = New-Object System.Collections.Generic.List[object]
+    foreach ($file in $files) {
+        if ($file.Name.EndsWith(".gz")) {
+            $fs = [System.IO.File]::OpenRead($file.FullName)
+            try {
+                $gz = New-Object System.IO.Compression.GZipStream($fs, [System.IO.Compression.CompressionMode]::Decompress)
+                try {
+                    $reader = New-Object System.IO.StreamReader($gz)
+                    try {
+                        while (($line = $reader.ReadLine()) -ne $null) {
+                            if ($line.Contains('"type":"capture_capabilities"')) {
+                                $hits.Add([pscustomobject]@{
+                                    path = $file.FullName
+                                    line = $line
+                                })
+                            }
+                        }
+                    } finally {
+                        $reader.Dispose()
+                    }
+                } finally {
+                    $gz.Dispose()
+                }
+            } finally {
+                $fs.Dispose()
+            }
+        } else {
+            Select-String -LiteralPath $file.FullName -Pattern '"type":"capture_capabilities"' -SimpleMatch |
+                ForEach-Object {
+                    $hits.Add([pscustomobject]@{
+                        path = $file.FullName
+                        line = $_.Line
+                    })
+                }
+        }
+    }
+    return $hits.ToArray()
+}
+
+function Summarize-Capabilities {
+    param([string]$JsonLine)
+    try {
+        $obj = $JsonLine | ConvertFrom-Json
+    } catch {
+        return @([pscustomobject]@{
+            feature = "parse_error"
+            requested = $false
+            status = "parse_error"
+            mode = ""
+            reason_code = ""
+            message = $_.Exception.Message
+        })
+    }
+    return @($obj.capabilities | ForEach-Object {
+        [pscustomobject]@{
+            feature = $_.feature
+            requested = [bool]$_.requested
+            status = $_.status
+            mode = $_.mode
+            reason_code = $_.reason_code
+            message = $_.message
+        }
+    })
+}
+
+$rows = New-Object System.Collections.Generic.List[object]
+
+foreach ($combo in $Combos) {
+    $safe = $combo -replace "[^A-Za-z0-9]+", "_"
+    $out = Join-Path $RunRoot "$safe.out.txt"
+    $err = Join-Path $RunRoot "$safe.err.txt"
+    $startedAt = Get-Date
+
+    Write-Host ""
+    Write-Host "=== RUN $combo ==="
+
+    $env:GPUFL_ENGINE_COMBO = $combo
+    $proc = Start-Process -FilePath $ExePath `
+        -WorkingDirectory $WorkDir `
+        -PassThru `
+        -RedirectStandardOutput $out `
+        -RedirectStandardError $err
+
+    $finished = $proc.WaitForExit($TimeoutSeconds * 1000)
+    if (-not $finished) {
+        Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue
+        $exitCode = "TIMEOUT"
+        $timedOut = $true
+    } else {
+        $proc.Refresh()
+        $exitCode = $proc.ExitCode
+        $timedOut = $false
+    }
+
+    $logRoot = Join-Path $WorkDir "multi_engine"
+    $capLines = Get-CapabilityLines -Root $logRoot -Since $startedAt
+    if ($capLines.Count -eq 0) {
+        Write-Warning "No capture_capabilities event found for $combo under $logRoot"
+        $rows.Add([pscustomobject]@{
+            combo = $combo
+            exit = $exitCode
+            timed_out = $timedOut
+            feature = "(missing)"
+            requested = ""
+            status = "missing"
+            mode = ""
+            reason_code = ""
+            message = "No capture_capabilities event found"
+            log_path = ""
+        })
+        continue
+    }
+
+    $latest = $capLines | Sort-Object path | Select-Object -Last 1
+    $caps = Summarize-Capabilities -JsonLine $latest.line
+    foreach ($cap in $caps) {
+        $rows.Add([pscustomobject]@{
+            combo = $combo
+            exit = $exitCode
+            timed_out = $timedOut
+            feature = $cap.feature
+            requested = $cap.requested
+            status = $cap.status
+            mode = $cap.mode
+            reason_code = $cap.reason_code
+            message = $cap.message
+            log_path = $latest.path
+        })
+    }
+
+    $interesting = $caps | Where-Object {
+        $_.feature -in @(
+            "kernel_events",
+            "kernel_names",
+            "kernel_details",
+            "memcpy_activity",
+            "sync_activity",
+            "nvtx_markers",
+            "graph_activity",
+            "pc_sampling",
+            "sass_metrics",
+            "pm_sampling",
+            "range_counters",
+            "cubin_disassembly",
+            "source_correlation"
+        )
+    }
+    $interesting | Format-Table feature, requested, status, mode, reason_code -AutoSize
+}
+
+Remove-Item Env:\GPUFL_ENGINE_COMBO -ErrorAction SilentlyContinue
+
+$summaryCsv = Join-Path $RunRoot "capabilities.csv"
+$summaryMd = Join-Path $RunRoot "capabilities.md"
+$rows | Export-Csv -NoTypeInformation -Path $summaryCsv
+
+$md = New-Object System.Collections.Generic.List[string]
+$md.Add("# GPUFlight capability matrix")
+$md.Add("")
+$md.Add("- Date: $(Get-Date -Format s)")
+$md.Add("- Elevated PowerShell: $isAdmin")
+$md.Add("- Executable: $ExePath")
+$md.Add("- Timeout seconds: $TimeoutSeconds")
+$md.Add("")
+$md.Add("| Combo | Feature | Requested | Status | Mode | Reason |")
+$md.Add("|---|---|---:|---|---|---|")
+foreach ($row in $rows) {
+    $reason = ($row.reason_code -replace "\|", "\|")
+    $md.Add("| $($row.combo) | $($row.feature) | $($row.requested) | $($row.status) | $($row.mode) | $reason |")
+}
+$md | Set-Content -Encoding UTF8 -Path $summaryMd
+
+Write-Host ""
+Write-Host "Summary CSV: $summaryCsv"
+Write-Host "Summary MD : $summaryMd"

--- a/scripts/windows/run_multi_engine_matrix.ps1
+++ b/scripts/windows/run_multi_engine_matrix.ps1
@@ -25,12 +25,16 @@ if (-not $Combos -or $Combos.Count -eq 0) {
         "Trace",
         "PcSampling",
         "RangeProfiler",
+        "RangeProfilerKernelReplay",
         "Trace,PcSampling",
         "Trace,PmSampling",
         "Trace,RangeProfiler",
+        "Trace,RangeProfilerKernelReplay",
         "Trace,PcSampling,PmSampling",
         "Trace,PcSampling,RangeProfiler",
+        "Trace,PcSampling,RangeProfilerKernelReplay",
         "Trace,PmSampling,RangeProfiler",
+        "Trace,PmSampling,RangeProfilerKernelReplay",
         "Trace,PcSampling,PmSampling,RangeProfiler"
     )
 }

--- a/scripts/windows/run_multi_engine_matrix.ps1
+++ b/scripts/windows/run_multi_engine_matrix.ps1
@@ -1,0 +1,128 @@
+param(
+    [string]$ExePath,
+    [int]$TimeoutSeconds = 120,
+    [switch]$IncludeSass,
+    [string[]]$Combos
+)
+
+$ErrorActionPreference = "Stop"
+
+$RepoRoot = Resolve-Path (Join-Path $PSScriptRoot "..\..")
+if (-not $ExePath) {
+    $ExePath = Join-Path $RepoRoot "build\example\cuda\Release\multi_engine_demo.exe"
+}
+$ExePath = (Resolve-Path $ExePath).Path
+$WorkDir = Split-Path $ExePath
+
+$principal = New-Object Security.Principal.WindowsPrincipal([Security.Principal.WindowsIdentity]::GetCurrent())
+$isAdmin = $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+if (-not $isAdmin) {
+    Write-Warning "This PowerShell is not elevated. PcSampling/PmSampling/RangeProfiler may report CUPTI_ERROR_INSUFFICIENT_PRIVILEGES."
+}
+
+if (-not $Combos -or $Combos.Count -eq 0) {
+    $Combos = @(
+        "Trace",
+        "PcSampling",
+        "RangeProfiler",
+        "Trace,PcSampling",
+        "Trace,PmSampling",
+        "Trace,RangeProfiler",
+        "Trace,PcSampling,PmSampling",
+        "Trace,PcSampling,RangeProfiler",
+        "Trace,PmSampling,RangeProfiler",
+        "Trace,PcSampling,PmSampling,RangeProfiler"
+    )
+}
+if ($IncludeSass) {
+    $Combos += "Trace,SassMetrics"
+}
+
+$stamp = Get-Date -Format "yyyyMMdd_HHmmss"
+$RunRoot = Join-Path $RepoRoot "runs\multi_engine_matrix_$stamp"
+New-Item -ItemType Directory -Force -Path $RunRoot | Out-Null
+
+$summary = New-Object System.Collections.Generic.List[object]
+
+foreach ($combo in $Combos) {
+    $safe = $combo -replace "[^A-Za-z0-9]+", "_"
+    $out = Join-Path $RunRoot "$safe.out.txt"
+    $err = Join-Path $RunRoot "$safe.err.txt"
+
+    Write-Host ""
+    Write-Host "=== RUN $combo ==="
+
+    $env:GPUFL_ENGINE_COMBO = $combo
+    $proc = Start-Process -FilePath $ExePath `
+        -WorkingDirectory $WorkDir `
+        -PassThru `
+        -RedirectStandardOutput $out `
+        -RedirectStandardError $err
+
+    $finished = $proc.WaitForExit($TimeoutSeconds * 1000)
+    if (-not $finished) {
+        Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue
+        $exitCode = "TIMEOUT"
+        $timedOut = $true
+    } else {
+        $proc.Refresh()
+        $exitCode = $proc.ExitCode
+        $timedOut = $false
+    }
+
+    $outText = if (Test-Path $out) { Get-Content -Raw -LiteralPath $out } else { "" }
+    $errText = if (Test-Path $err) { Get-Content -Raw -LiteralPath $err } else { "" }
+    $allLines = ($outText + "`n" + $errText) -split "`r?`n"
+
+    $matrixLines = @($allLines | Where-Object { $_ -match "\[Composite\]\[matrix\]\s+\S+Engine\s+armed=" })
+    $notableLines = @($allLines | Where-Object {
+        $_ -match "CUPTI_ERROR|INSUFFICIENT|UNKNOWN|NOT_INITIALIZED|Failed|ERROR|deadlock|exception|timeout"
+    } | Select-Object -First 20)
+
+    Write-Host "exit=$exitCode"
+    if ($matrixLines.Count -gt 0) {
+        $matrixLines | ForEach-Object { Write-Host $_ }
+    }
+    if ($notableLines.Count -gt 0) {
+        Write-Host "notable:"
+        $notableLines | ForEach-Object { Write-Host $_ }
+    }
+
+    $summary.Add([pscustomobject]@{
+        combo = $combo
+        exit = $exitCode
+        timed_out = $timedOut
+        matrix = ($matrixLines -join " | ")
+        notable = ($notableLines -join " | ")
+        stdout = $out
+        stderr = $err
+    })
+}
+
+Remove-Item Env:\GPUFL_ENGINE_COMBO -ErrorAction SilentlyContinue
+
+$summaryCsv = Join-Path $RunRoot "summary.csv"
+$summaryMd = Join-Path $RunRoot "summary.md"
+$summary | Export-Csv -NoTypeInformation -Path $summaryCsv
+
+$md = New-Object System.Collections.Generic.List[string]
+$md.Add("# GPUFlight multi-engine compatibility run")
+$md.Add("")
+$md.Add("- Date: $(Get-Date -Format s)")
+$md.Add("- Elevated PowerShell: $isAdmin")
+$md.Add("- Executable: $ExePath")
+$md.Add("- Timeout seconds: $TimeoutSeconds")
+$md.Add("")
+$md.Add("| Combo | Exit | Timeout | Matrix | Notable |")
+$md.Add("|---|---:|---:|---|---|")
+foreach ($row in $summary) {
+    $matrix = ($row.matrix -replace "\|", "\|") -replace "`r?`n", " "
+    $notable = ($row.notable -replace "\|", "\|") -replace "`r?`n", " "
+    $md.Add("| $($row.combo) | $($row.exit) | $($row.timed_out) | $matrix | $notable |")
+}
+$md | Set-Content -Encoding UTF8 -Path $summaryMd
+
+Write-Host ""
+Write-Host "Summary CSV: $summaryCsv"
+Write-Host "Summary MD : $summaryMd"
+$summary | Format-Table -AutoSize

--- a/tests/common/log_utils.cpp
+++ b/tests/common/log_utils.cpp
@@ -203,14 +203,17 @@ std::vector<std::string> GetStringArrayField(
     return out;
 }
 
-const char* EngineName(gpufl::ProfilingEngine e) {
+const char* EngineName(ProfilingEngine e) {
     switch (e) {
-        case gpufl::ProfilingEngine::Monitor:       return "Monitor";
-        case gpufl::ProfilingEngine::Trace:         return "Trace";
-        case gpufl::ProfilingEngine::PcSampling:    return "PcSampling";
-        case gpufl::ProfilingEngine::SassMetrics:   return "SassMetrics";
-        case gpufl::ProfilingEngine::RangeProfiler: return "RangeProfiler";
-        case gpufl::ProfilingEngine::Deep:          return "Deep";
+        case ProfilingEngine::Monitor:       return "Monitor";
+        case ProfilingEngine::Trace:         return "Trace";
+        case ProfilingEngine::PcSampling:    return "PcSampling";
+        case ProfilingEngine::SassMetrics:   return "SassMetrics";
+        case ProfilingEngine::PmSampling:    return "PmSampling";
+        case ProfilingEngine::RangeProfiler: return "RangeProfiler";
+        case ProfilingEngine::RangeProfilerKernelReplay:
+            return "RangeProfilerKernelReplay";
+        case ProfilingEngine::Deep:          return "Deep";
     }
     return "Unknown";
 }

--- a/tests/core/test_disabled.cpp
+++ b/tests/core/test_disabled.cpp
@@ -18,6 +18,8 @@
 #include <gtest/gtest.h>
 
 #include <cstdlib>
+
+#include "gpufl/core/env_vars.hpp"
 #include <optional>
 #include <string>
 
@@ -49,9 +51,9 @@ protected:
     void SetUp() override {
         // Each test starts from a clean env. Capture whatever was set
         // outside the test process so we can restore it after.
-        const char* prior = std::getenv("GPUFL_DISABLED");
+        const char* prior = std::getenv(gpufl::env::kDisabled);
         if (prior) saved_env_ = prior;
-        unsetEnv_("GPUFL_DISABLED");
+        unsetEnv_(gpufl::env::kDisabled);
     }
     void TearDown() override {
         // Always shut down — safe even if init() returned false (no
@@ -59,9 +61,9 @@ protected:
         gpufl::shutdown();
         // Restore env.
         if (saved_env_.has_value()) {
-            setEnv_("GPUFL_DISABLED", saved_env_->c_str());
+            setEnv_(gpufl::env::kDisabled, saved_env_->c_str());
         } else {
-            unsetEnv_("GPUFL_DISABLED");
+            unsetEnv_(gpufl::env::kDisabled);
         }
     }
     std::optional<std::string> saved_env_;
@@ -98,12 +100,12 @@ TEST_F(DisabledFlagTest, EnabledTrueIsTheDefault) {
 
 TEST_F(DisabledFlagTest, EnvVarTruthyDisables) {
     for (const char* v : {"1", "true", "TRUE", "yes", "on", "  yes  "}) {
-        setEnv_("GPUFL_DISABLED", v);
+        setEnv_(gpufl::env::kDisabled, v);
         gpufl::InitOptions opts;  // enabled stays true
         EXPECT_FALSE(gpufl::init(opts))
             << "env GPUFL_DISABLED='" << v << "' should disable but didn't";
         gpufl::shutdown();
-        unsetEnv_("GPUFL_DISABLED");
+        unsetEnv_(gpufl::env::kDisabled);
     }
 }
 
@@ -117,7 +119,7 @@ TEST_F(DisabledFlagTest, EnvVarFalsyDoesNotDisable) {
     // different post-CUDA outcomes; the only invariant is "disable
     // didn't fire.")
     for (const char* v : {"0", "false", "no", "off", ""}) {
-        setEnv_("GPUFL_DISABLED", v);
+        setEnv_(gpufl::env::kDisabled, v);
         gpufl::InitOptions opts;
         opts.enabled = false;  // we WANT this to win — proving env didn't
         // With both env=falsy and opts.enabled=false, the field decides:
@@ -126,14 +128,14 @@ TEST_F(DisabledFlagTest, EnvVarFalsyDoesNotDisable) {
             << "env='" << v
             << "' is falsy → field (enabled=false) should still disable";
         gpufl::shutdown();
-        unsetEnv_("GPUFL_DISABLED");
+        unsetEnv_(gpufl::env::kDisabled);
     }
 }
 
 TEST_F(DisabledFlagTest, EnvVarOverridesEnabledTrueKwarg) {
     // Env var is the kill switch — wins even when the caller explicitly
     // requested enabled=true.
-    setEnv_("GPUFL_DISABLED", "1");
+    setEnv_(gpufl::env::kDisabled, "1");
     gpufl::InitOptions opts;
     opts.enabled = true;
     EXPECT_FALSE(gpufl::init(opts));

--- a/tests/core/test_itanium_demangle.cpp
+++ b/tests/core/test_itanium_demangle.cpp
@@ -14,7 +14,9 @@
 #include <gtest/gtest.h>
 
 #include "gpufl/core/itanium_demangle.hpp"
+#include "gpufl/core/stack_trace.hpp"
 
+using gpufl::core::DemangleFunctionKey;
 using gpufl::core::DemangleItaniumName;
 
 // ── Pass-through cases ───────────────────────────────────────────────
@@ -143,4 +145,47 @@ TEST(ItaniumDemangle, UnknownTemplateArgFallsBack) {
         << "must always return something displayable, even on parse failure";
     // Doesn't matter whether it's the original mangled form or a
     // partial demangle — we just guarantee the caller can show it.
+}
+
+// ── DemangleFunctionKey: "name@source" → "demangled@source" ──────────
+//
+// SASS / PC sampling intern their per-symbol identity as
+// `mangled_name + "@" + source_file`. DemangleFunctionKey demangles ONLY the
+// name half so the result joins Trace's already-demangled kernel_dict for the
+// multi-pass merge, while the source path survives verbatim. Delegates to
+// DemangleName, so the same substring-not-byte-exact contract applies.
+
+TEST(DemangleFunctionKey, DemanglesNameKeepsSourceTail) {
+    const auto out =
+        DemangleFunctionKey("_Z16branchByWarpQuadPfPKfi@/kernels/foo.cu");
+    EXPECT_NE(out.find("branchByWarpQuad"), std::string::npos)
+        << "name half must be demangled — got: " << out;
+    EXPECT_NE(out.find("@/kernels/foo.cu"), std::string::npos)
+        << "the @source tail must survive verbatim — got: " << out;
+}
+
+TEST(DemangleFunctionKey, NonMangledNamePassesThrough) {
+    // Already-demangled / plain names + their source survive byte-for-byte.
+    EXPECT_EQ(DemangleFunctionKey("vectorAdd@/kernels/foo.cu"),
+              "vectorAdd@/kernels/foo.cu");
+}
+
+TEST(DemangleFunctionKey, NoAtSignDemanglesWholeKey) {
+    const auto out = DemangleFunctionKey("_Z16branchByWarpQuadPfPKfi");
+    EXPECT_NE(out.find("branchByWarpQuad"), std::string::npos) << out;
+    EXPECT_EQ(out.find('@'), std::string::npos)
+        << "must not invent a source tail when the key has none — got: " << out;
+}
+
+TEST(DemangleFunctionKey, EmptySourceKeepsTrailingAt) {
+    const auto out = DemangleFunctionKey("_Z16branchByWarpQuadPfPKfi@");
+    EXPECT_NE(out.find("branchByWarpQuad"), std::string::npos) << out;
+    ASSERT_FALSE(out.empty());
+    EXPECT_EQ(out.back(), '@')
+        << "empty source → trailing '@' preserved — got: " << out;
+}
+
+TEST(DemangleFunctionKey, EmptyNameKeepsSource) {
+    // First '@' is at index 0 → empty name half, source survives.
+    EXPECT_EQ(DemangleFunctionKey("@/kernels/foo.cu"), "@/kernels/foo.cu");
 }

--- a/tests/core/test_wire_contract.cpp
+++ b/tests/core/test_wire_contract.cpp
@@ -28,6 +28,7 @@
 #include "gpufl/core/version.hpp"
 #include "gpufl/core/model/batch_models.hpp"
 #include "gpufl/core/model/lifecycle_model.hpp"
+#include "gpufl/core/model/perf_metric_model.hpp"
 
 namespace {
 
@@ -535,4 +536,34 @@ TEST(WireContract, MemoryAllocEventBatchColumns) {
         "\"address\",\"bytes\",\"device_id\",\"stream_id\",\"corr_id\"]"));
     EXPECT_TRUE(JsonContains(
         json, "\"rows\":[[0,0,1,3,139637976727552,1048576,0,0,42]]"));
+}
+
+TEST(WireContract, KernelPerfMetricEventFields) {
+    gpufl::KernelPerfMetricEvent ev{};
+    ev.pid = 123;
+    ev.app = "demo";
+    ev.session_id = "sess-1";
+    ev.device_id = 0;
+    ev.range_index = 2;
+    ev.range_name = "VectorAdd";
+    ev.kernel_name = "VectorAdd";
+    ev.launch_ordinal = 3;
+    ev.sm_throughput_pct = 75.25;
+    ev.l1_hit_rate_pct = 91.5;
+    ev.l2_hit_rate_pct = -1.0;
+    ev.dram_read_bytes = 1024;
+    ev.dram_write_bytes = -1;
+    ev.tensor_active_pct = -1.0;
+
+    const std::string json = gpufl::model::KernelPerfMetricModel(ev).buildJson();
+
+    EXPECT_TRUE(JsonContains(json, "\"type\":\"kernel_perf_metric_event\""));
+    EXPECT_TRUE(JsonContains(json, "\"range_index\":2"));
+    EXPECT_TRUE(JsonContains(json, "\"range_name\":\"VectorAdd\""));
+    EXPECT_TRUE(JsonContains(json, "\"kernel_name\":\"VectorAdd\""));
+    EXPECT_TRUE(JsonContains(json, "\"launch_ordinal\":3"));
+    EXPECT_TRUE(JsonContains(json, "\"sm_throughput_pct\":75.2500"));
+    EXPECT_TRUE(JsonContains(json, "\"l1_hit_rate_pct\":91.5000"));
+    EXPECT_TRUE(JsonContains(json, "\"dram_read_bytes\":1024"));
+    EXPECT_TRUE(JsonContains(json, "\"dram_write_bytes\":-1"));
 }

--- a/tests/core/test_wire_contract.cpp
+++ b/tests/core/test_wire_contract.cpp
@@ -118,6 +118,54 @@ TEST(WireContract, JobStartEmitsNvidiaNoneSentinel) {
         << "explicit-None sessions must emit profiling_engine: nvidia.none: " << json;
 }
 
+// ── job_start multi-pass grouping (P1) ─────────────────────────────────────
+//
+// analysis_id / pass_index / pass_count are emitted together, and ONLY when
+// analysis_id is set (a multi-pass run). They are additive optional fields on
+// the non-columnar job_start record, so they do NOT bump kWireVersion — the
+// backend ignores unknown fields until the P2 merge consumes them.
+TEST(WireContract, JobStartEmitsMultiPassGroupingWhenSet) {
+    gpufl::InitEvent e;
+    e.pid = 7;
+    e.app = "mp_app";
+    e.session_id = "sess-mp";
+    e.ts_ns = 1;
+    e.session_kind = "trace";
+    e.profiling_engine = "nvidia.sass_metrics";
+    e.analysis_id = "ana-123";
+    e.pass_index = 2;
+    e.pass_count = 3;
+
+    const std::string json = gpufl::model::InitEventModel(e).buildJson();
+
+    EXPECT_TRUE(JsonContains(json, "\"analysis_id\":\"ana-123\""));
+    EXPECT_TRUE(JsonContains(json, "\"pass_index\":2"));
+    EXPECT_TRUE(JsonContains(json, "\"pass_count\":3"));
+}
+
+// A single-pass run leaves analysis_id empty; all three fields must be omitted
+// so the job_start wire is byte-identical to pre-P1 (and pass_index==0 is never
+// confused with "unset").
+TEST(WireContract, JobStartOmitsMultiPassGroupingWhenUnset) {
+    gpufl::InitEvent e;
+    e.pid = 7;
+    e.app = "sp_app";
+    e.session_id = "sess-sp";
+    e.ts_ns = 1;
+    e.session_kind = "trace";
+    e.profiling_engine = "nvidia.trace";
+    // analysis_id intentionally left empty → ordinary single-pass run.
+
+    const std::string json = gpufl::model::InitEventModel(e).buildJson();
+
+    EXPECT_EQ(json.find("\"analysis_id\""), std::string::npos)
+        << "analysis_id must be omitted for single-pass runs: " << json;
+    EXPECT_EQ(json.find("\"pass_index\""), std::string::npos)
+        << "pass_index must be omitted when analysis_id is unset: " << json;
+    EXPECT_EQ(json.find("\"pass_count\""), std::string::npos)
+        << "pass_count must be omitted when analysis_id is unset: " << json;
+}
+
 // ── shutdown ──────────────────────────────────────────────────────────────
 TEST(WireContract, ShutdownShape) {
     gpufl::ShutdownEvent e;

--- a/tests/core/test_wire_contract.cpp
+++ b/tests/core/test_wire_contract.cpp
@@ -204,6 +204,44 @@ TEST(WireContract, SassConfigShape) {
     EXPECT_TRUE(JsonContains(json, "\"skipped_metrics\":[\"dram__bytes\"]"));
 }
 
+// ── execution_signature (P2 multi-pass determinism guard) ──────────────────
+//
+// One per scope per pass; the backend compares the `signature` per scope across
+// the passes of an analysis to decide whether SASS metrics may be merged onto
+// another pass's timing. `signature` is a full-width uint64 hash emitted as a
+// STRING so JSON number precision (JS doubles lose >2^53) can't corrupt it.
+TEST(WireContract, ExecutionSignatureShape) {
+    gpufl::ExecutionSignatureEvent e;
+    e.session_id = "sess-1";
+    e.ts_ns = 1234;
+    e.scope_name = "train_epoch";
+    e.signature = 12345678901234567890ULL;  // > 2^53 — must round-trip as a string
+    e.launch_count = 9002;
+    e.distinct_kernels = 27;
+
+    const std::string json = gpufl::model::ExecutionSignatureModel(e).buildJson();
+
+    EXPECT_TRUE(JsonContains(json, "\"version\":1"));
+    EXPECT_TRUE(JsonContains(json, "\"type\":\"execution_signature\""));
+    EXPECT_TRUE(JsonContains(json, "\"session_id\":\"sess-1\""));
+    EXPECT_TRUE(JsonContains(json, "\"scope_name\":\"train_epoch\""));
+    EXPECT_TRUE(JsonContains(json, "\"signature\":\"12345678901234567890\""))
+        << "uint64 signature must serialize as a quoted string: " << json;
+    EXPECT_TRUE(JsonContains(json, "\"launch_count\":9002"));
+    EXPECT_TRUE(JsonContains(json, "\"distinct_kernels\":27"));
+}
+
+TEST(WireContract, ExecutionSignatureEscapesScopeName) {
+    gpufl::ExecutionSignatureEvent e;
+    e.session_id = "sess-1";
+    e.ts_ns = 1;
+    e.scope_name = "a\"b";  // embedded quote must be JSON-escaped
+    e.signature = 0;
+    const std::string json = gpufl::model::ExecutionSignatureModel(e).buildJson();
+    EXPECT_TRUE(JsonContains(json, "\"scope_name\":\"a\\\"b\""))
+        << "scope_name must be JSON-escaped: " << json;
+}
+
 // ── kernel_event_batch ────────────────────────────────────────────────────
 //
 // The columnar batch records are the heart of the wire contract: the

--- a/tests/launcher/test_cli_parse.cpp
+++ b/tests/launcher/test_cli_parse.cpp
@@ -168,6 +168,85 @@ TEST(CliParseTrace, FlagsAfterDashDashTreatedAsCommandArgs) {
     EXPECT_EQ(r.args->command[1], "--verbose");
 }
 
+// ── gpufl trace --passes / multi-pass plan resolution ────────────────────
+
+TEST(CliParseTrace, PassesParsedAsList) {
+    auto r = parseTraceArgs(
+        argsFor({"--passes", "Trace,PcSampling,SassMetrics", "--", "./bin"}));
+    ASSERT_TRUE(r.args.has_value()) << r.error;
+    ASSERT_EQ(r.args->passes.size(), 3u);
+    EXPECT_EQ(r.args->passes[0], "Trace");
+    EXPECT_EQ(r.args->passes[1], "PcSampling");
+    EXPECT_EQ(r.args->passes[2], "SassMetrics");
+    EXPECT_TRUE(r.args->engine.empty());
+}
+
+TEST(CliParseTrace, PassesTrimsWhitespace) {
+    // Spaces after commas (a natural way to type the list) are tolerated.
+    auto r = parseTraceArgs(
+        argsFor({"--passes=Trace, SassMetrics", "--", "./bin"}));
+    ASSERT_TRUE(r.args.has_value()) << r.error;
+    ASSERT_EQ(r.args->passes.size(), 2u);
+    EXPECT_EQ(r.args->passes[0], "Trace");
+    EXPECT_EQ(r.args->passes[1], "SassMetrics");
+}
+
+TEST(CliParseTrace, PassesInvalidEngineRejected) {
+    auto r = parseTraceArgs(argsFor({"--passes=Trace,warpdrive", "--", "./bin"}));
+    EXPECT_FALSE(r.args.has_value());
+    EXPECT_NE(r.error.find("invalid --passes"), std::string::npos);
+}
+
+TEST(CliParseTrace, PassesEmptyRejected) {
+    auto r = parseTraceArgs(argsFor({"--passes=", "--", "./bin"}));
+    EXPECT_FALSE(r.args.has_value());
+    EXPECT_NE(r.error.find("--passes requires"), std::string::npos);
+}
+
+TEST(CliParseTrace, EngineAndPassesMutuallyExclusive) {
+    auto r = parseTraceArgs(
+        argsFor({"--engine=Deep", "--passes=Trace", "--", "./bin"}));
+    EXPECT_FALSE(r.args.has_value());
+    EXPECT_NE(r.error.find("mutually exclusive"), std::string::npos);
+}
+
+TEST(ResolvePassPlan, ExplicitPassesWin) {
+    TraceArgs a;
+    a.passes = {"Trace", "SassMetrics"};
+    a.engine = "";  // empty — passes take precedence regardless
+    const auto plan = resolvePassPlan(a);
+    ASSERT_EQ(plan.size(), 2u);
+    EXPECT_EQ(plan[0], "Trace");
+    EXPECT_EQ(plan[1], "SassMetrics");
+}
+
+TEST(ResolvePassPlan, DeepExpandsToDefaultPlan) {
+    TraceArgs a;
+    a.engine = "Deep";
+    const auto plan = resolvePassPlan(a);
+    ASSERT_EQ(plan.size(), 3u);
+    EXPECT_EQ(plan[0], "Trace");
+    EXPECT_EQ(plan[1], "PcSampling");
+    EXPECT_EQ(plan[2], "SassMetrics");
+}
+
+TEST(ResolvePassPlan, SingleExplicitEngineIsOnePass) {
+    TraceArgs a;
+    a.engine = "PcSampling";
+    const auto plan = resolvePassPlan(a);
+    ASSERT_EQ(plan.size(), 1u);
+    EXPECT_EQ(plan[0], "PcSampling");
+}
+
+TEST(ResolvePassPlan, NoEngineIsOneDefaultPass) {
+    // No --engine, no --passes → one pass with an empty engine string, i.e.
+    // "use the profile's default engine" — the legacy single-pass behavior.
+    TraceArgs a;
+    const auto plan = resolvePassPlan(a);
+    ASSERT_EQ(plan.size(), 1u);
+    EXPECT_TRUE(plan[0].empty());
+}
+
 // ── gpufl upload ────────────────────────────────────────────────────────
 
 TEST(CliParseUpload, BasicLogPath) {

--- a/tests/python/test_bindings.py
+++ b/tests/python/test_bindings.py
@@ -70,7 +70,9 @@ EXPECTED_PROFILING_ENGINES = [
     "Trace",         # activity trace (kernels + memcpy + sync), no sampling
     "PcSampling",
     "SassMetrics",
+    "PmSampling",
     "RangeProfiler",
+    "RangeProfilerKernelReplay",
     "Deep",          # PcSampling + SassMetrics
 ]
 


### PR DESCRIPTION
## Description
This PR adds the client-side foundation for running and merging multiple profiling engine passes, and extends RangeProfiler support with kernel replay hardware counter reporting.


- Added multi-engine / multi-pass profiling support for `gpufl trace`
- Added `RangeProfilerKernelReplay` engine mode for per-kernel hardware counters
- Added capability metadata so collected / missing / unsupported data is explicit
- Added Windows profiling matrix scripts for validating engine combinations
- Updated C++ and Python text reports to show Range Profiler counter rows
- Updated Python analyzer to surface scope-level and kernel-level perf metrics together
- Updated Python bindings and tests for new profiling engine enum/API fields
- Updated README with current profiling engine and multi-pass usage guidance
## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update

## Testing
## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas