### PR TITLE
feat: gpufl monitoring feature

### DIFF
--- a/daemon/launcher/CMakeLists.txt
+++ b/daemon/launcher/CMakeLists.txt
@@ -22,6 +22,8 @@ add_executable(gpufl_launcher
     main.cpp
     cli_parse.cpp
     ${GPUFL_LAUNCHER_TRACE_IMPL}
+    monitor_command.cpp
+    ../monitor/monitor_runner.cpp
     upload_command.cpp
 )
 
@@ -32,6 +34,11 @@ set_target_properties(gpufl_launcher PROPERTIES OUTPUT_NAME gpufl)
 # Most of gpufl's object files are unreferenced from the launcher and
 # get DCE'd at link time with --gc-sections.
 target_link_libraries(gpufl_launcher PRIVATE gpufl::gpufl)
+
+target_include_directories(gpufl_launcher PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}/../monitor
+)
 
 target_compile_features(gpufl_launcher PRIVATE cxx_std_17)
 

--- a/daemon/launcher/cli_parse.cpp
+++ b/daemon/launcher/cli_parse.cpp
@@ -27,7 +27,7 @@ FlagBreak splitFlag(const std::string& tok) {
 // sync with the ProfilingEngine ladder.
 constexpr const char* kEngines[] = {
     "Monitor", "Trace", "PcSampling", "SassMetrics",
-    "PmSampling", "RangeProfiler", "Deep"};
+    "PmSampling", "RangeProfiler", "RangeProfilerKernelReplay", "Deep"};
 bool isValidEngine(const std::string& e) {
     for (auto* k : kEngines) if (e == k) return true;
     return false;
@@ -53,6 +53,7 @@ const char* topLevelHelp() {
         "\n"
         "SUBCOMMANDS:\n"
         "    trace      Inject GPUFlight into a target process and capture telemetry\n"
+        "    monitor    Run long-lived GPU/host telemetry collection\n"
         "    upload     Upload a captured session's NDJSON logs to the backend\n"
         "    version    Print version + build info\n"
         "\n"
@@ -73,7 +74,8 @@ const char* traceHelp() {
         "        --profile <PROF>    comprehensive (default) | light | monitoring-only\n"
         "        --engine <ENG>      Override profiling engine. One of:\n"
         "                            Monitor | Trace | PcSampling | SassMetrics |\n"
-        "                            PmSampling | RangeProfiler | Deep\n"
+        "                            PmSampling | RangeProfiler |\n"
+        "                            RangeProfilerKernelReplay | Deep\n"
         "                            (Deep = the default multi-pass plan: Trace,\n"
         "                            PcSampling, SassMetrics run as isolated passes\n"
         "                            and merged by the backend.)\n"
@@ -113,6 +115,8 @@ ParsedTopLevel parseTopLevel(int argc, char** argv) {
         out.sub = Subcommand::Trace;
     } else if (first == "upload") {
         out.sub = Subcommand::Upload;
+    } else if (first == "monitor") {
+        out.sub = Subcommand::Monitor;
     } else {
         out.sub = Subcommand::Unknown;
         out.remaining.push_back(first);
@@ -174,7 +178,7 @@ TraceParseResult parseTraceArgs(const std::vector<std::string>& argv) {
                 return {std::nullopt,
                         "invalid --engine value: " + out.engine +
                         " (expected: Monitor | Trace | PcSampling | SassMetrics | "
-                        "PmSampling | RangeProfiler | Deep)"};
+                        "PmSampling | RangeProfiler | RangeProfilerKernelReplay | Deep)"};
             }
         } else if (key == "--passes") {
             std::string v;
@@ -195,7 +199,7 @@ TraceParseResult parseTraceArgs(const std::vector<std::string>& argv) {
                                 "invalid --passes engine: " + item +
                                 " (expected a comma-separated list of: Monitor | "
                                 "Trace | PcSampling | SassMetrics | PmSampling | "
-                                "RangeProfiler | Deep)"};
+                                "RangeProfiler | RangeProfilerKernelReplay | Deep)"};
                     }
                     out.passes.push_back(item);
                 }
@@ -261,6 +265,38 @@ const char* uploadHelp() {
         "    gpufl upload ./logs --all-sessions\n"
         "    GPUFL_API_KEY=gpfl_… GPUFL_BACKEND_URL=https://api.gpuflight.com \\\n"
         "        gpufl upload ./logs --session-id <uuid>\n";
+}
+
+const char* monitorHelp() {
+    return
+        "gpufl monitor - Run long-lived GPU/host telemetry collection\n"
+        "\n"
+        "USAGE:\n"
+        "    gpufl monitor [OPTIONS]\n"
+        "\n"
+        "OPTIONS:\n"
+        "    -n, --name <NAME>       Monitor session name. Default: gpufl-monitor\n"
+        "    -o, --output <DIR>      Local NDJSON output dir\n"
+        "                            (default: ~/.gpufl/monitor/{ts}_{session_id}/)\n"
+        "        --interval <MS>     Sampling interval in milliseconds. Default: 5000\n"
+        "        --upload            Start gpufl-agent as the live uploader\n"
+        "        --backend-url <URL> Backend base URL for --upload\n"
+        "                            Env fallback: GPUFL_BACKEND_URL\n"
+        "        --api-key <KEY>     Bearer token for --upload\n"
+        "                            Env fallback: GPUFL_API_KEY\n"
+        "        --api-version <VER> Agent HTTP API version. Default: v1\n"
+        "        --agent-jar <PATH>  Run agent as `java -jar <PATH>`\n"
+        "                            Env fallback: GPUFL_AGENT_JAR\n"
+        "        --agent-cursor <P>  Agent cursor file. Default: <output>/cursor.json\n"
+        "        --log-types <LIST>  Agent channels to upload. Default: system\n"
+        "    -q, --quiet             Suppress launcher chatter\n"
+        "    -v, --verbose           Verbose launcher logging\n"
+        "    -h, --help              Print this help\n"
+        "\n"
+        "EXAMPLES:\n"
+        "    gpufl monitor\n"
+        "    gpufl monitor --interval 1000\n"
+        "    gpufl monitor --name llm-node-1 --upload\n";
 }
 
 UploadParseResult parseUploadArgs(const std::vector<std::string>& argv) {
@@ -339,6 +375,85 @@ UploadParseResult parseUploadArgs(const std::vector<std::string>& argv) {
     if (!out.session_id.empty() && out.all_sessions) {
         return {std::nullopt, "--session-id and --all-sessions are mutually exclusive"};
     }
+    return {out, ""};
+}
+
+MonitorParseResult parseMonitorArgs(const std::vector<std::string>& argv) {
+    MonitorArgs out;
+
+    auto parsePositiveInt = [](const std::string& s, int& slot) -> bool {
+        if (s.empty()) return false;
+        char* end = nullptr;
+        long v = std::strtol(s.c_str(), &end, 10);
+        if (*end != '\0' || v <= 0) return false;
+        slot = static_cast<int>(v);
+        return true;
+    };
+
+    for (size_t i = 0; i < argv.size(); ++i) {
+        const std::string& tok = argv[i];
+        if (tok == "-h" || tok == "--help") return {std::nullopt, "__help__"};
+        if (tok == "-v" || tok == "--verbose") { out.verbose = true; continue; }
+        if (tok == "-q" || tok == "--quiet")   { out.quiet = true; continue; }
+        if (tok == "--upload")                 { out.upload = true; continue; }
+
+        auto fb = splitFlag(tok);
+        const std::string& key = fb.key;
+        auto take_value = [&](std::string& slot) -> std::string {
+            if (fb.inline_value) { slot = *fb.inline_value; return ""; }
+            if (i + 1 >= argv.size()) return "missing value for " + key;
+            slot = argv[++i];
+            return "";
+        };
+
+        if (key == "-n" || key == "--name") {
+            auto err = take_value(out.name);
+            if (!err.empty()) return {std::nullopt, err};
+            if (out.name.empty()) return {std::nullopt, "--name cannot be empty"};
+        } else if (key == "-o" || key == "--output") {
+            auto err = take_value(out.output_dir);
+            if (!err.empty()) return {std::nullopt, err};
+            if (out.output_dir.empty()) return {std::nullopt, "--output cannot be empty"};
+        } else if (key == "--interval") {
+            std::string v;
+            auto err = take_value(v);
+            if (!err.empty()) return {std::nullopt, err};
+            if (!parsePositiveInt(v, out.interval_ms)) {
+                return {std::nullopt,
+                        "invalid --interval value: " + v +
+                        " (expected a positive integer, milliseconds)"};
+            }
+        } else if (key == "--backend-url") {
+            auto err = take_value(out.backend_url);
+            if (!err.empty()) return {std::nullopt, err};
+        } else if (key == "--api-key") {
+            auto err = take_value(out.api_key);
+            if (!err.empty()) return {std::nullopt, err};
+        } else if (key == "--api-version") {
+            auto err = take_value(out.api_version);
+            if (!err.empty()) return {std::nullopt, err};
+            if (out.api_version.empty()) return {std::nullopt, "--api-version cannot be empty"};
+        } else if (key == "--agent-jar") {
+            auto err = take_value(out.agent_jar);
+            if (!err.empty()) return {std::nullopt, err};
+            if (out.agent_jar.empty()) return {std::nullopt, "--agent-jar cannot be empty"};
+        } else if (key == "--agent-cursor") {
+            auto err = take_value(out.agent_cursor);
+            if (!err.empty()) return {std::nullopt, err};
+            if (out.agent_cursor.empty()) return {std::nullopt, "--agent-cursor cannot be empty"};
+        } else if (key == "--log-types") {
+            auto err = take_value(out.log_types);
+            if (!err.empty()) return {std::nullopt, err};
+            if (out.log_types.empty()) return {std::nullopt, "--log-types cannot be empty"};
+        } else if (!tok.empty() && tok[0] == '-') {
+            return {std::nullopt, "unknown flag: " + key};
+        } else {
+            return {std::nullopt,
+                    "unexpected argument: " + tok +
+                    " (`gpufl monitor` does not launch a target process; use `gpufl trace -- <cmd>`)"};
+        }
+    }
+
     return {out, ""};
 }
 

--- a/daemon/launcher/cli_parse.hpp
+++ b/daemon/launcher/cli_parse.hpp
@@ -43,11 +43,30 @@ struct UploadArgs {
     bool force = false;             // --force: re-upload despite cursor
 };
 
+// Parsed `gpufl monitor` invocation. This starts the long-running
+// telemetry-only sampler in the launcher process. When --upload is set, the
+// launcher also starts gpufl-agent as the live uploader.
+struct MonitorArgs {
+    std::string name = "gpufl-monitor";  // --name / -n
+    std::string output_dir;              // --output / -o; default ~/.gpufl/monitor/{ts}_{sid}
+    int interval_ms = 5000;              // --interval
+    bool upload = false;                 // --upload: start gpufl-agent
+    std::string backend_url;             // --backend-url; else GPUFL_BACKEND_URL
+    std::string api_key;                 // --api-key; else GPUFL_API_KEY
+    std::string api_version = "v1";      // --api-version
+    std::string agent_jar;               // --agent-jar; else GPUFL_AGENT_JAR
+    std::string agent_cursor;            // --agent-cursor; default <output>/cursor.json
+    std::string log_types = "system";    // --log-types
+    bool quiet = false;                  // -q
+    bool verbose = false;                // -v
+};
+
 enum class Subcommand {
     Help,        // `gpufl --help` / `gpufl` with no args
     Version,     // `gpufl version` / `gpufl -V`
     Trace,       // `gpufl trace [opts] -- <command>...`
     Upload,      // `gpufl upload <log_path> [opts]`
+    Monitor,     // `gpufl monitor [opts]`
     Unknown,
 };
 
@@ -92,10 +111,19 @@ struct UploadParseResult {
 
 UploadParseResult parseUploadArgs(const std::vector<std::string>& argv);
 
+// Parses the args passed to `gpufl monitor`.
+struct MonitorParseResult {
+    std::optional<MonitorArgs> args;
+    std::string error;
+};
+
+MonitorParseResult parseMonitorArgs(const std::vector<std::string>& argv);
+
 // Help text printed for `gpufl --help`, `gpufl trace --help`,
-// and `gpufl upload --help`.
+// `gpufl upload --help`, and `gpufl monitor --help`.
 const char* topLevelHelp();
 const char* traceHelp();
 const char* uploadHelp();
+const char* monitorHelp();
 
 }  // namespace gpufl::launcher

--- a/daemon/launcher/main.cpp
+++ b/daemon/launcher/main.cpp
@@ -9,6 +9,7 @@
 #include <vector>
 
 #include "cli_parse.hpp"
+#include "monitor_command.hpp"
 #include "trace_command.hpp"
 #include "upload_command.hpp"
 
@@ -52,6 +53,20 @@ int runUploadFromArgs(const std::vector<std::string>& argv) {
     return runUpload(*parsed.args);
 }
 
+int runMonitorFromArgs(const std::vector<std::string>& argv) {
+    auto parsed = parseMonitorArgs(argv);
+    if (!parsed.args) {
+        if (parsed.error == "__help__") {
+            std::fputs(monitorHelp(), stdout);
+            return 0;
+        }
+        std::fprintf(stderr, "gpufl monitor: %s\n\n", parsed.error.c_str());
+        std::fputs(monitorHelp(), stderr);
+        return 2;
+    }
+    return runMonitor(*parsed.args);
+}
+
 }  // namespace
 
 int main(int argc, char** argv) {
@@ -66,6 +81,8 @@ int main(int argc, char** argv) {
             return runTraceFromArgs(top.remaining);
         case Subcommand::Upload:
             return runUploadFromArgs(top.remaining);
+        case Subcommand::Monitor:
+            return runMonitorFromArgs(top.remaining);
         case Subcommand::Unknown:
             std::fprintf(stderr, "gpufl: unknown subcommand: %s\n\n",
                          top.remaining.empty() ? "" : top.remaining[0].c_str());

--- a/daemon/launcher/monitor_command.cpp
+++ b/daemon/launcher/monitor_command.cpp
@@ -1,0 +1,374 @@
+#include "monitor_command.hpp"
+
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <ctime>
+#include <filesystem>
+#include <iomanip>
+#include <random>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#ifdef _WIN32
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+#else
+#include <signal.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#endif
+
+#include "gpufl/core/env_vars.hpp"
+#include "monitor_runner.hpp"
+
+namespace fs = std::filesystem;
+
+namespace gpufl::launcher {
+namespace {
+
+constexpr const char* kAgentJarEnv = "GPUFL_AGENT_JAR";
+
+std::string envOrEmpty(const char* name) {
+    if (const char* v = std::getenv(name); v && *v) return v;
+    return {};
+}
+
+std::string resolve(const std::string& flag, const char* env_name) {
+    if (!flag.empty()) return flag;
+    return envOrEmpty(env_name);
+}
+
+std::string makeSessionId() {
+    static std::mt19937_64 rng{
+        static_cast<uint64_t>(
+            std::chrono::steady_clock::now().time_since_epoch().count()) ^
+        0x6eed0e9da4d94a4fULL};
+    const uint64_t v = rng();
+    std::ostringstream os;
+    os << std::hex << std::setw(8) << std::setfill('0') << (v & 0xffffffffu);
+    return os.str();
+}
+
+std::string makeTimestamp() {
+    const auto t = std::time(nullptr);
+    std::tm tm{};
+#ifdef _WIN32
+    localtime_s(&tm, &t);
+#else
+    localtime_r(&t, &tm);
+#endif
+    char buf[32];
+    std::strftime(buf, sizeof(buf), "%Y%m%d-%H%M%S", &tm);
+    return buf;
+}
+
+fs::path homeDir() {
+#ifdef _WIN32
+    if (const char* up = std::getenv("USERPROFILE"); up && *up) {
+        return fs::path(up);
+    }
+    if (const char* hd = std::getenv("HOMEDRIVE")) {
+        if (const char* hp = std::getenv("HOMEPATH")) {
+            return fs::path(std::string(hd) + hp);
+        }
+    }
+    return fs::temp_directory_path();
+#else
+    if (const char* home = std::getenv("HOME"); home && *home) {
+        return fs::path(home);
+    }
+    return fs::path("/tmp");
+#endif
+}
+
+fs::path defaultOutputDir() {
+    return homeDir() / ".gpufl" / "monitor" /
+           (makeTimestamp() + "_" + makeSessionId());
+}
+
+std::vector<std::string> splitPathEnv() {
+    std::vector<std::string> out;
+    const char* raw = std::getenv("PATH");
+    if (!raw) return out;
+    std::string path(raw);
+#ifdef _WIN32
+    constexpr char delim = ';';
+#else
+    constexpr char delim = ':';
+#endif
+    size_t start = 0;
+    while (start <= path.size()) {
+        const size_t pos = path.find(delim, start);
+        std::string item = path.substr(
+            start, pos == std::string::npos ? std::string::npos : pos - start);
+        if (!item.empty()) out.push_back(std::move(item));
+        if (pos == std::string::npos) break;
+        start = pos + 1;
+    }
+    return out;
+}
+
+fs::path findExecutableOnPath(const std::string& name) {
+    const std::vector<std::string> dirs = splitPathEnv();
+#ifdef _WIN32
+    const std::vector<std::string> suffixes = {".exe"};
+#else
+    const std::vector<std::string> suffixes = {""};
+#endif
+    for (const auto& dir : dirs) {
+        for (const auto& suffix : suffixes) {
+            fs::path candidate = fs::path(dir) / (name + suffix);
+            std::error_code ec;
+            if (fs::exists(candidate, ec) && !fs::is_directory(candidate, ec)) {
+                return fs::weakly_canonical(candidate, ec);
+            }
+        }
+    }
+    return {};
+}
+
+bool setEnv(const char* name, const std::string& value) {
+#ifdef _WIN32
+    return SetEnvironmentVariableA(name, value.c_str()) != 0;
+#else
+    return ::setenv(name, value.c_str(), 1) == 0;
+#endif
+}
+
+void appendQuotedArg(const std::string& arg, std::string& cmd) {
+    if (!arg.empty() && arg.find_first_of(" \t\n\v\"") == std::string::npos) {
+        cmd += arg;
+        return;
+    }
+    cmd += '"';
+    for (auto it = arg.begin();; ++it) {
+        unsigned backslashes = 0;
+        while (it != arg.end() && *it == '\\') { ++it; ++backslashes; }
+        if (it == arg.end()) {
+            cmd.append(backslashes * 2, '\\');
+            break;
+        }
+        if (*it == '"') {
+            cmd.append(backslashes * 2 + 1, '\\');
+            cmd += '"';
+        } else {
+            cmd.append(backslashes, '\\');
+            cmd += *it;
+        }
+    }
+    cmd += '"';
+}
+
+std::string buildCommandLine(const std::vector<std::string>& args) {
+    std::string cmd;
+    for (size_t i = 0; i < args.size(); ++i) {
+        if (i) cmd += ' ';
+        appendQuotedArg(args[i], cmd);
+    }
+    return cmd;
+}
+
+#ifdef _WIN32
+std::wstring widen(const std::string& s) {
+    if (s.empty()) return {};
+    const int n = MultiByteToWideChar(CP_ACP, 0, s.data(),
+                                      static_cast<int>(s.size()), nullptr, 0);
+    std::wstring w(n, L'\0');
+    MultiByteToWideChar(CP_ACP, 0, s.data(), static_cast<int>(s.size()),
+                        w.data(), n);
+    return w;
+}
+#endif
+
+struct AgentProcess {
+#ifdef _WIN32
+    PROCESS_INFORMATION pi{};
+#else
+    pid_t pid = -1;
+#endif
+    bool running = false;
+
+    bool start(const std::vector<std::string>& command, std::string& error) {
+#ifdef _WIN32
+        std::wstring cmdline = widen(buildCommandLine(command));
+        std::vector<wchar_t> cmdbuf(cmdline.begin(), cmdline.end());
+        cmdbuf.push_back(L'\0');
+
+        STARTUPINFOW si{};
+        si.cb = sizeof(si);
+        if (!CreateProcessW(nullptr, cmdbuf.data(), nullptr, nullptr, TRUE, 0,
+                            nullptr, nullptr, &si, &pi)) {
+            error = "CreateProcess failed for gpufl-agent (err=" +
+                    std::to_string(static_cast<unsigned long>(GetLastError())) + ")";
+            return false;
+        }
+        running = true;
+        return true;
+#else
+        pid = ::fork();
+        if (pid < 0) {
+            error = "fork failed while starting gpufl-agent";
+            return false;
+        }
+        if (pid == 0) {
+            std::vector<char*> argv;
+            argv.reserve(command.size() + 1);
+            for (const auto& s : command) {
+                argv.push_back(const_cast<char*>(s.c_str()));
+            }
+            argv.push_back(nullptr);
+            ::execvp(command.front().c_str(), argv.data());
+            std::fprintf(stderr, "gpufl monitor: cannot exec %s\n",
+                         command.front().c_str());
+            std::_Exit(127);
+        }
+        running = true;
+        return true;
+#endif
+    }
+
+    void stop() {
+        if (!running) return;
+#ifdef _WIN32
+        TerminateProcess(pi.hProcess, 0);
+        WaitForSingleObject(pi.hProcess, 5000);
+        CloseHandle(pi.hThread);
+        CloseHandle(pi.hProcess);
+#else
+        ::kill(pid, SIGTERM);
+        int status = 0;
+        for (int i = 0; i < 50; ++i) {
+            const pid_t rc = ::waitpid(pid, &status, WNOHANG);
+            if (rc == pid) {
+                running = false;
+                return;
+            }
+            usleep(100000);
+        }
+        ::kill(pid, SIGKILL);
+        ::waitpid(pid, &status, 0);
+#endif
+        running = false;
+    }
+};
+
+struct AgentStartPlan {
+    std::vector<std::string> command;
+    std::string description;
+};
+
+bool buildAgentStartPlan(const MonitorArgs& args, AgentStartPlan& plan,
+                         std::string& error) {
+    const std::string agent_jar = resolve(args.agent_jar, kAgentJarEnv);
+    if (!agent_jar.empty()) {
+        std::error_code ec;
+        if (!fs::exists(agent_jar, ec)) {
+            error = "agent jar not found: " + agent_jar;
+            return false;
+        }
+        const fs::path java = findExecutableOnPath("java");
+        if (java.empty()) {
+            error = "java not found on PATH; install Java or put gpufl-agent on PATH";
+            return false;
+        }
+        plan.command = {java.string(), "-jar", agent_jar};
+        plan.description = "java -jar " + agent_jar;
+        return true;
+    }
+
+    const fs::path agent = findExecutableOnPath("gpufl-agent");
+    if (agent.empty()) {
+        error = "gpufl-agent not found. Install gpufl-agent on PATH or pass "
+                "--agent-jar <path> / GPUFL_AGENT_JAR.";
+        return false;
+    }
+    plan.command = {agent.string()};
+    plan.description = agent.string();
+    return true;
+}
+
+}  // namespace
+
+int runMonitor(const MonitorArgs& args) {
+    fs::path output_dir = args.output_dir.empty()
+                        ? defaultOutputDir()
+                        : fs::path(args.output_dir);
+    std::error_code ec;
+    fs::create_directories(output_dir, ec);
+    if (ec) {
+        std::fprintf(stderr, "gpufl monitor: cannot create %s: %s\n",
+                     output_dir.string().c_str(), ec.message().c_str());
+        return 2;
+    }
+    output_dir = fs::weakly_canonical(output_dir, ec);
+
+    AgentProcess agent;
+    if (args.upload) {
+        const std::string backend_url =
+            resolve(args.backend_url, gpufl::env::kBackendUrl);
+        const std::string api_key =
+            resolve(args.api_key, gpufl::env::kApiKey);
+        if (backend_url.empty()) {
+            std::fprintf(stderr,
+                "gpufl monitor --upload: --backend-url required "
+                "(or set GPUFL_BACKEND_URL)\n");
+            return 2;
+        }
+        if (api_key.empty()) {
+            std::fprintf(stderr,
+                "gpufl monitor --upload: --api-key required "
+                "(or set GPUFL_API_KEY)\n");
+            return 2;
+        }
+
+        fs::path cursor = args.agent_cursor.empty()
+                        ? output_dir / "cursor.json"
+                        : fs::path(args.agent_cursor);
+
+        if (!setEnv("GPUFL_SOURCE_FOLDERS", output_dir.string()) ||
+            !setEnv("GPUFL_LOG_TYPES", args.log_types) ||
+            !setEnv("GPUFL_CURSOR_FILE", cursor.string()) ||
+            !setEnv("GPUFL_PUBLISHER_TYPE", "http") ||
+            !setEnv("GPUFL_HTTP_HOST", backend_url) ||
+            !setEnv("GPUFL_HTTP_TOKEN", api_key) ||
+            !setEnv("GPUFL_HTTP_API_VERSION", args.api_version) ||
+            !setEnv("GPUFL_AGENT_UPLOAD_MODE", "stream")) {
+            std::fprintf(stderr, "gpufl monitor: failed to configure agent environment\n");
+            return 2;
+        }
+
+        AgentStartPlan plan;
+        std::string error;
+        if (!buildAgentStartPlan(args, plan, error)) {
+            std::fprintf(stderr, "gpufl monitor --upload: %s\n", error.c_str());
+            return 2;
+        }
+        if (!args.quiet) {
+            std::fprintf(stderr, "[gpufl] starting agent: %s\n",
+                         plan.description.c_str());
+        }
+        if (!agent.start(plan.command, error)) {
+            std::fprintf(stderr, "gpufl monitor --upload: %s\n", error.c_str());
+            return 3;
+        }
+    }
+
+    gpufl::daemon::MonitorRunOptions opts;
+    opts.app_name = args.name;
+    opts.log_path = output_dir.string();
+    opts.interval_ms = args.interval_ms;
+    opts.quiet = args.quiet;
+
+    const int rc = gpufl::daemon::runMonitorForeground(opts);
+    agent.stop();
+    return rc;
+}
+
+}  // namespace gpufl::launcher

--- a/daemon/launcher/monitor_command.hpp
+++ b/daemon/launcher/monitor_command.hpp
@@ -1,0 +1,11 @@
+#pragma once
+
+#include "cli_parse.hpp"
+
+namespace gpufl::launcher {
+
+// Runs `gpufl monitor`: telemetry-only foreground monitoring in this process.
+// With --upload, starts gpufl-agent as a managed child for live upload.
+int runMonitor(const MonitorArgs& args);
+
+}  // namespace gpufl::launcher

--- a/daemon/monitor/CMakeLists.txt
+++ b/daemon/monitor/CMakeLists.txt
@@ -1,6 +1,9 @@
 cmake_minimum_required(VERSION 3.31)
 
-add_executable(gpufl-monitor main.cpp)
+add_executable(gpufl-monitor
+    main.cpp
+    monitor_runner.cpp
+)
 
 target_link_libraries(gpufl-monitor PRIVATE gpufl::gpufl)
 

--- a/daemon/monitor/main.cpp
+++ b/daemon/monitor/main.cpp
@@ -1,17 +1,9 @@
-#include <csignal>
 #include <cstdlib>
-#include <cerrno>
-#include <cstring>
 #include <iostream>
 #include <string>
-#include <thread>
 
-#ifndef _WIN32
-#include <pthread.h>
-#endif
-
-#include "gpufl/gpufl.hpp"
 #include "gpufl/core/env_vars.hpp"
+#include "monitor_runner.hpp"
 
 namespace {
 
@@ -20,91 +12,29 @@ std::string getenv_or(const char* var, const char* fallback) {
     return val ? std::string(val) : std::string(fallback);
 }
 
-#ifdef _WIN32
-volatile std::sig_atomic_t g_shutdownRequested = 0;
-
-void signalHandler(int /*sig*/) {
-    g_shutdownRequested = 1;
-}
-
-bool blockTerminationSignals() {
-    return true;
-}
-
-bool waitForShutdownSignal() {
-    while (!g_shutdownRequested) {
-        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+int getenv_int_or(const char* var, int fallback) {
+    const char* val = std::getenv(var);
+    if (!val || !*val) return fallback;
+    try {
+        return std::stoi(val);
+    } catch (...) {
+        return fallback;
     }
-    return true;
 }
-#else
-bool blockTerminationSignals() {
-    sigset_t set;
-    if (::sigemptyset(&set) != 0) return false;
-    if (::sigaddset(&set, SIGINT) != 0) return false;
-    if (::sigaddset(&set, SIGTERM) != 0) return false;
-
-    return ::pthread_sigmask(SIG_BLOCK, &set, nullptr) == 0;
-}
-
-bool waitForShutdownSignal() {
-    sigset_t set;
-    if (::sigemptyset(&set) != 0) return false;
-    if (::sigaddset(&set, SIGINT) != 0) return false;
-    if (::sigaddset(&set, SIGTERM) != 0) return false;
-
-    int sig = 0;
-    const int rc = ::sigwait(&set, &sig);
-    return rc == 0;
-}
-#endif
 
 }  // namespace
 
 int main() {
-#ifdef _WIN32
-    std::signal(SIGINT, signalHandler);
-    std::signal(SIGTERM, signalHandler);
-#endif
+    gpufl::daemon::MonitorRunOptions opts;
+    opts.app_name = getenv_or(gpufl::env::kMonitorApp, "gpufl-monitor");
+    opts.log_path = getenv_or(gpufl::env::kMonitorLogDir,
+                              "/var/gpufl/monitor/session");
+    opts.interval_ms = getenv_int_or(gpufl::env::kMonitorIntervalMs, 5000);
 
-    if (!blockTerminationSignals()) {
-        std::cerr << "Failed to block termination signals: "
-                  << std::strerror(errno) << '\n';
-        return 1;
+    if (opts.interval_ms <= 0) {
+        std::cerr << "GPUFL_MONITOR_INTERVAL_MS must be positive.\n";
+        return 2;
     }
 
-    const std::string appName = getenv_or(gpufl::env::kMonitorApp, "gpufl-monitor");
-    const std::string logPath =
-        getenv_or(gpufl::env::kMonitorLogDir, "/var/gpufl/monitor/session");
-    const int intervalMs =
-        std::stoi(getenv_or(gpufl::env::kMonitorIntervalMs, "5000"));
-
-    std::cout << "Starting GPUFL monitor with app name: " << appName
-              << ", log path: " << logPath << ", interval: " << intervalMs
-              << "ms\n";
-    gpufl::InitOptions opts;
-    opts.app_name = appName;
-    opts.log_path = logPath;
-    // Telemetry-only daemon: Monitor means no CUPTI at all, just the
-    // NVML/host metrics sampler driven by continuous_system_sampling
-    // below. (This used to pass `None`, which despite the name still
-    // subscribed CUPTI and captured kernel events the daemon never wanted.)
-    opts.profiling_engine = gpufl::ProfilingEngine::Monitor;
-    opts.continuous_system_sampling = true;
-    opts.system_sample_rate_ms = intervalMs;
-    opts.enable_debug_output = true;
-    opts.flush_logs_always = true;
-
-    if (!gpufl::init(opts)) {
-        return 1;
-    }
-
-    if (!waitForShutdownSignal()) {
-        std::cerr << "Failed while waiting for termination signal.\n";
-        gpufl::shutdown();
-        return 1;
-    }
-
-    gpufl::shutdown();
-    return 0;
+    return gpufl::daemon::runMonitorForeground(opts);
 }

--- a/daemon/monitor/monitor_runner.cpp
+++ b/daemon/monitor/monitor_runner.cpp
@@ -1,0 +1,104 @@
+#include "monitor_runner.hpp"
+
+#include <cerrno>
+#include <csignal>
+#include <cstring>
+#include <iostream>
+#include <thread>
+
+#ifndef _WIN32
+#include <pthread.h>
+#endif
+
+#include "gpufl/gpufl.hpp"
+
+namespace gpufl::daemon {
+namespace {
+
+#ifdef _WIN32
+volatile std::sig_atomic_t g_shutdownRequested = 0;
+
+void signalHandler(int /*sig*/) {
+    g_shutdownRequested = 1;
+}
+
+bool setupSignalHandling() {
+    std::signal(SIGINT, signalHandler);
+    std::signal(SIGTERM, signalHandler);
+    return true;
+}
+
+bool waitForShutdownSignal() {
+    while (!g_shutdownRequested) {
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+    return true;
+}
+#else
+bool setupSignalHandling() {
+    sigset_t set;
+    if (::sigemptyset(&set) != 0) return false;
+    if (::sigaddset(&set, SIGINT) != 0) return false;
+    if (::sigaddset(&set, SIGTERM) != 0) return false;
+    return ::pthread_sigmask(SIG_BLOCK, &set, nullptr) == 0;
+}
+
+bool waitForShutdownSignal() {
+    sigset_t set;
+    if (::sigemptyset(&set) != 0) return false;
+    if (::sigaddset(&set, SIGINT) != 0) return false;
+    if (::sigaddset(&set, SIGTERM) != 0) return false;
+
+    int sig = 0;
+    const int rc = ::sigwait(&set, &sig);
+    return rc == 0;
+}
+#endif
+
+}  // namespace
+
+int runMonitorForeground(const MonitorRunOptions& opts) {
+    if (!setupSignalHandling()) {
+        std::cerr << "gpufl monitor: failed to set signal handling: "
+                  << std::strerror(errno) << '\n';
+        return 3;
+    }
+
+    if (!opts.quiet) {
+        std::cerr << "[gpufl] monitor sampling -> " << opts.log_path
+                  << " every " << opts.interval_ms << "ms\n";
+    }
+
+    gpufl::InitOptions init;
+    init.app_name = opts.app_name.empty() ? "gpufl-monitor" : opts.app_name;
+    init.log_path = opts.log_path;
+    init.profiling_engine = gpufl::ProfilingEngine::Monitor;
+    init.continuous_system_sampling = true;
+    init.system_sample_rate_ms = opts.interval_ms;
+    init.enable_debug_output = false;
+    init.enable_stack_trace = false;
+    init.enable_source_collection = false;
+    init.enable_synchronization = false;
+    init.enable_memory_tracking = false;
+    init.enable_cuda_graphs_tracking = false;
+    init.enable_external_correlation = false;
+    init.flush_logs_always = true;
+
+    if (!gpufl::init(init)) {
+        return 3;
+    }
+
+    const bool wait_ok = waitForShutdownSignal();
+    gpufl::shutdown();
+
+    if (!wait_ok) {
+        std::cerr << "gpufl monitor: failed while waiting for termination signal.\n";
+        return 3;
+    }
+    if (!opts.quiet) {
+        std::cerr << "[gpufl] monitor stopped\n";
+    }
+    return 0;
+}
+
+}  // namespace gpufl::daemon

--- a/daemon/monitor/monitor_runner.hpp
+++ b/daemon/monitor/monitor_runner.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <string>
+
+namespace gpufl::daemon {
+
+struct MonitorRunOptions {
+    std::string app_name = "gpufl-monitor";
+    std::string log_path;
+    int interval_ms = 5000;
+    bool quiet = false;
+};
+
+// Runs telemetry-only monitoring in the current process until SIGINT/SIGTERM.
+// Returns 0 on clean shutdown and 3 when gpufl::init() cannot start.
+int runMonitorForeground(const MonitorRunOptions& opts);
+
+}  // namespace gpufl::daemon

--- a/tests/launcher/test_cli_parse.cpp
+++ b/tests/launcher/test_cli_parse.cpp
@@ -326,6 +326,65 @@ TEST(CliParseUpload, HelpFlag) {
     EXPECT_EQ(r.error, "__help__");
 }
 
+// ── gpufl monitor ───────────────────────────────────────────────────────────
+
+TEST(CliParseMonitor, Defaults) {
+    auto r = parseMonitorArgs(argsFor({}));
+    ASSERT_TRUE(r.args.has_value()) << r.error;
+    EXPECT_EQ(r.args->name, "gpufl-monitor");
+    EXPECT_TRUE(r.args->output_dir.empty());
+    EXPECT_EQ(r.args->interval_ms, 5000);
+    EXPECT_FALSE(r.args->upload);
+    EXPECT_EQ(r.args->api_version, "v1");
+    EXPECT_EQ(r.args->log_types, "system");
+}
+
+TEST(CliParseMonitor, AllCommonFlags) {
+    auto r = parseMonitorArgs(argsFor({
+        "--name=llm-node-1", "--output", "/tmp/gpufl-monitor",
+        "--interval=1000", "--upload", "--backend-url=https://api.example.com",
+        "--api-key", "gpfl_key", "--api-version=v2", "--agent-jar=/tmp/agent.jar",
+        "--agent-cursor=/tmp/cursor.json", "--log-types=system,device",
+        "-v", "-q"}));
+    ASSERT_TRUE(r.args.has_value()) << r.error;
+    EXPECT_EQ(r.args->name, "llm-node-1");
+    EXPECT_EQ(r.args->output_dir, "/tmp/gpufl-monitor");
+    EXPECT_EQ(r.args->interval_ms, 1000);
+    EXPECT_TRUE(r.args->upload);
+    EXPECT_EQ(r.args->backend_url, "https://api.example.com");
+    EXPECT_EQ(r.args->api_key, "gpfl_key");
+    EXPECT_EQ(r.args->api_version, "v2");
+    EXPECT_EQ(r.args->agent_jar, "/tmp/agent.jar");
+    EXPECT_EQ(r.args->agent_cursor, "/tmp/cursor.json");
+    EXPECT_EQ(r.args->log_types, "system,device");
+    EXPECT_TRUE(r.args->verbose);
+    EXPECT_TRUE(r.args->quiet);
+}
+
+TEST(CliParseMonitor, InvalidIntervalRejected) {
+    auto r = parseMonitorArgs(argsFor({"--interval=0"}));
+    EXPECT_FALSE(r.args.has_value());
+    EXPECT_NE(r.error.find("invalid --interval"), std::string::npos);
+}
+
+TEST(CliParseMonitor, AgentJarParsed) {
+    auto r = parseMonitorArgs(argsFor({"--agent-jar", "/opt/gpufl-agent.jar"}));
+    ASSERT_TRUE(r.args.has_value()) << r.error;
+    EXPECT_EQ(r.args->agent_jar, "/opt/gpufl-agent.jar");
+}
+
+TEST(CliParseMonitor, BareArgumentRejected) {
+    auto r = parseMonitorArgs(argsFor({"python", "server.py"}));
+    EXPECT_FALSE(r.args.has_value());
+    EXPECT_NE(r.error.find("does not launch"), std::string::npos);
+}
+
+TEST(CliParseMonitor, HelpFlag) {
+    auto r = parseMonitorArgs(argsFor({"--help"}));
+    EXPECT_FALSE(r.args.has_value());
+    EXPECT_EQ(r.error, "__help__");
+}
+
 TEST(CliParseTopLevel, NoArgsShowsHelp) {
     char* argv[] = {const_cast<char*>("gpufl"), nullptr};
     auto p = parseTopLevel(1, argv);
@@ -356,6 +415,16 @@ TEST(CliParseTopLevel, TraceSubcommandStripsFirstToken) {
     ASSERT_EQ(p.remaining.size(), 2u);
     EXPECT_EQ(p.remaining[0], "--");
     EXPECT_EQ(p.remaining[1], "./app");
+}
+
+TEST(CliParseTopLevel, MonitorSubcommandStripsFirstToken) {
+    char* argv[] = {const_cast<char*>("gpufl"),
+                    const_cast<char*>("monitor"),
+                    const_cast<char*>("--interval=1000"), nullptr};
+    auto p = parseTopLevel(3, argv);
+    EXPECT_EQ(p.sub, Subcommand::Monitor);
+    ASSERT_EQ(p.remaining.size(), 1u);
+    EXPECT_EQ(p.remaining[0], "--interval=1000");
 }
 
 TEST(CliParseTopLevel, UnknownSubcommand) {


### PR DESCRIPTION
## Description
Added RangeProfilerKernelReplay engine to collect the range profiling data. 
Adds `gpufl monitor` as the native CLI entry point for long-running GPU/host telemetry.

The new command runs the existing monitor sampler in-process from the `gpufl` launcher, while keeping the existing standalone `gpufl-monitor` binary for Docker and supervisor-based deployments. `gpufl monitor --upload` starts `gpufl-agent` as a managed child process instead of duplicating live upload logic in C++.


## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update

## Testing
## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas