### PR TITLE
Stabilize trace capture and upload flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Try the portal with real session data — no sign-up required:
 - **Production Grade**: Uses a **Lock-Free Ring Buffer** and a **Background Collector Thread** to decouple logging from your hot path.
 - **Logical Scoping**: Group thousands of micro-kernels into meaningful phases (e.g., "Inference", "PhysicsStep") using `GFL_SCOPE` or `gpufl.Scope`.
 - **Rich Metadata**: Captures kernel names, grid/block dimensions, register counts, shared memory usage, occupancy with per-resource breakdown, and CPU stack traces.
-- **Profiling Engines**: Choose from PC Sampling (stall analysis), SASS Metrics (instruction-level divergence), or Range Profiler (hardware counters) — one engine per session.
+- **Profiling Passes**: Use `gpufl trace --passes` for Trace, PC Sampling, SASS Metrics, PM Sampling, or Range Profiler captures; launcher mode can run isolated passes and merge them later.
 - **System Monitoring**: Collects GPU utilization, VRAM, temperature, power, and clock speeds via NVML.
 - **Sidecar Ready**: Outputs structured NDJSON logs with automatic rotation and gzip compression.
 - **Deferred Upload**: After a session ends, ship its NDJSON files to the GPUFlight backend with one call (`gpufl.upload_logs(...)`) or the orchestrated `with gpufl.session(backend_url=..., api_key=...):` context manager. All HTTP happens post-shutdown, so transient network failures cannot affect your GPU workload. Ideal for local dev, SSH, and Jupyter — no sidecar needed.
@@ -219,10 +219,12 @@ gpufl.init("my-app",
 
 `gpufl trace` can run several passes of the same target process. This is the
 recommended path when you want data from engines that cannot safely coexist in
-one CUDA context.
+one CUDA context. Without `--passes`, launcher mode runs a single `Trace` pass.
+Use `--passes=Deep` as shorthand for `Trace,PcSampling,SassMetrics`. Use
+`gpufl monitor` for monitoring-only GPU/host telemetry.
 
 ```bash
-gpufl trace --passes Trace,PcSampling,RangeProfilerKernelReplay -- python train.py
+gpufl trace --passes=Trace,PcSampling,RangeProfilerKernelReplay -- python train.py
 ```
 
 For embedded examples and test scripts, the lower-level compatibility-matrix
@@ -322,17 +324,17 @@ if not result.success:
 
 ```bash
 gpufl upload ./logs \
-    --backend-url https://api.gpuflight.com \
-    --api-key gpfl_xxxxxxxxxxxx
+    --backend-url=https://api.gpuflight.com \
+    --api-key=gpfl_xxxxxxxxxxxx
 
 # Specific session
-gpufl upload ./logs --session-id <uuid> --backend-url ... --api-key ...
+gpufl upload ./logs --session-id=<uuid> --backend-url=... --api-key=...
 
 # Batch every session in the dir
-gpufl upload ./logs --all-sessions --backend-url ... --api-key ...
+gpufl upload ./logs --all-sessions --backend-url=... --api-key=...
 
 # Re-upload after the cursor marked it done
-gpufl upload ./logs --force --backend-url ... --api-key ...
+gpufl upload ./logs --force --backend-url=... --api-key=...
 ```
 
 > The native `gpufl` binary is **Linux-only**. On Windows/macOS (or any
@@ -340,7 +342,7 @@ gpufl upload ./logs --force --backend-url ... --api-key ...
 > through the Python package:
 >
 > ```bash
-> python -m gpufl.cli upload ./logs --backend-url ... --api-key ...
+> python -m gpufl.cli upload ./logs --backend-url=... --api-key=...
 > ```
 >
 > Up to v1.1.0rc2 this shipped as a `gpufl` pip console-script; it was

--- a/daemon/launcher/CMakeLists.txt
+++ b/daemon/launcher/CMakeLists.txt
@@ -20,6 +20,7 @@ endif()
 # `gpufl trace -- <cmd>` (not `gpufl_launcher trace -- <cmd>`).
 add_executable(gpufl_launcher
     main.cpp
+    agent_launcher.cpp
     cli_parse.cpp
     ${GPUFL_LAUNCHER_TRACE_IMPL}
     monitor_command.cpp

--- a/daemon/launcher/agent_launcher.cpp
+++ b/daemon/launcher/agent_launcher.cpp
@@ -1,0 +1,278 @@
+#include "agent_launcher.hpp"
+
+#include <cstdio>
+#include <cstdlib>
+#include <filesystem>
+#include <string>
+#include <utility>
+#include <vector>
+
+#ifdef _WIN32
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+#else
+#include <signal.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#endif
+
+namespace fs = std::filesystem;
+
+namespace gpufl::launcher {
+namespace {
+
+constexpr const char* kAgentJarEnv = "GPUFL_AGENT_JAR";
+
+std::vector<std::string> splitPathEnv() {
+    std::vector<std::string> out;
+    const char* raw = std::getenv("PATH");
+    if (!raw) return out;
+    std::string path(raw);
+#ifdef _WIN32
+    constexpr char delim = ';';
+#else
+    constexpr char delim = ':';
+#endif
+    size_t start = 0;
+    while (start <= path.size()) {
+        const size_t pos = path.find(delim, start);
+        std::string item = path.substr(
+            start, pos == std::string::npos ? std::string::npos : pos - start);
+        if (!item.empty()) out.push_back(std::move(item));
+        if (pos == std::string::npos) break;
+        start = pos + 1;
+    }
+    return out;
+}
+
+fs::path findExecutableOnPath(const std::string& name) {
+    const std::vector<std::string> dirs = splitPathEnv();
+#ifdef _WIN32
+    const std::vector<std::string> suffixes = {".exe"};
+#else
+    const std::vector<std::string> suffixes = {""};
+#endif
+    for (const auto& dir : dirs) {
+        for (const auto& suffix : suffixes) {
+            fs::path candidate = fs::path(dir) / (name + suffix);
+            std::error_code ec;
+            if (fs::exists(candidate, ec) && !fs::is_directory(candidate, ec)) {
+                return fs::weakly_canonical(candidate, ec);
+            }
+        }
+    }
+    return {};
+}
+
+bool setEnv(const char* name, const std::string& value) {
+#ifdef _WIN32
+    return SetEnvironmentVariableA(name, value.c_str()) != 0;
+#else
+    return ::setenv(name, value.c_str(), 1) == 0;
+#endif
+}
+
+void appendQuotedArg(const std::string& arg, std::string& cmd) {
+    if (!arg.empty() && arg.find_first_of(" \t\n\v\"") == std::string::npos) {
+        cmd += arg;
+        return;
+    }
+    cmd += '"';
+    for (auto it = arg.begin();; ++it) {
+        unsigned backslashes = 0;
+        while (it != arg.end() && *it == '\\') { ++it; ++backslashes; }
+        if (it == arg.end()) {
+            cmd.append(backslashes * 2, '\\');
+            break;
+        }
+        if (*it == '"') {
+            cmd.append(backslashes * 2 + 1, '\\');
+            cmd += '"';
+        } else {
+            cmd.append(backslashes, '\\');
+            cmd += *it;
+        }
+    }
+    cmd += '"';
+}
+
+std::string buildCommandLine(const std::vector<std::string>& args) {
+    std::string cmd;
+    for (size_t i = 0; i < args.size(); ++i) {
+        if (i) cmd += ' ';
+        appendQuotedArg(args[i], cmd);
+    }
+    return cmd;
+}
+
+#ifdef _WIN32
+std::wstring widen(const std::string& s) {
+    if (s.empty()) return {};
+    const int n = MultiByteToWideChar(CP_ACP, 0, s.data(),
+                                      static_cast<int>(s.size()), nullptr, 0);
+    std::wstring w(n, L'\0');
+    MultiByteToWideChar(CP_ACP, 0, s.data(), static_cast<int>(s.size()),
+                        w.data(), n);
+    return w;
+}
+#endif
+
+}  // namespace
+
+AgentProcess::~AgentProcess() {
+    stop();
+}
+
+bool AgentProcess::start(const std::vector<std::string>& command,
+                         std::string& error) {
+#ifdef _WIN32
+    std::wstring cmdline = widen(buildCommandLine(command));
+    std::vector<wchar_t> cmdbuf(cmdline.begin(), cmdline.end());
+    cmdbuf.push_back(L'\0');
+
+    STARTUPINFOW si{};
+    si.cb = sizeof(si);
+    PROCESS_INFORMATION pi{};
+    if (!CreateProcessW(nullptr, cmdbuf.data(), nullptr, nullptr, TRUE, 0,
+                        nullptr, nullptr, &si, &pi)) {
+        error = "CreateProcess failed for gpufl-agent (err=" +
+                std::to_string(static_cast<unsigned long>(GetLastError())) + ")";
+        return false;
+    }
+    process_ = pi.hProcess;
+    thread_ = pi.hThread;
+    running_ = true;
+    return true;
+#else
+    pid_ = ::fork();
+    if (pid_ < 0) {
+        error = "fork failed while starting gpufl-agent";
+        return false;
+    }
+    if (pid_ == 0) {
+        std::vector<char*> argv;
+        argv.reserve(command.size() + 1);
+        for (const auto& s : command) {
+            argv.push_back(const_cast<char*>(s.c_str()));
+        }
+        argv.push_back(nullptr);
+        ::execvp(command.front().c_str(), argv.data());
+        std::fprintf(stderr, "gpufl: cannot exec %s\n", command.front().c_str());
+        std::_Exit(127);
+    }
+    running_ = true;
+    return true;
+#endif
+}
+
+void AgentProcess::stop() {
+    if (!running_) return;
+#ifdef _WIN32
+    auto process = static_cast<HANDLE>(process_);
+    auto thread = static_cast<HANDLE>(thread_);
+    TerminateProcess(process, 0);
+    WaitForSingleObject(process, 5000);
+    CloseHandle(thread);
+    CloseHandle(process);
+    process_ = nullptr;
+    thread_ = nullptr;
+#else
+    ::kill(pid_, SIGTERM);
+    int status = 0;
+    for (int i = 0; i < 50; ++i) {
+        const pid_t rc = ::waitpid(pid_, &status, WNOHANG);
+        if (rc == pid_) {
+            running_ = false;
+            return;
+        }
+        usleep(100000);
+    }
+    ::kill(pid_, SIGKILL);
+    ::waitpid(pid_, &status, 0);
+    pid_ = -1;
+#endif
+    running_ = false;
+}
+
+std::string envOrEmpty(const char* name) {
+    if (const char* v = std::getenv(name); v && *v) return v;
+    return {};
+}
+
+std::string resolveOption(const std::string& flag, const char* env_name) {
+    if (!flag.empty()) return flag;
+    return envOrEmpty(env_name);
+}
+
+bool configureAgentEnvironment(const AgentOptions& opts, std::string& error) {
+    if (opts.source_folders.empty()) {
+        error = "agent source folder is empty";
+        return false;
+    }
+    if (opts.log_types.empty()) {
+        error = "agent log types are empty";
+        return false;
+    }
+    if (opts.cursor_file.empty()) {
+        error = "agent cursor file is empty";
+        return false;
+    }
+    if (opts.backend_url.empty()) {
+        error = "--backend-url required (or set GPUFL_BACKEND_URL)";
+        return false;
+    }
+    if (opts.api_key.empty()) {
+        error = "--api-key required (or set GPUFL_API_KEY)";
+        return false;
+    }
+    if (!setEnv("GPUFL_SOURCE_FOLDER", opts.source_folders) ||
+        !setEnv("GPUFL_SOURCE_FOLDERS", opts.source_folders) ||
+        !setEnv("GPUFL_LOG_TYPES", opts.log_types) ||
+        !setEnv("GPUFL_CURSOR_FILE", opts.cursor_file) ||
+        !setEnv("GPUFL_PUBLISHER_TYPE", "http") ||
+        !setEnv("GPUFL_HTTP_HOST", opts.backend_url) ||
+        !setEnv("GPUFL_HTTP_TOKEN", opts.api_key) ||
+        !setEnv("GPUFL_HTTP_API_VERSION", opts.api_version) ||
+        !setEnv("GPUFL_AGENT_UPLOAD_MODE", "stream")) {
+        error = "failed to configure agent environment";
+        return false;
+    }
+    return true;
+}
+
+bool buildAgentLaunchPlan(const AgentOptions& opts, AgentLaunchPlan& plan,
+                          std::string& error) {
+    const std::string agent_jar = resolveOption(opts.agent_jar, kAgentJarEnv);
+    if (!agent_jar.empty()) {
+        std::error_code ec;
+        if (!fs::exists(agent_jar, ec)) {
+            error = "agent jar not found: " + agent_jar;
+            return false;
+        }
+        const fs::path java = findExecutableOnPath("java");
+        if (java.empty()) {
+            error = "java not found on PATH; install Java or put gpufl-agent on PATH";
+            return false;
+        }
+        plan.command = {java.string(), "-jar", agent_jar};
+        plan.description = "java -jar " + agent_jar;
+        return true;
+    }
+
+    const fs::path agent = findExecutableOnPath("gpufl-agent");
+    if (agent.empty()) {
+        error = "gpufl-agent not found. Install gpufl-agent on PATH or pass "
+                "--agent-jar <path> / GPUFL_AGENT_JAR.";
+        return false;
+    }
+    plan.command = {agent.string()};
+    plan.description = agent.string();
+    return true;
+}
+
+}  // namespace gpufl::launcher

--- a/daemon/launcher/agent_launcher.hpp
+++ b/daemon/launcher/agent_launcher.hpp
@@ -1,0 +1,51 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+namespace gpufl::launcher {
+
+struct AgentOptions {
+    std::string source_folders;
+    std::string log_types;
+    std::string cursor_file;
+    std::string backend_url;
+    std::string api_key;
+    std::string api_version = "v1";
+    std::string agent_jar;
+};
+
+struct AgentLaunchPlan {
+    std::vector<std::string> command;
+    std::string description;
+};
+
+class AgentProcess {
+public:
+    AgentProcess() = default;
+    AgentProcess(const AgentProcess&) = delete;
+    AgentProcess& operator=(const AgentProcess&) = delete;
+    ~AgentProcess();
+
+    bool start(const std::vector<std::string>& command, std::string& error);
+    void stop();
+    bool isRunning() const { return running_; }
+
+private:
+#ifdef _WIN32
+    void* process_ = nullptr;
+    void* thread_ = nullptr;
+#else
+    int pid_ = -1;
+#endif
+    bool running_ = false;
+};
+
+std::string envOrEmpty(const char* name);
+std::string resolveOption(const std::string& flag, const char* env_name);
+
+bool configureAgentEnvironment(const AgentOptions& opts, std::string& error);
+bool buildAgentLaunchPlan(const AgentOptions& opts, AgentLaunchPlan& plan,
+                          std::string& error);
+
+}  // namespace gpufl::launcher

--- a/daemon/launcher/cli_parse.cpp
+++ b/daemon/launcher/cli_parse.cpp
@@ -20,13 +20,13 @@ FlagBreak splitFlag(const std::string& tok) {
     return {tok.substr(0, eq), tok.substr(eq + 1)};
 }
 
-// Canonical engine names accepted by --engine and by each --passes token.
+// Canonical engine names accepted by each --passes token.
 // Must match the set gpufl::init() parses for GPUFL_PROFILING_ENGINE (see
 // gpufl.cpp). The launcher only validates + forwards verbatim; init() is the
 // single string→enum parser, so this is the one launcher-side copy to keep in
 // sync with the ProfilingEngine ladder.
 constexpr const char* kEngines[] = {
-    "Monitor", "Trace", "PcSampling", "SassMetrics",
+    "Trace", "PcSampling", "SassMetrics",
     "PmSampling", "RangeProfiler", "RangeProfilerKernelReplay", "Deep"};
 bool isValidEngine(const std::string& e) {
     for (auto* k : kEngines) if (e == k) return true;
@@ -62,42 +62,47 @@ const char* topLevelHelp() {
 
 const char* traceHelp() {
     return
-        "gpufl trace — Capture telemetry from a target process\n"
+        "gpufl trace - Capture telemetry from a target process\n"
         "\n"
         "USAGE:\n"
         "    gpufl trace [OPTIONS] -- <COMMAND>...\n"
         "\n"
         "OPTIONS:\n"
-        "    -n, --name <NAME>       Session name (default: basename of <COMMAND>)\n"
-        "    -o, --output <DIR>      Local NDJSON output dir\n"
+        "    -n, --name=<NAME>       Session name (default: basename of <COMMAND>)\n"
+        "    -o, --output=<DIR>      Local NDJSON output dir\n"
         "                            (default: ~/.gpufl/traces/{ts}_{session_id}/)\n"
-        "        --profile <PROF>    comprehensive (default) | light | monitoring-only\n"
-        "        --engine <ENG>      Override profiling engine. One of:\n"
-        "                            Monitor | Trace | PcSampling | SassMetrics |\n"
-        "                            PmSampling | RangeProfiler |\n"
-        "                            RangeProfilerKernelReplay | Deep\n"
-        "                            (Deep = the default multi-pass plan: Trace,\n"
-        "                            PcSampling, SassMetrics run as isolated passes\n"
-        "                            and merged by the backend.)\n"
-        "        --passes <LIST>     Multi-pass run: comma-separated engines, one\n"
-        "                            isolated pass each, merged by the backend.\n"
-        "                            e.g. Trace,PcSampling,SassMetrics. Mutually\n"
-        "                            exclusive with --engine. (PcSampling needs\n"
-        "                            admin / GPU perf-counter access; that pass is\n"
-        "                            reported + skipped if unprivileged.)\n"
+        "        --passes=<LIST>     Capture pass list: comma-separated values from:\n"
+        "                            Trace | PcSampling | SassMetrics | PmSampling |\n"
+        "                            RangeProfiler | RangeProfilerKernelReplay | Deep\n"
+        "                            Default: Trace. Deep expands to isolated\n"
+        "                            Trace,PcSampling,SassMetrics passes and cannot\n"
+        "                            be combined with other passes. Use gpufl monitor\n"
+        "                            for monitoring-only GPU/host telemetry.\n"
+        "                            PcSampling / PM / Range passes may need NVIDIA\n"
+        "                            performance-counter access.\n"
         "    -q, --quiet             Suppress launcher chatter (errors still printed)\n"
         "    -v, --verbose           Verbose launcher logging\n"
-        "        --upload            After the run, upload the trace to the\n"
-        "                            GPUFlight backend (needs GPUFL_API_KEY +\n"
-        "                            GPUFL_BACKEND_URL in the environment)\n"
+        "        --upload            Start gpufl-agent as the live uploader\n"
+        "        --backend-url=<URL> Backend base URL for --upload\n"
+        "                            Env fallback: GPUFL_BACKEND_URL\n"
+        "        --api-key=<KEY>     Bearer token for --upload\n"
+        "                            Env fallback: GPUFL_API_KEY\n"
+        "        --api-version=<VER> Agent HTTP API version. Default: v1\n"
+        "        --agent-jar=<PATH>  Run agent as `java -jar <PATH>`\n"
+        "                            Env fallback: GPUFL_AGENT_JAR\n"
+        "        --agent-cursor=<P>  Agent cursor file. Default: <output>/cursor.json\n"
+        "        --log-types=<LIST>  Agent channels to upload. Default: device,scope,system\n"
+        "        --agent-drain-ms=<MS>\n"
+        "                            Wait after target exit before stopping agent.\n"
+        "                            Default: 3000\n"
         "    -h, --help              Print this help\n"
         "\n"
         "EXAMPLES:\n"
         "    gpufl trace -- python train.py\n"
         "    gpufl trace --name=quantize -- ./inference_server\n"
-        "    gpufl trace --profile=light -- python long_train.py\n"
-        "    gpufl trace --engine Deep -- python train.py        # multi-pass\n"
-        "    gpufl trace --passes Trace,SassMetrics -- ./app     # custom plan\n";
+        "    gpufl trace --passes=Trace,PmSampling -- python train.py\n"
+        "    gpufl trace --passes=Deep -- python train.py        # multi-pass\n"
+        "    gpufl trace --passes=Trace,SassMetrics -- ./app     # custom plan\n";
 }
 
 ParsedTopLevel parseTopLevel(int argc, char** argv) {
@@ -129,6 +134,15 @@ ParsedTopLevel parseTopLevel(int argc, char** argv) {
 TraceParseResult parseTraceArgs(const std::vector<std::string>& argv) {
     TraceArgs out;
     bool seen_dash_dash = false;
+    auto parseNonNegativeInt = [](const std::string& s, int& slot) -> bool {
+        if (s.empty()) return false;
+        char* end = nullptr;
+        long v = std::strtol(s.c_str(), &end, 10);
+        if (*end != '\0' || v < 0) return false;
+        slot = static_cast<int>(v);
+        return true;
+    };
+
     for (size_t i = 0; i < argv.size(); ++i) {
         const std::string& tok = argv[i];
         if (!seen_dash_dash && tok == "--") {
@@ -163,30 +177,27 @@ TraceParseResult parseTraceArgs(const std::vector<std::string>& argv) {
             auto err = take_value(out.output_dir);
             if (!err.empty()) return {std::nullopt, err};
         } else if (key == "--profile") {
-            auto err = take_value(out.profile);
+            std::string ignored;
+            auto err = take_value(ignored);
             if (!err.empty()) return {std::nullopt, err};
-            if (out.profile != "comprehensive" && out.profile != "light" &&
-                out.profile != "monitoring-only") {
-                return {std::nullopt,
-                        "invalid --profile value: " + out.profile +
-                        " (expected: comprehensive | light | monitoring-only)"};
-            }
+            return {std::nullopt,
+                    "`gpufl trace --profile` has been removed; use --passes=Trace, "
+                    "--passes=Deep, or `gpufl monitor` for monitoring-only telemetry"};
         } else if (key == "--engine") {
-            auto err = take_value(out.engine);
+            std::string ignored;
+            auto err = take_value(ignored);
             if (!err.empty()) return {std::nullopt, err};
-            if (!isValidEngine(out.engine)) {
-                return {std::nullopt,
-                        "invalid --engine value: " + out.engine +
-                        " (expected: Monitor | Trace | PcSampling | SassMetrics | "
-                        "PmSampling | RangeProfiler | RangeProfilerKernelReplay | Deep)"};
-            }
+            return {std::nullopt,
+                    "`gpufl trace --engine` has been removed; use --passes=Trace, "
+                    "--passes=Deep, or an explicit list like --passes=Trace,PmSampling"};
         } else if (key == "--passes") {
             std::string v;
             auto err = take_value(v);
             if (!err.empty()) return {std::nullopt, err};
-            // Comma-separated engine list → one isolated pass each. Every token
-            // must be a canonical engine name (same set as --engine).
+            // Comma-separated engine list -> one isolated pass each. Every token
+            // must be a canonical engine name.
             out.passes.clear();
+            bool saw_deep = false;
             size_t start = 0;
             while (true) {
                 const size_t comma = v.find(',', start);
@@ -197,10 +208,11 @@ TraceParseResult parseTraceArgs(const std::vector<std::string>& argv) {
                     if (!isValidEngine(item)) {
                         return {std::nullopt,
                                 "invalid --passes engine: " + item +
-                                " (expected a comma-separated list of: Monitor | "
-                                "Trace | PcSampling | SassMetrics | PmSampling | "
+                                " (expected a comma-separated list of: Trace | "
+                                "PcSampling | SassMetrics | PmSampling | "
                                 "RangeProfiler | RangeProfilerKernelReplay | Deep)"};
                     }
+                    saw_deep = saw_deep || item == "Deep";
                     out.passes.push_back(item);
                 }
                 if (comma == std::string::npos) break;
@@ -208,6 +220,41 @@ TraceParseResult parseTraceArgs(const std::vector<std::string>& argv) {
             }
             if (out.passes.empty()) {
                 return {std::nullopt, "--passes requires at least one engine"};
+            }
+            if (saw_deep && out.passes.size() != 1) {
+                return {std::nullopt,
+                        "--passes=Deep is a preset and cannot be combined with other passes"};
+            }
+        } else if (key == "--backend-url") {
+            auto err = take_value(out.backend_url);
+            if (!err.empty()) return {std::nullopt, err};
+        } else if (key == "--api-key") {
+            auto err = take_value(out.api_key);
+            if (!err.empty()) return {std::nullopt, err};
+        } else if (key == "--api-version") {
+            auto err = take_value(out.api_version);
+            if (!err.empty()) return {std::nullopt, err};
+            if (out.api_version.empty()) return {std::nullopt, "--api-version cannot be empty"};
+        } else if (key == "--agent-jar") {
+            auto err = take_value(out.agent_jar);
+            if (!err.empty()) return {std::nullopt, err};
+            if (out.agent_jar.empty()) return {std::nullopt, "--agent-jar cannot be empty"};
+        } else if (key == "--agent-cursor") {
+            auto err = take_value(out.agent_cursor);
+            if (!err.empty()) return {std::nullopt, err};
+            if (out.agent_cursor.empty()) return {std::nullopt, "--agent-cursor cannot be empty"};
+        } else if (key == "--log-types") {
+            auto err = take_value(out.log_types);
+            if (!err.empty()) return {std::nullopt, err};
+            if (out.log_types.empty()) return {std::nullopt, "--log-types cannot be empty"};
+        } else if (key == "--agent-drain-ms") {
+            std::string v;
+            auto err = take_value(v);
+            if (!err.empty()) return {std::nullopt, err};
+            if (!parseNonNegativeInt(v, out.agent_drain_ms)) {
+                return {std::nullopt,
+                        "invalid --agent-drain-ms value: " + v +
+                        " (expected a non-negative integer, milliseconds)"};
             }
         } else {
             // A non-flag token before `--` is almost certainly the
@@ -218,12 +265,6 @@ TraceParseResult parseTraceArgs(const std::vector<std::string>& argv) {
             }
             return {std::nullopt, "unknown flag: " + key};
         }
-    }
-    if (!out.passes.empty() && !out.engine.empty()) {
-        return {std::nullopt,
-                "--engine and --passes are mutually exclusive (use --passes to "
-                "list engines for a multi-pass run, or --engine for one engine "
-                "— --engine Deep expands to the default multi-pass plan)"};
     }
     if (!seen_dash_dash) {
         return {std::nullopt, "missing `--` separator before command"};
@@ -242,20 +283,20 @@ const char* uploadHelp() {
         "    gpufl upload <LOG_PATH> [OPTIONS]\n"
         "\n"
         "ARGS:\n"
-        "    <LOG_PATH>              Session log-path prefix — the same value as\n"
-        "                            `gpufl trace`'s output dir, or the InitOptions\n"
-        "                            log_path. Matches '<LOG_PATH>.device.log' plus\n"
-        "                            rotated/.gz files. A trace dir works directly:\n"
+        "    <LOG_PATH>              Output directory written by `gpufl trace`, or\n"
+        "                            the InitOptions log_path directory. Looks for\n"
+        "                            '<LOG_PATH>/<session_id>/<channel>.log[.gz]'.\n"
+        "                            A trace dir works directly:\n"
         "                            e.g. ~/.gpufl/traces/20260603-101500_ab12cd34\n"
         "\n"
         "OPTIONS:\n"
-        "        --backend-url <URL> Backend base URL.   Env: GPUFL_BACKEND_URL\n"
-        "        --api-key <KEY>     Bearer token.       Env: GPUFL_API_KEY\n"
-        "        --api-path <PATH>   Reverse-proxy mount. Defaults to /api/v1\n"
-        "        --timeout <SECS>    Total wall budget for the upload. Default 300\n"
-        "        --retries <N>       Retries per failing POST. Default 1\n"
+        "        --backend-url=<URL> Backend base URL.   Env: GPUFL_BACKEND_URL\n"
+        "        --api-key=<KEY>     Bearer token.       Env: GPUFL_API_KEY\n"
+        "        --api-path=<PATH>   Reverse-proxy mount. Defaults to /api/v1\n"
+        "        --timeout=<SECS>    Total wall budget for the upload. Default 300\n"
+        "        --retries=<N>       Retries per failing POST. Default 1\n"
         "    -q, --quiet             Suppress periodic progress lines\n"
-        "        --session-id <ID>   Upload only this session (default: latest)\n"
+        "        --session-id=<ID>   Upload only this session (default: latest)\n"
         "        --all-sessions      Upload every session in the dir (excl. --session-id)\n"
         "        --force             Re-upload even if the cursor says it shipped\n"
         "    -h, --help              Print this help\n"
@@ -264,7 +305,7 @@ const char* uploadHelp() {
         "    gpufl upload ~/.gpufl/traces/20260603-101500_ab12cd34\n"
         "    gpufl upload ./logs --all-sessions\n"
         "    GPUFL_API_KEY=gpfl_… GPUFL_BACKEND_URL=https://api.gpuflight.com \\\n"
-        "        gpufl upload ./logs --session-id <uuid>\n";
+        "        gpufl upload ./logs --session-id=<uuid>\n";
 }
 
 const char* monitorHelp() {
@@ -275,28 +316,28 @@ const char* monitorHelp() {
         "    gpufl monitor [OPTIONS]\n"
         "\n"
         "OPTIONS:\n"
-        "    -n, --name <NAME>       Monitor session name. Default: gpufl-monitor\n"
-        "    -o, --output <DIR>      Local NDJSON output dir\n"
+        "    -n, --name=<NAME>       Monitor session name. Default: gpufl-monitor\n"
+        "    -o, --output=<DIR>      Local NDJSON output dir\n"
         "                            (default: ~/.gpufl/monitor/{ts}_{session_id}/)\n"
-        "        --interval <MS>     Sampling interval in milliseconds. Default: 5000\n"
+        "        --interval=<MS>     Sampling interval in milliseconds. Default: 5000\n"
         "        --upload            Start gpufl-agent as the live uploader\n"
-        "        --backend-url <URL> Backend base URL for --upload\n"
+        "        --backend-url=<URL> Backend base URL for --upload\n"
         "                            Env fallback: GPUFL_BACKEND_URL\n"
-        "        --api-key <KEY>     Bearer token for --upload\n"
+        "        --api-key=<KEY>     Bearer token for --upload\n"
         "                            Env fallback: GPUFL_API_KEY\n"
-        "        --api-version <VER> Agent HTTP API version. Default: v1\n"
-        "        --agent-jar <PATH>  Run agent as `java -jar <PATH>`\n"
+        "        --api-version=<VER> Agent HTTP API version. Default: v1\n"
+        "        --agent-jar=<PATH>  Run agent as `java -jar <PATH>`\n"
         "                            Env fallback: GPUFL_AGENT_JAR\n"
-        "        --agent-cursor <P>  Agent cursor file. Default: <output>/cursor.json\n"
-        "        --log-types <LIST>  Agent channels to upload. Default: system\n"
+        "        --agent-cursor=<P>  Agent cursor file. Default: <output>/cursor.json\n"
+        "        --log-types=<LIST>  Agent channels to upload. Default: system\n"
         "    -q, --quiet             Suppress launcher chatter\n"
         "    -v, --verbose           Verbose launcher logging\n"
         "    -h, --help              Print this help\n"
         "\n"
         "EXAMPLES:\n"
         "    gpufl monitor\n"
-        "    gpufl monitor --interval 1000\n"
-        "    gpufl monitor --name llm-node-1 --upload\n";
+        "    gpufl monitor --interval=1000\n"
+        "    gpufl monitor --name=llm-node-1 --upload\n";
 }
 
 UploadParseResult parseUploadArgs(const std::vector<std::string>& argv) {
@@ -370,7 +411,7 @@ UploadParseResult parseUploadArgs(const std::vector<std::string>& argv) {
     }
 
     if (!have_log_path) {
-        return {std::nullopt, "missing <LOG_PATH> (the session's log-path prefix)"};
+        return {std::nullopt, "missing <LOG_PATH> (the trace output directory)"};
     }
     if (!out.session_id.empty() && out.all_sessions) {
         return {std::nullopt, "--session-id and --all-sessions are mutually exclusive"};
@@ -458,20 +499,11 @@ MonitorParseResult parseMonitorArgs(const std::vector<std::string>& argv) {
 }
 
 std::vector<std::string> resolvePassPlan(const TraceArgs& args) {
-    // 1. Explicit plan wins.
-    if (!args.passes.empty()) return args.passes;
-    // 2. Deep at the launcher = the multi-pass orchestrator: each engine runs
-    //    in its OWN process/pass (isolated), which dodges the SASS +
-    //    kernel-activity deadlock by construction; the backend stitches the
-    //    passes back into one kernel view. (The library / Python Deep engine
-    //    is unchanged — still the single-process PcSamplingWithSass composite;
-    //    only the launcher expands Deep here.)
-    if (args.engine == "Deep") {
+    if (args.passes.empty()) return {"Trace"};
+    if (args.passes.size() == 1 && args.passes.front() == "Deep") {
         return {"Trace", "PcSampling", "SassMetrics"};
     }
-    // 3. Single pass — the explicit engine, or "" = the profile's default
-    //    engine. This is the legacy single-pass path, unchanged.
-    return {args.engine};
+    return args.passes;
 }
 
 }  // namespace gpufl::launcher

--- a/daemon/launcher/cli_parse.hpp
+++ b/daemon/launcher/cli_parse.hpp
@@ -12,17 +12,21 @@ namespace gpufl::launcher {
 struct TraceArgs {
     std::string name;                   // --name / -n; default: basename of cmd[0]
     std::string output_dir;             // --output / -o; default: ~/.gpufl/traces/{ts}_{sid}
-    std::string profile = "comprehensive"; // --profile
-    std::string engine;                 // --engine; empty = profile default
-    // --passes: explicit multi-pass plan — a comma-separated list of engines,
-    // one isolated pass each (e.g. "Trace,PcSampling,SassMetrics"). Mutually
-    // exclusive with --engine. Empty here means "no explicit plan"; the plan is
-    // then resolved from --engine (Deep expands to the default multi-pass plan)
-    // — see resolvePassPlan().
+    // --passes: explicit capture plan: a comma-separated list of engines, one
+    // isolated pass each (e.g. "Trace,PcSampling,SassMetrics"). "--passes=Deep"
+    // is a shorthand for the default deep plan. Empty here means "no explicit
+    // plan"; the launcher runs a single Trace pass.
     std::vector<std::string> passes;
     bool verbose = false;               // -v
     bool quiet = false;                 // -q
-    bool upload = false;                // --upload: ship trace to backend post-run
+    bool upload = false;                // --upload: start gpufl-agent for live upload
+    std::string backend_url;            // --backend-url; else GPUFL_BACKEND_URL
+    std::string api_key;                // --api-key; else GPUFL_API_KEY
+    std::string api_version = "v1";     // --api-version
+    std::string agent_jar;              // --agent-jar; else GPUFL_AGENT_JAR
+    std::string agent_cursor;           // --agent-cursor; default <output>/cursor.json
+    std::string log_types = "device,scope,system"; // --log-types
+    int agent_drain_ms = 3000;          // --agent-drain-ms after target exits
     std::vector<std::string> command;   // tokens after `--`
 };
 
@@ -31,7 +35,7 @@ struct TraceArgs {
 // upload_command.cpp resolves creds from env when a flag is omitted and
 // calls gpufl::uploadLogs().
 struct UploadArgs {
-    std::string log_path;           // positional: session log-path prefix
+    std::string log_path;           // positional: trace output directory
     std::string backend_url;        // --backend-url (else env GPUFL_BACKEND_URL)
     std::string api_key;            // --api-key (else env GPUFL_API_KEY)
     std::string api_path;           // --api-path; empty resolves to /api/v1
@@ -87,17 +91,15 @@ struct TraceParseResult {
 
 TraceParseResult parseTraceArgs(const std::vector<std::string>& argv);
 
-// Resolves the ordered multi-pass plan (one isolated CUPTI engine per pass)
-// from parsed trace args. Precedence:
-//   1. explicit --passes list (verbatim);
-//   2. --engine Deep        → the default multi-pass plan
+// Resolves the ordered capture plan (one isolated CUPTI engine per pass) from
+// parsed trace args. Precedence:
+//   1. --passes=Deep        -> the default deep plan
 //                             [Trace, PcSampling, SassMetrics];
-//   3. otherwise            → a single pass = {engine} (engine may be "" =
-//                             use the profile's default engine — the legacy
-//                             single-pass behavior, unchanged).
+//   2. explicit --passes    -> the listed engines, one pass each;
+//   3. otherwise            -> a single Trace pass.
 // A returned size() > 1 is a multi-pass run (the launcher assigns one
 // analysis_id and labels each pass). This is the single source of truth for
-// the default plan, shared by the Linux and Windows launchers.
+// the default deep plan, shared by the Linux and Windows launchers.
 std::vector<std::string> resolvePassPlan(const TraceArgs& args);
 
 // Parses the args passed to `gpufl upload`. On success returns the

--- a/daemon/launcher/monitor_command.cpp
+++ b/daemon/launcher/monitor_command.cpp
@@ -9,22 +9,8 @@
 #include <random>
 #include <sstream>
 #include <string>
-#include <vector>
 
-#ifdef _WIN32
-#ifndef WIN32_LEAN_AND_MEAN
-#define WIN32_LEAN_AND_MEAN
-#endif
-#ifndef NOMINMAX
-#define NOMINMAX
-#endif
-#include <windows.h>
-#else
-#include <signal.h>
-#include <sys/wait.h>
-#include <unistd.h>
-#endif
-
+#include "agent_launcher.hpp"
 #include "gpufl/core/env_vars.hpp"
 #include "monitor_runner.hpp"
 
@@ -32,18 +18,6 @@ namespace fs = std::filesystem;
 
 namespace gpufl::launcher {
 namespace {
-
-constexpr const char* kAgentJarEnv = "GPUFL_AGENT_JAR";
-
-std::string envOrEmpty(const char* name) {
-    if (const char* v = std::getenv(name); v && *v) return v;
-    return {};
-}
-
-std::string resolve(const std::string& flag, const char* env_name) {
-    if (!flag.empty()) return flag;
-    return envOrEmpty(env_name);
-}
 
 std::string makeSessionId() {
     static std::mt19937_64 rng{
@@ -93,207 +67,6 @@ fs::path defaultOutputDir() {
            (makeTimestamp() + "_" + makeSessionId());
 }
 
-std::vector<std::string> splitPathEnv() {
-    std::vector<std::string> out;
-    const char* raw = std::getenv("PATH");
-    if (!raw) return out;
-    std::string path(raw);
-#ifdef _WIN32
-    constexpr char delim = ';';
-#else
-    constexpr char delim = ':';
-#endif
-    size_t start = 0;
-    while (start <= path.size()) {
-        const size_t pos = path.find(delim, start);
-        std::string item = path.substr(
-            start, pos == std::string::npos ? std::string::npos : pos - start);
-        if (!item.empty()) out.push_back(std::move(item));
-        if (pos == std::string::npos) break;
-        start = pos + 1;
-    }
-    return out;
-}
-
-fs::path findExecutableOnPath(const std::string& name) {
-    const std::vector<std::string> dirs = splitPathEnv();
-#ifdef _WIN32
-    const std::vector<std::string> suffixes = {".exe"};
-#else
-    const std::vector<std::string> suffixes = {""};
-#endif
-    for (const auto& dir : dirs) {
-        for (const auto& suffix : suffixes) {
-            fs::path candidate = fs::path(dir) / (name + suffix);
-            std::error_code ec;
-            if (fs::exists(candidate, ec) && !fs::is_directory(candidate, ec)) {
-                return fs::weakly_canonical(candidate, ec);
-            }
-        }
-    }
-    return {};
-}
-
-bool setEnv(const char* name, const std::string& value) {
-#ifdef _WIN32
-    return SetEnvironmentVariableA(name, value.c_str()) != 0;
-#else
-    return ::setenv(name, value.c_str(), 1) == 0;
-#endif
-}
-
-void appendQuotedArg(const std::string& arg, std::string& cmd) {
-    if (!arg.empty() && arg.find_first_of(" \t\n\v\"") == std::string::npos) {
-        cmd += arg;
-        return;
-    }
-    cmd += '"';
-    for (auto it = arg.begin();; ++it) {
-        unsigned backslashes = 0;
-        while (it != arg.end() && *it == '\\') { ++it; ++backslashes; }
-        if (it == arg.end()) {
-            cmd.append(backslashes * 2, '\\');
-            break;
-        }
-        if (*it == '"') {
-            cmd.append(backslashes * 2 + 1, '\\');
-            cmd += '"';
-        } else {
-            cmd.append(backslashes, '\\');
-            cmd += *it;
-        }
-    }
-    cmd += '"';
-}
-
-std::string buildCommandLine(const std::vector<std::string>& args) {
-    std::string cmd;
-    for (size_t i = 0; i < args.size(); ++i) {
-        if (i) cmd += ' ';
-        appendQuotedArg(args[i], cmd);
-    }
-    return cmd;
-}
-
-#ifdef _WIN32
-std::wstring widen(const std::string& s) {
-    if (s.empty()) return {};
-    const int n = MultiByteToWideChar(CP_ACP, 0, s.data(),
-                                      static_cast<int>(s.size()), nullptr, 0);
-    std::wstring w(n, L'\0');
-    MultiByteToWideChar(CP_ACP, 0, s.data(), static_cast<int>(s.size()),
-                        w.data(), n);
-    return w;
-}
-#endif
-
-struct AgentProcess {
-#ifdef _WIN32
-    PROCESS_INFORMATION pi{};
-#else
-    pid_t pid = -1;
-#endif
-    bool running = false;
-
-    bool start(const std::vector<std::string>& command, std::string& error) {
-#ifdef _WIN32
-        std::wstring cmdline = widen(buildCommandLine(command));
-        std::vector<wchar_t> cmdbuf(cmdline.begin(), cmdline.end());
-        cmdbuf.push_back(L'\0');
-
-        STARTUPINFOW si{};
-        si.cb = sizeof(si);
-        if (!CreateProcessW(nullptr, cmdbuf.data(), nullptr, nullptr, TRUE, 0,
-                            nullptr, nullptr, &si, &pi)) {
-            error = "CreateProcess failed for gpufl-agent (err=" +
-                    std::to_string(static_cast<unsigned long>(GetLastError())) + ")";
-            return false;
-        }
-        running = true;
-        return true;
-#else
-        pid = ::fork();
-        if (pid < 0) {
-            error = "fork failed while starting gpufl-agent";
-            return false;
-        }
-        if (pid == 0) {
-            std::vector<char*> argv;
-            argv.reserve(command.size() + 1);
-            for (const auto& s : command) {
-                argv.push_back(const_cast<char*>(s.c_str()));
-            }
-            argv.push_back(nullptr);
-            ::execvp(command.front().c_str(), argv.data());
-            std::fprintf(stderr, "gpufl monitor: cannot exec %s\n",
-                         command.front().c_str());
-            std::_Exit(127);
-        }
-        running = true;
-        return true;
-#endif
-    }
-
-    void stop() {
-        if (!running) return;
-#ifdef _WIN32
-        TerminateProcess(pi.hProcess, 0);
-        WaitForSingleObject(pi.hProcess, 5000);
-        CloseHandle(pi.hThread);
-        CloseHandle(pi.hProcess);
-#else
-        ::kill(pid, SIGTERM);
-        int status = 0;
-        for (int i = 0; i < 50; ++i) {
-            const pid_t rc = ::waitpid(pid, &status, WNOHANG);
-            if (rc == pid) {
-                running = false;
-                return;
-            }
-            usleep(100000);
-        }
-        ::kill(pid, SIGKILL);
-        ::waitpid(pid, &status, 0);
-#endif
-        running = false;
-    }
-};
-
-struct AgentStartPlan {
-    std::vector<std::string> command;
-    std::string description;
-};
-
-bool buildAgentStartPlan(const MonitorArgs& args, AgentStartPlan& plan,
-                         std::string& error) {
-    const std::string agent_jar = resolve(args.agent_jar, kAgentJarEnv);
-    if (!agent_jar.empty()) {
-        std::error_code ec;
-        if (!fs::exists(agent_jar, ec)) {
-            error = "agent jar not found: " + agent_jar;
-            return false;
-        }
-        const fs::path java = findExecutableOnPath("java");
-        if (java.empty()) {
-            error = "java not found on PATH; install Java or put gpufl-agent on PATH";
-            return false;
-        }
-        plan.command = {java.string(), "-jar", agent_jar};
-        plan.description = "java -jar " + agent_jar;
-        return true;
-    }
-
-    const fs::path agent = findExecutableOnPath("gpufl-agent");
-    if (agent.empty()) {
-        error = "gpufl-agent not found. Install gpufl-agent on PATH or pass "
-                "--agent-jar <path> / GPUFL_AGENT_JAR.";
-        return false;
-    }
-    plan.command = {agent.string()};
-    plan.description = agent.string();
-    return true;
-}
-
 }  // namespace
 
 int runMonitor(const MonitorArgs& args) {
@@ -311,42 +84,27 @@ int runMonitor(const MonitorArgs& args) {
 
     AgentProcess agent;
     if (args.upload) {
-        const std::string backend_url =
-            resolve(args.backend_url, gpufl::env::kBackendUrl);
-        const std::string api_key =
-            resolve(args.api_key, gpufl::env::kApiKey);
-        if (backend_url.empty()) {
-            std::fprintf(stderr,
-                "gpufl monitor --upload: --backend-url required "
-                "(or set GPUFL_BACKEND_URL)\n");
-            return 2;
-        }
-        if (api_key.empty()) {
-            std::fprintf(stderr,
-                "gpufl monitor --upload: --api-key required "
-                "(or set GPUFL_API_KEY)\n");
-            return 2;
-        }
-
         fs::path cursor = args.agent_cursor.empty()
                         ? output_dir / "cursor.json"
                         : fs::path(args.agent_cursor);
 
-        if (!setEnv("GPUFL_SOURCE_FOLDERS", output_dir.string()) ||
-            !setEnv("GPUFL_LOG_TYPES", args.log_types) ||
-            !setEnv("GPUFL_CURSOR_FILE", cursor.string()) ||
-            !setEnv("GPUFL_PUBLISHER_TYPE", "http") ||
-            !setEnv("GPUFL_HTTP_HOST", backend_url) ||
-            !setEnv("GPUFL_HTTP_TOKEN", api_key) ||
-            !setEnv("GPUFL_HTTP_API_VERSION", args.api_version) ||
-            !setEnv("GPUFL_AGENT_UPLOAD_MODE", "stream")) {
-            std::fprintf(stderr, "gpufl monitor: failed to configure agent environment\n");
+        AgentOptions agent_opts;
+        agent_opts.source_folders = output_dir.string();
+        agent_opts.log_types = args.log_types;
+        agent_opts.cursor_file = cursor.string();
+        agent_opts.backend_url = resolveOption(args.backend_url, gpufl::env::kBackendUrl);
+        agent_opts.api_key = resolveOption(args.api_key, gpufl::env::kApiKey);
+        agent_opts.api_version = args.api_version;
+        agent_opts.agent_jar = args.agent_jar;
+
+        std::string error;
+        if (!configureAgentEnvironment(agent_opts, error)) {
+            std::fprintf(stderr, "gpufl monitor --upload: %s\n", error.c_str());
             return 2;
         }
 
-        AgentStartPlan plan;
-        std::string error;
-        if (!buildAgentStartPlan(args, plan, error)) {
+        AgentLaunchPlan plan;
+        if (!buildAgentLaunchPlan(agent_opts, plan, error)) {
             std::fprintf(stderr, "gpufl monitor --upload: %s\n", error.c_str());
             return 2;
         }

--- a/daemon/launcher/trace_command.cpp
+++ b/daemon/launcher/trace_command.cpp
@@ -27,9 +27,13 @@
 #include <random>
 #include <sstream>
 #include <string>
+#include <thread>
 #include <vector>
 
+#include "agent_launcher.hpp"
 #include "gpufl/core/env_vars.hpp"
+#include "gpufl/core/logger/file_compressor.hpp"
+#include "gpufl/inject/inject_entry.hpp"
 
 namespace fs = std::filesystem;
 
@@ -133,6 +137,50 @@ void setEnvOrDie(const char* k, const std::string& v) {
     }
 }
 
+int repairUncompressedLogs(const fs::path& root) {
+    std::error_code root_ec;
+    if (root.empty() || !fs::exists(root, root_ec)) return 0;
+
+    gpufl::GzipFileCompressor compressor;
+    int repaired = 0;
+    std::error_code iter_ec;
+    for (fs::recursive_directory_iterator it(root, fs::directory_options::skip_permission_denied, iter_ec), end;
+         !iter_ec && it != end;
+         it.increment(iter_ec)) {
+        std::error_code entry_ec;
+        if (!it->is_regular_file(entry_ec)) continue;
+        const fs::path path = it->path();
+        if (path.extension() != ".log") continue;
+
+        std::error_code size_ec;
+        const auto size = fs::file_size(path, size_ec);
+        if (size_ec) continue;
+        if (size == 0) {
+            std::error_code remove_ec;
+            fs::remove(path, remove_ec);
+            continue;
+        }
+
+        const fs::path gz_path(path.string() + ".gz");
+        std::error_code exists_ec;
+        if (fs::exists(gz_path, exists_ec)) {
+            std::error_code remove_ec;
+            fs::remove(path, remove_ec);
+            continue;
+        }
+
+        if (compressor.compress(path.string())) {
+            ++repaired;
+            std::error_code remaining_ec;
+            if (fs::exists(path, remaining_ec)) {
+                std::error_code remove_ec;
+                fs::remove(path, remove_ec);
+            }
+        }
+    }
+    return repaired;
+}
+
 }  // namespace
 
 int runTrace(const TraceArgs& args) {
@@ -155,8 +203,8 @@ int runTrace(const TraceArgs& args) {
         return 3;
     }
 
-    // Resolve the multi-pass plan (explicit --passes, --engine Deep expanded,
-    // or a single pass) — the shared source of truth lives in cli_parse.
+    // Resolve the capture plan (explicit --passes, --passes=Deep expanded, or
+    // the default Trace pass) — the shared source of truth lives in cli_parse.
     const std::vector<std::string> plan = resolvePassPlan(args);
     const bool multipass = plan.size() > 1;
 
@@ -177,6 +225,8 @@ int runTrace(const TraceArgs& args) {
                      output_dir.string().c_str(), ec.message().c_str());
         return 2;
     }
+    const fs::path agent_output_dir = fs::weakly_canonical(output_dir, ec);
+    const fs::path upload_dir = ec ? output_dir : agent_output_dir;
 
     const std::string app_name = args.name.empty()
                                ? baseName(args.command.front())
@@ -198,26 +248,48 @@ int runTrace(const TraceArgs& args) {
     setEnvOrDie(gpufl::env::kInject, "1");
     setEnvOrDie(gpufl::env::kAppName, app_name);
     setEnvOrDie(gpufl::env::kLogDir, output_dir.string());
-    setEnvOrDie(gpufl::env::kInjectProfile, args.profile);
+    setEnvOrDie(gpufl::env::kInjectProfile, gpufl::inject::kProfileComprehensive);
+    setEnvOrDie(gpufl::env::kInjectUpload, "0");
 
-    // --upload: fail fast here (before we exec) if the creds the inject lib's
-    // post-run uploadLogs() will need aren't in the environment. Each pass
-    // uploads its own session; the backend groups them by analysis_id.
+    AgentProcess agent;
     if (args.upload) {
-        const char* api_key     = std::getenv(gpufl::env::kApiKey);
-        const char* backend_url = std::getenv(gpufl::env::kBackendUrl);
-        if (!api_key || !*api_key || !backend_url || !*backend_url) {
-            std::fprintf(stderr,
-                "gpufl trace --upload: GPUFL_API_KEY and GPUFL_BACKEND_URL "
-                "must both be set in the environment to upload.\n");
+        const fs::path cursor = args.agent_cursor.empty()
+                              ? upload_dir / "cursor.json"
+                              : fs::path(args.agent_cursor);
+
+        AgentOptions agent_opts;
+        agent_opts.source_folders = upload_dir.string();
+        agent_opts.log_types = args.log_types;
+        agent_opts.cursor_file = cursor.string();
+        agent_opts.backend_url = resolveOption(args.backend_url, gpufl::env::kBackendUrl);
+        agent_opts.api_key = resolveOption(args.api_key, gpufl::env::kApiKey);
+        agent_opts.api_version = args.api_version;
+        agent_opts.agent_jar = args.agent_jar;
+
+        std::string error;
+        if (!configureAgentEnvironment(agent_opts, error)) {
+            std::fprintf(stderr, "gpufl trace --upload: %s\n", error.c_str());
             return 2;
         }
-        setEnvOrDie(gpufl::env::kInjectUpload, "1");
+
+        AgentLaunchPlan plan;
+        if (!buildAgentLaunchPlan(agent_opts, plan, error)) {
+            std::fprintf(stderr, "gpufl trace --upload: %s\n", error.c_str());
+            return 2;
+        }
+        if (!args.quiet) {
+            std::fprintf(stderr, "[gpufl] starting agent: %s\n",
+                         plan.description.c_str());
+        }
+        if (!agent.start(plan.command, error)) {
+            std::fprintf(stderr, "gpufl trace --upload: %s\n", error.c_str());
+            return 3;
+        }
     }
 
     if (multipass) {
-        setEnvOrDie(gpufl::env::kAnalysisId, analysis_id);
-        setEnvOrDie(gpufl::env::kPassCount, std::to_string(plan.size()));
+        setEnvOrDie(env::kAnalysisId, analysis_id);
+        setEnvOrDie(env::kPassCount, std::to_string(plan.size()));
     }
 
     if (!args.quiet) {
@@ -233,7 +305,6 @@ int runTrace(const TraceArgs& args) {
             std::fprintf(stderr, "[gpufl] inject lib: %s\n",
                          inject_lib.string().c_str());
             std::fprintf(stderr, "[gpufl] app_name: %s\n", app_name.c_str());
-            std::fprintf(stderr, "[gpufl] profile: %s\n", args.profile.c_str());
         }
     }
 
@@ -244,11 +315,8 @@ int runTrace(const TraceArgs& args) {
     for (size_t i = 0; i < plan.size(); ++i) {
         const std::string& engine = plan[i];
 
-        // Per-pass engine. An empty engine (legacy single pass with no
-        // --engine) leaves GPUFL_PROFILING_ENGINE as the user/profile set it.
-        if (!engine.empty()) {
-            setEnvOrDie(gpufl::env::kProfilingEngine, engine);
-        }
+        // Per-pass engine. The default no-flag path resolves to Trace.
+        setEnvOrDie(gpufl::env::kProfilingEngine, engine);
         if (multipass) {
             setEnvOrDie(gpufl::env::kPassIndex, std::to_string(i));
         }
@@ -323,6 +391,20 @@ int runTrace(const TraceArgs& args) {
 
     if (!args.quiet) {
         std::fprintf(stderr, "[gpufl] inspect: %s\n", output_dir.string().c_str());
+    }
+    if (args.upload && args.agent_drain_ms > 0) {
+        if (!args.quiet) {
+            std::fprintf(stderr, "[gpufl] waiting %.2fs for agent drain\n",
+                         args.agent_drain_ms / 1000.0);
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(args.agent_drain_ms));
+    }
+    if (args.upload) {
+        agent.stop();
+    }
+    const int repaired_logs = repairUncompressedLogs(output_dir);
+    if (!args.quiet && repaired_logs > 0) {
+        std::fprintf(stderr, "[gpufl] compressed %d log file(s)\n", repaired_logs);
     }
 
     return overall_rc;

--- a/daemon/launcher/trace_command_win.cpp
+++ b/daemon/launcher/trace_command_win.cpp
@@ -33,9 +33,13 @@
 #include <random>
 #include <sstream>
 #include <string>
+#include <thread>
 #include <vector>
 
+#include "agent_launcher.hpp"
 #include "gpufl/core/env_vars.hpp"
+#include "gpufl/core/logger/file_compressor.hpp"
+#include "gpufl/inject/inject_entry.hpp"
 
 namespace fs = std::filesystem;
 
@@ -192,6 +196,50 @@ std::wstring widen(const std::string& s) {
     return w;
 }
 
+int repairUncompressedLogs(const fs::path& root) {
+    std::error_code root_ec;
+    if (root.empty() || !fs::exists(root, root_ec)) return 0;
+
+    GzipFileCompressor compressor;
+    int repaired = 0;
+    std::error_code iter_ec;
+    for (fs::recursive_directory_iterator it(root, fs::directory_options::skip_permission_denied, iter_ec), end;
+         !iter_ec && it != end;
+         it.increment(iter_ec)) {
+        std::error_code entry_ec;
+        if (!it->is_regular_file(entry_ec)) continue;
+        const fs::path path = it->path();
+        if (path.extension() != ".log") continue;
+
+        std::error_code size_ec;
+        const auto size = fs::file_size(path, size_ec);
+        if (size_ec) continue;
+        if (size == 0) {
+            std::error_code remove_ec;
+            fs::remove(path, remove_ec);
+            continue;
+        }
+
+        const fs::path gz_path(path.string() + ".gz");
+        std::error_code exists_ec;
+        if (fs::exists(gz_path, exists_ec)) {
+            std::error_code remove_ec;
+            fs::remove(path, remove_ec);
+            continue;
+        }
+
+        if (compressor.compress(path.string())) {
+            ++repaired;
+            std::error_code remaining_ec;
+            if (fs::exists(path, remaining_ec)) {
+                std::error_code remove_ec;
+                fs::remove(path, remove_ec);
+            }
+        }
+    }
+    return repaired;
+}
+
 }  // namespace
 
 int runTrace(const TraceArgs& args) {
@@ -213,8 +261,8 @@ int runTrace(const TraceArgs& args) {
         return 3;
     }
 
-    // Resolve the multi-pass plan (explicit --passes, --engine Deep expanded,
-    // or a single pass) — the shared source of truth lives in cli_parse.
+    // Resolve the capture plan (explicit --passes, --passes=Deep expanded, or
+    // the default Trace pass) — the shared source of truth lives in cli_parse.
     const std::vector<std::string> plan = resolvePassPlan(args);
     const bool multipass = plan.size() > 1;
 
@@ -235,6 +283,8 @@ int runTrace(const TraceArgs& args) {
                      output_dir.string().c_str(), ec.message().c_str());
         return 2;
     }
+    const fs::path agent_output_dir = fs::weakly_canonical(output_dir, ec);
+    const fs::path upload_dir = ec ? output_dir : agent_output_dir;
 
     const std::string app_name = args.name.empty()
                                ? baseName(args.command.front())
@@ -260,31 +310,53 @@ int runTrace(const TraceArgs& args) {
     // These (and the shared log dir) are set once and inherited by every
     // child; each pass's process writes under its OWN session-id subdir, so
     // the uploader discovers N sessions grouped by analysis_id.
-    setEnvOrDie(gpufl::env::kCudaInjection64Path, inject_lib.string());
-    setEnvOrDie(gpufl::env::kNvtxInjection64Path, inject_lib.string());
-    setEnvOrDie(gpufl::env::kInject, "1");
-    setEnvOrDie(gpufl::env::kAppName, app_name);
-    setEnvOrDie(gpufl::env::kLogDir, output_dir.string());
-    setEnvOrDie(gpufl::env::kInjectProfile, args.profile);
+    setEnvOrDie(env::kCudaInjection64Path, inject_lib.string());
+    setEnvOrDie(env::kNvtxInjection64Path, inject_lib.string());
+    setEnvOrDie(env::kInject, "1");
+    setEnvOrDie(env::kAppName, app_name);
+    setEnvOrDie(env::kLogDir, output_dir.string());
+    setEnvOrDie(env::kInjectProfile, inject::kProfileComprehensive);
+    setEnvOrDie(env::kInjectUpload, "0");
 
-    // --upload: fail fast before launch if creds the inject DLL's post-run
-    // uploadLogs() will need aren't in the environment. Each pass uploads its
-    // own session; the backend groups them by analysis_id.
+    AgentProcess agent;
     if (args.upload) {
-        const char* api_key     = std::getenv(gpufl::env::kApiKey);
-        const char* backend_url = std::getenv(gpufl::env::kBackendUrl);
-        if (!api_key || !*api_key || !backend_url || !*backend_url) {
-            std::fprintf(stderr,
-                "gpufl trace --upload: GPUFL_API_KEY and GPUFL_BACKEND_URL "
-                "must both be set in the environment to upload.\n");
+        const fs::path cursor = args.agent_cursor.empty()
+                              ? upload_dir / "cursor.json"
+                              : fs::path(args.agent_cursor);
+
+        AgentOptions agent_opts;
+        agent_opts.source_folders = upload_dir.string();
+        agent_opts.log_types = args.log_types;
+        agent_opts.cursor_file = cursor.string();
+        agent_opts.backend_url = resolveOption(args.backend_url, gpufl::env::kBackendUrl);
+        agent_opts.api_key = resolveOption(args.api_key, gpufl::env::kApiKey);
+        agent_opts.api_version = args.api_version;
+        agent_opts.agent_jar = args.agent_jar;
+
+        std::string error;
+        if (!configureAgentEnvironment(agent_opts, error)) {
+            std::fprintf(stderr, "gpufl trace --upload: %s\n", error.c_str());
             return 2;
         }
-        setEnvOrDie(gpufl::env::kInjectUpload, "1");
+
+        AgentLaunchPlan plan;
+        if (!buildAgentLaunchPlan(agent_opts, plan, error)) {
+            std::fprintf(stderr, "gpufl trace --upload: %s\n", error.c_str());
+            return 2;
+        }
+        if (!args.quiet) {
+            std::fprintf(stderr, "[gpufl] starting agent: %s\n",
+                         plan.description.c_str());
+        }
+        if (!agent.start(plan.command, error)) {
+            std::fprintf(stderr, "gpufl trace --upload: %s\n", error.c_str());
+            return 3;
+        }
     }
 
     if (multipass) {
-        setEnvOrDie(gpufl::env::kAnalysisId, analysis_id);
-        setEnvOrDie(gpufl::env::kPassCount, std::to_string(plan.size()));
+        setEnvOrDie(env::kAnalysisId, analysis_id);
+        setEnvOrDie(env::kPassCount, std::to_string(plan.size()));
     }
 
     if (!args.quiet) {
@@ -298,7 +370,6 @@ int runTrace(const TraceArgs& args) {
         if (args.verbose) {
             std::fprintf(stderr, "[gpufl] inject dll: %s\n", inject_lib.string().c_str());
             std::fprintf(stderr, "[gpufl] app_name: %s\n", app_name.c_str());
-            std::fprintf(stderr, "[gpufl] profile: %s\n", args.profile.c_str());
         }
     }
 
@@ -309,13 +380,10 @@ int runTrace(const TraceArgs& args) {
     for (size_t i = 0; i < plan.size(); ++i) {
         const std::string& engine = plan[i];
 
-        // Per-pass engine. An empty engine (legacy single pass with no
-        // --engine) leaves GPUFL_PROFILING_ENGINE as the user/profile set it.
-        if (!engine.empty()) {
-            setEnvOrDie(gpufl::env::kProfilingEngine, engine);
-        }
+        // Per-pass engine. The default no-flag path resolves to Trace.
+        setEnvOrDie(env::kProfilingEngine, engine);
         if (multipass) {
-            setEnvOrDie(gpufl::env::kPassIndex, std::to_string(i));
+            setEnvOrDie(env::kPassIndex, std::to_string(i));
         }
 
         const std::string what =
@@ -337,7 +405,7 @@ int runTrace(const TraceArgs& args) {
         // so rebuild it per pass. lpApplicationName = null so the program is
         // resolved from the command line (incl. PATH), mirroring execvp.
         std::wstring cmdline = widen(buildCommandLine(args.command));
-        std::vector<wchar_t> cmdbuf(cmdline.begin(), cmdline.end());
+        std::vector cmdbuf(cmdline.begin(), cmdline.end());
         cmdbuf.push_back(L'\0');
 
         STARTUPINFOW si{};
@@ -386,6 +454,20 @@ int runTrace(const TraceArgs& args) {
 
     if (!args.quiet) {
         std::fprintf(stderr, "[gpufl] inspect: %s\n", output_dir.string().c_str());
+    }
+    if (args.upload && args.agent_drain_ms > 0) {
+        if (!args.quiet) {
+            std::fprintf(stderr, "[gpufl] waiting %.2fs for agent drain\n",
+                         args.agent_drain_ms / 1000.0);
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(args.agent_drain_ms));
+    }
+    if (args.upload) {
+        agent.stop();
+    }
+    const int repaired_logs = repairUncompressedLogs(output_dir);
+    if (!args.quiet && repaired_logs > 0) {
+        std::fprintf(stderr, "[gpufl] compressed %d log file(s)\n", repaired_logs);
     }
 
     return overall_rc;

--- a/daemon/launcher/upload_command.cpp
+++ b/daemon/launcher/upload_command.cpp
@@ -62,11 +62,17 @@ int runUpload(const UploadArgs& args) {
     const gpufl::UploadResult r = gpufl::uploadLogs(opts);
 
     // Summary on stdout (machine-friendlier than the per-progress stderr).
-    std::printf("Uploaded %zu events (%.1f MB) across %zu file(s) in %.1fs.\n",
-                r.events_uploaded,
+    // Event counts are only known against legacy synchronous backends;
+    // async-accept backends (202 + spool id) report none at POST time,
+    // so bytes/files are the universal numbers.
+    std::printf("Uploaded %.1f MB across %zu file(s) in %.1fs.\n",
                 static_cast<double>(r.bytes_uploaded) / (1024.0 * 1024.0),
                 r.files_processed,
                 static_cast<double>(r.elapsed_ms) / 1000.0);
+    if (r.events_uploaded > 0) {
+        std::printf("Backend acknowledged %zu event(s) synchronously.\n",
+                    r.events_uploaded);
+    }
     if (r.files_skipped_by_cursor) {
         std::printf("Skipped %zu file(s) already uploaded (per cursor).\n",
                     r.files_skipped_by_cursor);

--- a/example/cuda/multi_engine_demo.cu
+++ b/example/cuda/multi_engine_demo.cu
@@ -17,7 +17,7 @@
 //
 //   Launcher / PyTorch:
 //     $env:GPUFL_ENGINE_COMBO = "Trace,PcSampling,PmSampling,RangeProfiler"
-//     gpufl.exe trace --engine Trace -- python train.py
+//     gpufl.exe trace --passes=Trace -- python train.py
 //
 // Combos to try — Trace gives REAL kernel timings; the rest enrich the same run:
 //     Trace,PcSampling             PC stall-reason sampling + real kernels

--- a/example/python/02_numba_cuda.py
+++ b/example/python/02_numba_cuda.py
@@ -24,9 +24,9 @@ def matmul_kernel(A, B, C):
 
 def run_benchmark():
     # --- 2. Initialize GPUFL ---
-    # LOG_PATH is the file prefix the FileLogSink writes to — it produces
-    # <LOG_PATH>.device.log / .scope.log / .system.log. We reuse it below
-    # to point generate_report() at the same files.
+    # LOG_PATH is the session output root. FileLogSink writes
+    # <LOG_PATH>/<session_id>/<channel>.log[.gz], and generate_report()
+    # can read the same directory later.
     LOG_PATH = "./gfl_logs"
 
     BACKEND_URL = os.environ.get("GPUFL_BACKEND_URL", "https://api.gpuflight.com")

--- a/include/gpufl/backends/nvidia/cupti_backend.cpp
+++ b/include/gpufl/backends/nvidia/cupti_backend.cpp
@@ -5,6 +5,7 @@
 
 #include <algorithm>
 #include <atomic>
+#include <chrono>
 #include <cstring>
 #include <cstdlib>
 #include <exception>
@@ -776,6 +777,7 @@ void CuptiBackend::start() {
     external_correlation_seen_.store(0, std::memory_order_relaxed);
     source_locator_seen_.store(0, std::memory_order_relaxed);
     function_record_seen_.store(0, std::memory_order_relaxed);
+    kernel_launch_callback_seen_.store(false, std::memory_order_relaxed);
     capture_capabilities_emitted_.store(false, std::memory_order_relaxed);
 
     // Reset the BufferCompleted companion maps for a clean per-session slate
@@ -835,12 +837,16 @@ void CuptiBackend::start() {
             "engine will not start.");
     }
 
-    if (WindowsInjectedProcess() && !haveCudaContext) {
+    if (WindowsInjectedProcess() && !haveCudaContext && engine_) {
         GFL_LOG_DEBUG(
-            "[CuptiBackend] Skipping CUPTI activity start during Windows "
-            "injection init because no CUDA context is current.");
+            "[CuptiBackend] No CUDA context is current during Windows "
+            "injection init; disabling context-bound profiling engine but "
+            "keeping activity trace callbacks enabled.");
         engine_.reset();
-        return;
+    } else if (WindowsInjectedProcess() && !haveCudaContext) {
+        GFL_LOG_DEBUG(
+            "[CuptiBackend] No CUDA context is current during Windows "
+            "injection init; starting activity trace without creating one.");
     }
 
     if (IsSassProfilerMode()) {
@@ -1109,6 +1115,7 @@ void CuptiBackend::start() {
     }
 
     active_.store(true);
+    StartActivityFlushThreadIfNeeded_();
     GFL_LOG_DEBUG("Backend started.");
 }
 
@@ -1500,9 +1507,55 @@ void CuptiBackend::FlushProfilingDataBeforeCudaTeardown(const char* reason) {
     engine_->flushBeforeCudaTeardown(reason);
 }
 
+void CuptiBackend::DrainProfilingData() {
+    if (!initialized_ || !active_.load(std::memory_order_relaxed)) return;
+    if (engine_) {
+        engine_->drainData();
+    }
+}
+
+void CuptiBackend::StartActivityFlushThreadIfNeeded_() {
+    // Windows injection cannot safely force-flush CUPTI activity at process
+    // exit because the CUDA driver may already be tearing the context down.
+    // Trace has no SamplingAPI/ProfilerAPI engine armed, so a small worker can
+    // periodically force the activity buffer while the workload is still running
+    // and the collector thread remains free to drain g_monitorBuffer.
+    if (!WindowsInjectedProcess() || engine_ || !collectsKernelEvents()) return;
+
+    bool expected = false;
+    if (!activity_flush_thread_running_.compare_exchange_strong(
+            expected, true, std::memory_order_acq_rel, std::memory_order_relaxed)) {
+        return;
+    }
+
+    activity_flush_thread_ = std::thread([this] {
+        while (activity_flush_thread_running_.load(std::memory_order_acquire)) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(250));
+            if (!activity_flush_thread_running_.load(std::memory_order_acquire)) {
+                break;
+            }
+            if (!active_.load(std::memory_order_relaxed)) continue;
+            if (!kernel_launch_callback_seen_.load(std::memory_order_acquire)) {
+                continue;
+            }
+            LogCuptiIfUnexpected(
+                "periodic-trace-drain", "cuptiActivityFlushAll",
+                cuptiActivityFlushAll(CUPTI_ACTIVITY_FLAG_FLUSH_FORCED));
+        }
+    });
+}
+
+void CuptiBackend::StopActivityFlushThread_() {
+    activity_flush_thread_running_.store(false, std::memory_order_release);
+    if (activity_flush_thread_.joinable()) {
+        activity_flush_thread_.join();
+    }
+}
+
 void CuptiBackend::stop() {
     if (!initialized_) return;
     active_.store(false);
+    StopActivityFlushThread_();
 
     // Stop the engine BEFORE flushing activity records.  PcSamplingEngine::stop()
     // disables the SamplingAPI session — while it's armed, cuptiActivityFlushAll

--- a/include/gpufl/backends/nvidia/cupti_backend.hpp
+++ b/include/gpufl/backends/nvidia/cupti_backend.hpp
@@ -9,6 +9,7 @@
 #include <mutex>
 #include <optional>
 #include <string>
+#include <thread>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -106,7 +107,10 @@ class CuptiBackend : public IMonitorBackend {
         return resolved_plan_.allow_sass_external_correlation;
     }
     void FlushProfilingDataBeforeCudaTeardown(const char* reason);
+    void StartActivityFlushThreadIfNeeded_();
+    void StopActivityFlushThread_();
     void NoteKernelLaunchForCleanupFlush() {
+        kernel_launch_callback_seen_.store(true, std::memory_order_release);
         last_cleanup_flush_ns_.store(0, std::memory_order_release);
     }
     void NoteMemoryActivityEmitted() {
@@ -156,9 +160,7 @@ class CuptiBackend : public IMonitorBackend {
         GFL_LOG_DEBUG("OnScopeStart");
         if (engine_) engine_->onScopeStart(name);
     }
-    void DrainProfilingData() override {
-        if (engine_) engine_->drainData();
-    }
+    void DrainProfilingData() override;
     void OnScopeStop(const char* name) override {
         GFL_LOG_DEBUG("OnScopeStop");
         if (engine_) engine_->onScopeStop(name);
@@ -268,7 +270,10 @@ class CuptiBackend : public IMonitorBackend {
     std::atomic<uint64_t> external_correlation_seen_{0};
     std::atomic<uint64_t> source_locator_seen_{0};
     std::atomic<uint64_t> function_record_seen_{0};
+    std::atomic<bool> kernel_launch_callback_seen_{false};
     std::atomic<int64_t> last_cleanup_flush_ns_{0};
+    std::atomic<bool> activity_flush_thread_running_{false};
+    std::thread activity_flush_thread_;
     // Re-entrancy guard for FlushOnContextDestroy(): cuptiActivityFlushAll
     // drives BufferCompleted on the calling thread, so this prevents a nested
     // context-destroy callback from recursing into another flush.

--- a/include/gpufl/backends/nvidia/kernel_launch_handler.cpp
+++ b/include/gpufl/backends/nvidia/kernel_launch_handler.cpp
@@ -229,11 +229,14 @@ std::vector<CUpti_ActivityKind> KernelLaunchHandler::requiredActivityKinds()
         return {};
     }
 
-    // SASS metrics on sm_86/CUDA 13.2 produce all-zero counters when only
-    // CONCURRENT_KERNEL is enabled. Main's validated coexistence path enables
-    // both serialized and concurrent kernel activity; keep that combination so
-    // kernel rows and non-zero SASS counters are collected in one run.
-    return {CUPTI_ACTIVITY_KIND_KERNEL, CUPTI_ACTIVITY_KIND_CONCURRENT_KERNEL};
+    // Trace should subscribe to exactly one kernel activity kind. Enabling both
+    // KERNEL and CONCURRENT_KERNEL can emit duplicate rows for the same CUPTI
+    // correlation id, and the duplicate rate varies with flush timing. SASS
+    // coexistence is the only path that intentionally keeps both enabled.
+    if (backend_ && backend_->IsSassProfilerMode()) {
+        return {CUPTI_ACTIVITY_KIND_KERNEL, CUPTI_ACTIVITY_KIND_CONCURRENT_KERNEL};
+    }
+    return {CUPTI_ACTIVITY_KIND_CONCURRENT_KERNEL};
 }
 
 bool KernelLaunchHandler::shouldHandle(const CUpti_CallbackDomain domain,

--- a/include/gpufl/core/env_vars.hpp
+++ b/include/gpufl/core/env_vars.hpp
@@ -45,8 +45,10 @@ constexpr const char* kInject               = "GPUFL_INJECT";
 constexpr const char* kAppName              = "GPUFL_APP_NAME";
 // Local NDJSON output directory (becomes InitOptions.log_path).
 constexpr const char* kLogDir               = "GPUFL_LOG_DIR";
-// Profile preset: "comprehensive" | "light" | "monitoring-only" (the matching
-// VALUE constants are kProfile* in inject/inject_entry.hpp).
+// Internal/legacy injection profile preset: "comprehensive" | "light" |
+// "monitoring-only" (the matching VALUE constants are kProfile* in
+// inject/inject_entry.hpp). `gpufl trace` no longer exposes --profile and pins
+// this to "comprehensive".
 constexpr const char* kInjectProfile        = "GPUFL_INJECT_PROFILE";
 // Opt-in ("1"): inject lib runs uploadLogs() right after shutdown(), shipping
 // the session NDJSON with the kApiKey / kBackendUrl / kApiPath creds.
@@ -68,8 +70,9 @@ constexpr const char* kInjectInitDelayMs     = "GPUFL_INJECT_INIT_DELAY_MS";
 
 // ── Profiling engine selection ──────────────────────────────────────────────
 // Override the resolved ProfilingEngine; gpufl::init() is the single string→enum
-// parser. Canonical values: Monitor | Trace | PcSampling | SassMetrics |
-// PmSampling | RangeProfiler | Deep.
+// parser. Canonical init values include Monitor; `gpufl trace --passes`
+// intentionally excludes Monitor and routes monitoring-only use cases to
+// `gpufl monitor`.
 constexpr const char* kProfilingEngine    = "GPUFL_PROFILING_ENGINE";
 // Compatibility-matrix testing / generalized composite: run an arbitrary set of
 // engines in ONE process — comma-separated canonical names — overriding the

--- a/include/gpufl/core/logger/logger.hpp
+++ b/include/gpufl/core/logger/logger.hpp
@@ -31,6 +31,17 @@ class ILogSink;
  */
 class Logger {
    public:
+    /**
+     * Default per-file rotation threshold. Referenced by the uploader
+     * (upload_logs.cpp) — since U1 a rotated file is the upload unit
+     * (one POST per file), so its size guards derive from this value
+     * and the backend's decompressed body cap is sized at 2× it. If
+     * this grows, grow the backend's
+     * StreamEventIngestionConstants.MAX_DECOMPRESSED_BODY_BYTES in
+     * lockstep.
+     */
+    static constexpr std::size_t kDefaultRotateBytes = 64 * 1024 * 1024;
+
     struct Options {
         std::string base_path;
         /**
@@ -47,7 +58,13 @@ class Logger {
          * the uploader detects it only to emit a migration warning.
          */
         std::string session_id;
-        std::size_t rotate_bytes = 64 * 1024 * 1024;  // 64 MiB default
+        /**
+         * Rotate a channel file once the next write would push it past
+         * this many bytes (checked BEFORE writing, so a file only ever
+         * exceeds it by at most one event line). Keep ≤ half the
+         * backend's decompressed body cap — see kDefaultRotateBytes.
+         */
+        std::size_t rotate_bytes = kDefaultRotateBytes;
         std::size_t max_files = 100;
         bool compress_rotated = true;
         bool flush_always = false;

--- a/include/gpufl/core/monitor.cpp
+++ b/include/gpufl/core/monitor.cpp
@@ -9,6 +9,7 @@
 #include <stack>
 #include <thread>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "gpufl/core/activity_record.hpp"
@@ -239,6 +240,7 @@ static void flushBatches(Logger& logger, const std::string& session_id) {
 // Stores the whole KERNEL_LAUNCH_META ActivityRecord — it already carries every
 // field the join and the synthetic-kernel path need, so no parallel struct.
 static std::unordered_map<uint64_t, ActivityRecord> g_launchMetaByCorr;
+static std::unordered_set<uint64_t> g_emittedKernelCorrIds;
 
 // ── Execution Signature (P2 multi-pass determinism guard) ──────────────────
 // Per-scope multiset of (mangled kernel name + launch dims) -> launch count,
@@ -568,6 +570,12 @@ static bool collectorProcessNext() {
                 g_adapter ? g_adapter->platformName() : "unknown";
 
             if (rec.type == TraceType::KERNEL) {
+                if (rec.corr_id != 0 &&
+                    !g_emittedKernelCorrIds.insert(rec.corr_id).second) {
+                    GFL_LOG_DEBUG("[CollectorLoop] skipping duplicate kernel corr=",
+                                  rec.corr_id);
+                    return true;
+                }
                 emitKernelRecord(rec, stack_trace, rt);
 
             } else if (rec.type == TraceType::MEMCPY) {
@@ -826,6 +834,7 @@ void Monitor::Initialize(const MonitorOptions& opts) {
     // Worker-local launch-meta join map (Step 4b-2): drop any entries a prior
     // session left behind so corr ids can't collide across init/shutdown cycles.
     g_launchMetaByCorr.clear();
+    g_emittedKernelCorrIds.clear();
     g_syncStackByCorr.clear();  // Step 4c: same cross-session hygiene for syncs.
     g_execSignatureByScope.clear();  // P2 exec-signature: drop prior session's multiset.
     g_kernelBatchId  = 0;

--- a/include/gpufl/core/monitor.hpp
+++ b/include/gpufl/core/monitor.hpp
@@ -21,9 +21,10 @@ namespace gpufl {
 /// taken on the user thread inside onScopeStop), the only remaining
 /// producers are CUPTI callbacks: kernel activity records, memcpy
 /// activity records, NVTX markers, and PC sampling drain.  These are
-/// well below the 8K ceiling in normal use.  RingBuffer::Push retains
-/// a brief spin/yield on overrun as defense in depth.
-inline constexpr size_t kMonitorBufferSize = 8192;
+/// usually fit comfortably below this ceiling even when Windows Trace drains
+/// CUPTI activity in periodic bursts. RingBuffer::Push retains a brief
+/// spin/yield on overrun as defense in depth.
+inline constexpr size_t kMonitorBufferSize = 65536;
 
 /// Global ring buffer shared between profiling engines (producers) and
 /// the monitor collector thread (consumer).  Declared here so all
@@ -117,8 +118,8 @@ inline const char* ProfilingEngineWireName(const ProfilingEngine engine) {
 inline const char* ProfilingEngineSessionKind(const ProfilingEngine engine) {
     switch (engine) {
         case ProfilingEngine::Monitor:
-        case ProfilingEngine::Trace:
             return "monitor";
+        case ProfilingEngine::Trace:
         case ProfilingEngine::PcSampling:
         case ProfilingEngine::SassMetrics:
         case ProfilingEngine::PmSampling:

--- a/include/gpufl/gpufl.hpp
+++ b/include/gpufl/gpufl.hpp
@@ -276,15 +276,15 @@ bool init(const InitOptions& opts);
 // Stop runtime, flush and close logs.
 void shutdown();
 
-// Comprehensive-profile defaults for "injection" capture mode (the
+// Comprehensive defaults for "injection" capture mode (the
 // libgpufl_inject.so launcher path). Flips most observability flags on
 // and selects the Deep engine (PcSampling + SassMetrics in one run) for
 // the richest per-instruction view.
 // Documented overhead: ~5–15% wall time on heavy CUDA workloads.
 //
-// The launcher's `--profile` flag picks between this and
-// `light_mode_default_options()`; everything else is layered on top
-// (env-var overrides + remote named config) inside gpufl::init().
+// `gpufl trace` now selects capture engines through --passes; everything else
+// is layered on top (env-var overrides + remote named config) inside
+// gpufl::init().
 inline InitOptions injection_mode_default_options() {
     InitOptions opts;
     opts.app_name                    = "gpufl-trace";

--- a/include/gpufl/inject/inject_entry.cpp
+++ b/include/gpufl/inject/inject_entry.cpp
@@ -440,11 +440,10 @@ void doInjectInit() {
         opts.app_name = v;
     }
     if (const char* v = envOrNull(gpufl::env::kLogDir)) {
-        // Init expects a file path; the launcher provides the dir,
-        // we tack on app.log so log_rotator's three NDJSON channels
-        // (app.device.log / app.scope.log / app.system.log) land in
-        // the launcher's chosen dir.
-        opts.log_path = std::string(v) + "/app.log";
+        // v1.2 log_path is a directory. The logger writes
+        // <log_path>/<session_id>/<channel>.log[.gz], so the launcher's
+        // --output dir should be used as-is.
+        opts.log_path = std::string(v);
     }
 #ifdef _WIN32
     // Windows CUDA injection can leave the process through CRT/driver teardown

--- a/include/gpufl/inject/inject_entry.hpp
+++ b/include/gpufl/inject/inject_entry.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
-// Profile-preset VALUE constants shared between the launcher binary
-// (`gpufl trace --profile`) and the injection shared library.
+// Profile-preset VALUE constants read by the injection shared library.
 //
 // NOTE: the environment-variable NAME constants that used to live here (kEnv*)
 // moved to gpufl/core/env_vars.hpp (namespace gpufl::env) so every env-var name
@@ -10,8 +9,9 @@
 
 namespace gpufl::inject {
 
-// Profile-name string values (must stay in sync with the launcher's
-// `--profile` flag parsing in cli_parse.cpp).
+// Profile-name string values. `gpufl trace --profile` is no longer exposed; the
+// launcher pins comprehensive and these remain for internal/legacy env-based
+// injection overrides.
 constexpr const char* kProfileComprehensive  = "comprehensive";
 constexpr const char* kProfileLight          = "light";
 constexpr const char* kProfileMonitoringOnly = "monitoring-only";

--- a/include/gpufl/upload/upload_logs.cpp
+++ b/include/gpufl/upload/upload_logs.cpp
@@ -1,20 +1,25 @@
-// High-level structure:
-//   1. parse log_path → (directory, file-prefix)
-//   2. discover .log / .log.gz files matching the prefix; sort by
-//      (channel, rotation_index DESC, active-file last)
-//   3. read cursor file → set of filenames already uploaded
-//   4. for each file in order:
-//        - if in cursor (and not the active file): skip
-//        - open (decompress if .gz), stream NDJSON line by line
-//        - for each line: extract `"type"`, route to POST
-//          * `shutdown` → hold in a deferred-tail buffer, POST after all files
-//          * everything else (including `job_start`, which appears first
-//            naturally because it lives in the oldest file's first line)
-//            → POST immediately
-//      after a successful pass over a non-active file: append to cursor
-//   5. POST the held `shutdown` events last so the backend's
-//      session-lifecycle bookkeeping sees a clean job_start → … → shutdown
-//      sequence in arrival order
+// High-level structure (U1: file-unit upload — one POST per rotated file):
+//   1. resolve log_path as a v1.2 session-output root, with legacy prefix fallback
+//   2. discover .log / .log.gz files; sort by
+//      (session_id, channel, rotation_index DESC, active-file last)
+//   3. read cursor file → uploaded files + completed sessions
+//   4. for each target session, for each of its files in order:
+//        - rotated file already in cursor: skip (crash-resume)
+//        - POST the file body in ONE request: .log.gz bytes go on the
+//          wire AS-IS (Content-Encoding: gzip, zero re-encode), plain
+//          .log is gzipped first
+//        - rotated file shipped → append to cursor
+//      The old 5000-line/5 MB client-side chunking is gone: the rotator
+//      already caps files (Logger::kDefaultRotateBytes = 64 MiB raw,
+//      ≈ 4–8 MB gz), the backend accept path just streams the body to
+//      spool/lake storage, and the worker ingest is line-streamed — so
+//      the file IS the natural unit, ~13× fewer round trips / GCS
+//      objects / ingestion jobs per file.
+//   5. lifecycle ordering: job_start lives in the oldest file (POSTed
+//      first) and shutdown in the active file (POSTed last), so arrival
+//      order is preserved without the old extract-and-defer pass. Note
+//      arrival ≠ ingest-completion order under the async queue — the
+//      ordering chain (upload-plan U3) is the real guarantee.
 //   6. enforce total_timeout_ms across the whole loop — abort + return
 //      success=false on overrun rather than blocking the host process
 
@@ -44,6 +49,7 @@
 #include "gpufl/core/debug_logger.hpp"
 #include "gpufl/core/host_info.hpp"
 #include "gpufl/core/json/json.hpp"
+#include "gpufl/core/logger/logger.hpp"
 #include "gpufl/core/version.hpp"
 
 namespace gpufl {
@@ -352,7 +358,7 @@ class NdjsonReader {
 // Schema v2:
 //   {
 //     "schema_version": 2,
-//     "uploaded_files":      ["app.device.1.log.gz", ...],
+//     "uploaded_files":      ["<session_id>/device.1.log.gz", ...],
 //     "completed_sessions": {
 //       "<session_id>": {"completed_at": "2026-05-26T15:30:00Z",
 //                        "events": 1234}
@@ -500,42 +506,6 @@ std::string fastExtractType(const std::string& line) {
     return line.substr(start, end - start);
 }
 
-std::string extractType(const std::string& line) {
-    std::string t = fastExtractType(line);
-    if (!t.empty()) return t;
-    // Fallback: structured parse. Slow but reliable for unusual line shapes.
-    const json::JsonValue v = json::parseJson(line);
-    if (v.is_object() && v.contains("type") && v.at("type").is_string()) {
-        return v.at("type").get_string();
-    }
-    return {};
-}
-
-/// Same idea for the `"session_id":"<uuid>"` field. Every event the
-/// client emits carries one at the top level, so a single substring
-/// search per line is both correct and ~100× faster than a full JSON
-/// parse.
-std::string fastExtractSessionId(const std::string& line) {
-    static const std::string kKey = "\"session_id\":\"";
-    const auto pos = line.find(kKey);
-    if (pos == std::string::npos) return {};
-    const auto start = pos + kKey.size();
-    const auto end = line.find('"', start);
-    if (end == std::string::npos) return {};
-    return line.substr(start, end - start);
-}
-
-std::string extractSessionId(const std::string& line) {
-    std::string s = fastExtractSessionId(line);
-    if (!s.empty()) return s;
-    const json::JsonValue v = json::parseJson(line);
-    if (v.is_object() && v.contains("session_id") &&
-        v.at("session_id").is_string()) {
-        return v.at("session_id").get_string();
-    }
-    return {};
-}
-
 /// Pull a numeric `ts_ns` out of an NDJSON line. Used only on
 /// `job_start` events to pick the "latest" session by timestamp.
 /// Returns 0 if the field is missing or unparseable — sorts to the
@@ -668,6 +638,32 @@ std::string gzipString(const std::string& input) {
     if (rc != Z_STREAM_END) return {};
     out.resize(produced);
     return out;
+}
+
+/// Slurp a file's raw bytes. Empty string on open/read failure (caller
+/// warns + skips the file). Rotated logs are ≤ ~10 MB gzipped, so whole-
+/// file buffering is fine; this is the same memory order the old chunk
+/// assembly used.
+std::string readFileBytes(const fs::path& p) {
+    const std::ifstream in(p, std::ios::binary);
+    if (!in) return {};
+    std::ostringstream oss;
+    oss << in.rdbuf();
+    if (in.bad()) return {};
+    return oss.str();
+}
+
+/// Decompressed size of a gzip stream from its ISIZE trailer (last 4
+/// bytes, little-endian, mod 2^32). Exact for our single-member files
+/// (the rotator caps them at Logger::kDefaultRotateBytes = 64 MiB, far
+/// under 4 GB). 0 = unknown/empty.
+std::size_t gzipDecompressedSizeHint(const std::string& gz) {
+    if (gz.size() < 18) return 0;   // 10-byte header + 8-byte trailer
+    const auto* p = reinterpret_cast<const unsigned char*>(gz.data()) + gz.size() - 4;
+    return static_cast<std::size_t>(p[0]) |
+           (static_cast<std::size_t>(p[1]) << 8) |
+           (static_cast<std::size_t>(p[2]) << 16) |
+           (static_cast<std::size_t>(p[3]) << 24);
 }
 
 /// Outcome of a single stream-chunk POST. Drives the retry / abort
@@ -848,12 +844,13 @@ StreamPostResult postStreamChunk(httplib::Client&         client,
         return out;
     }
     if (status == 413) {
-        // Body exceeded backend's 50 MB cap — we should never hit this
-        // because our chunk targets are well under that. Treat as
-        // client error (don't retry) so the caller logs + skips.
+        // Body exceeded the backend's decompressed cap (128 MB) — we
+        // pre-check file sizes against it, so this means the check and
+        // the server disagree. Treat as client error (don't retry) so
+        // the caller logs + skips the file.
         out.failure_reason =
-            "chunk exceeded backend body limit (HTTP 413) — client bug, "
-            "chunk size should be < 50 MB";
+            "file exceeded backend body limit (HTTP 413) — rotated log "
+            "larger than the backend's decompressed cap?";
         out.outcome = StreamPostOutcome::ClientError;
         return out;
     }
@@ -1090,11 +1087,15 @@ UploadResult uploadLogs(const UploadOptions& opts) {
             const auto& tsid = targets.front().session_id;
             auto it = cursor.completed_sessions.find(tsid);
             if (it != cursor.completed_sessions.end()) {
+                // The events count is only known when the upload ran
+                // against a legacy synchronous backend; omit it at 0.
+                const std::string events_note = it->second.events > 0
+                    ? " (" + std::to_string(it->second.events) + " events)"
+                    : "";
                 result.warnings.emplace_back(
                     "Session '" + tsid + "' was already uploaded on " +
-                    it->second.completed_at_iso8601 + " (" +
-                    std::to_string(it->second.events) +
-                    " events). Pass force=true (CLI: --force) to re-upload.");
+                    it->second.completed_at_iso8601 + events_note +
+                    ". Pass force=true (CLI: --force) to re-upload.");
                 result.elapsed_ms = elapsedMs();
                 return result;  // success stays false
             }
@@ -1123,18 +1124,27 @@ UploadResult uploadLogs(const UploadOptions& opts) {
     // caches after first call.
     const std::string envelope_hostname = getLocalHostname();
 
-    // Chunk-size limits. Targets the bulk-NDJSON sweet spot: large
-    // enough to amortize HTTPS handshake + framework overhead, small
-    // enough to (a) keep memory bounded and (b) stay well under the
-    // backend's 50 MB decompressed cap. With ~250 B average per event,
-    // 5000 lines lands at ~1.2 MB pre-gzip / ~120 KB post-gzip.
-    static constexpr std::size_t kChunkLineLimit = 5000;
-    static constexpr std::size_t kChunkByteLimit = 5 * 1024 * 1024;  // 5 MB uncompressed
+    // File-size guards. The upload unit is one rotated file; these only
+    // reject pathological inputs the backend (or its fronting infra)
+    // would refuse anyway:
+    //   - compressed: Cloud Run hard-caps a request body at 32 MiB —
+    //     leave headroom. (Infra bound — unrelated to the rotate size.)
+    //   - decompressed: derived from the rotator's threshold (the file
+    //     size IS the rotate setting): 2× covers the one-line overshoot
+    //     the rotator allows plus any future modest bump, and matches
+    //     the backend's 128 MB streaming cap
+    //     (StreamEventIngestionConstants.MAX_DECOMPRESSED_BODY_BYTES).
+    //     Pre-checking the gzip ISIZE trailer avoids shipping megabytes
+    //     just to be 413'd.
+    // Real files sit at the 64 MiB rotate default (≈ 4–8 MB gz), far
+    // under both limits.
+    static constexpr std::size_t kMaxCompressedPostBytes   = 30 * 1024 * 1024;
+    static constexpr std::size_t kMaxDecompressedFileBytes = 2 * Logger::kDefaultRotateBytes;
 
     // Progress reporting state.
     auto last_progress_time = upload_start;
     std::size_t bytes_since_last_progress = 0;
-    auto maybeLogProgress = [&](bool force) {
+    auto maybeLogProgress = [&](const bool force) {
         if (!opts.report_progress) return;
         const auto now = std::chrono::steady_clock::now();
         const auto elapsed_since = std::chrono::duration_cast<std::chrono::milliseconds>(
@@ -1161,7 +1171,7 @@ UploadResult uploadLogs(const UploadOptions& opts) {
         bytes_since_last_progress = 0;
     };
 
-    auto budgetExpired = [&]() {
+    auto budgetExpired = [&] {
         return elapsedMs() >= opts.total_timeout_ms;
     };
 
@@ -1169,102 +1179,73 @@ UploadResult uploadLogs(const UploadOptions& opts) {
     bool budget_aborted  = false;
     bool old_backend_404 = false;   // /events/stream missing → abort all sessions
 
-    // Per-chunk POST with retry. Gzips the assembled NDJSON body,
-    // sends it to /api/v1/events/stream with the session-id header,
-    // parses the per-line accept/reject response, updates counters.
+    // Per-file POST with retry. The body is the file's gzipped bytes
+    // (either the .log.gz content verbatim or a just-gzipped .log);
+    // `decompressed_bytes` drives the byte accounting and progress.
     //
-    // Returns true if the chunk was either accepted (possibly with
-    // some per-line warnings) OR refused with a recorded warning AND
-    // the upload should continue. Returns false only when the WHOLE
-    // upload must abort (auth failure, budget exhausted, or 404 from
-    // an old backend that doesn't have /stream).
+    // Returns true if the file was either accepted (possibly with
+    // per-line warnings from a legacy sync backend) OR refused with a
+    // recorded warning AND the upload should continue. Returns false
+    // only when the WHOLE upload must abort (auth failure, budget
+    // exhausted, or 404 from an old backend that doesn't have /stream).
     //
-    // `chunk_lines` is the count we sent — used to spot the case where
-    // the backend's parsed `accepted + rejected` doesn't match (e.g.,
-    // server bug or response truncation): we trust the server's
-    // accepted count and warn on the delta.
-    auto flushChunk = [&](const std::string& session_id,
-                          const std::string& ndjson_body,
-                          const std::size_t  chunk_lines) -> bool {
-        if (ndjson_body.empty() || chunk_lines == 0) return true;
+    // `session_events` accumulates the per-session accepted count —
+    // only legacy synchronous backends report one; the async-accept
+    // path (202 + spool_id) has no per-line counts at POST time.
+    //
+    // `skipped_out` is set when the file was given up on (4xx, retries
+    // exhausted) but the upload continues — the caller must then NOT
+    // mark the session completed, so a re-run retries the hole.
+    auto postFile = [&](const std::string& session_id,
+                        const std::string& display_name,
+                        const std::string& gz_body,
+                        const std::size_t  decompressed_bytes,
+                        std::size_t&       session_events,
+                        bool&              skipped_out) -> bool {
+        skipped_out = false;
+        if (gz_body.empty()) return true;
         if (budgetExpired()) {
             budget_aborted = true;
             return false;
         }
 
-        const std::string gz_body = gzipString(ndjson_body);
-        if (gz_body.empty()) {
-            // zlib failed — surface as a warning and SKIP this chunk
-            // (return true to keep going with the next chunk). Should
-            // never happen in practice; defense for a misbuilt zlib.
-            result.warnings.push_back(
-                "gzip compression failed for chunk of " +
-                std::to_string(chunk_lines) + " line(s) — skipping chunk");
-            return true;
-        }
-
-        std::string fail_reason;
         for (int attempt = 0; attempt <= opts.max_retries; ++attempt) {
             const StreamPostResult r = postStreamChunk(
                 *client, api_path, session_id, envelope_hostname,
                 opts.api_key, ua_header, gz_body);
 
             if (r.outcome == StreamPostOutcome::Ok) {
-                // Two backend shapes, two accounting paths:
-                //
-                //   1. async_accepted (Phase 3a+): the backend spooled
-                //      our body and queued it for the SpoolWorker.
-                //      There's no per-line breakdown to consume — by
-                //      contract, the worker will ingest exactly what
-                //      we sent (per-line rejections show up in the
-                //      backend's structured log, not our response).
-                //      Trust chunk_lines as the accepted count, stash
-                //      the spool_id for operator debugging, return.
-                //
-                //   2. Legacy synchronous accept (pre-Phase 3a): the
-                //      response carries explicit accepted/rejected
-                //      counts and any per-line errors. Trust the
-                //      server's count and surface partials as
-                //      warnings.
-                //
-                // No mismatch warning in the async path — the invariant
-                // "accepted + rejected == chunk_lines" doesn't apply
-                // when the server hasn't done the dispatch yet.
+                result.bytes_uploaded     += decompressed_bytes;
+                bytes_since_last_progress += decompressed_bytes;
+                // Two backend shapes:
+                //   1. async-accept (Phase 3a+): 202 + spool_id, no
+                //      per-line counts — the worker ingests out-of-band.
+                //   2. legacy synchronous: explicit accepted/rejected
+                //      counts + per-line errors. Surface partials as
+                //      warnings, trust the server's accepted count.
                 if (r.async_accepted) {
-                    result.events_uploaded += chunk_lines;
-                    result.bytes_uploaded  += ndjson_body.size();
-                    bytes_since_last_progress += ndjson_body.size();
                     if (!r.spool_id.empty()) {
                         result.spool_ids.push_back(r.spool_id);
                     }
                     return true;
                 }
-
-                // Legacy synchronous path. The server's response is the
-                // source of truth: accepted == chunk_lines when nothing
-                // was rejected, otherwise rejected > 0 and
-                // r.line_errors carries the explanations.
                 result.events_uploaded += r.accepted;
-                result.bytes_uploaded  += ndjson_body.size();
-                bytes_since_last_progress += ndjson_body.size();
-
-                if (r.accepted + r.rejected != chunk_lines) {
+                session_events         += r.accepted;
+                if (r.rejected > 0) {
                     result.warnings.push_back(
-                        "chunk for session " + session_id + ": sent " +
-                        std::to_string(chunk_lines) + " line(s), backend reported " +
-                        std::to_string(r.accepted) + " accepted + " +
-                        std::to_string(r.rejected) + " rejected (mismatch)");
+                        display_name + ": backend rejected " +
+                        std::to_string(r.rejected) + " line(s)");
                 }
                 for (const auto& le : r.line_errors) {
                     result.warnings.push_back(
-                        "chunk line " + std::to_string(le.line) +
+                        display_name + " line " + std::to_string(le.line) +
                         " (type=" + le.type + ") rejected: " + le.reason);
                 }
                 return true;
             }
             if (r.outcome == StreamPostOutcome::OldBackend404) {
                 // Backend predates the /stream endpoint. No retry —
-                // every chunk would hit the same 404. Abort the whole
+                // every file would hit the same 404. Abort the whole
                 // upload with a migration-hint warning.
                 result.warnings.push_back(r.failure_reason);
                 old_backend_404 = true;
@@ -1272,32 +1253,33 @@ UploadResult uploadLogs(const UploadOptions& opts) {
             }
             if (r.outcome == StreamPostOutcome::AuthFailure) {
                 result.warnings.push_back(
-                    "chunk POST /events/stream failed: " + r.failure_reason +
+                    "POST /events/stream failed: " + r.failure_reason +
                     " — aborting remaining uploads");
                 auth_failed = true;
                 return false;
             }
             if (r.outcome == StreamPostOutcome::ClientError) {
-                // 4xx that isn't auth or 404. Probably 413 (we built
-                // a too-big chunk — a bug) or 400 (header missing or
-                // body malformed). Log and skip — retrying won't help.
+                // 4xx that isn't auth or 404 (e.g. 413/400). Log and
+                // skip the file — retrying won't help.
                 result.warnings.push_back(
-                    "chunk POST /events/stream failed: " + r.failure_reason +
-                    " — skipping chunk of " + std::to_string(chunk_lines) + " line(s)");
+                    "POST /events/stream failed: " + r.failure_reason +
+                    " — skipping " + display_name);
+                skipped_out = true;
                 return true;
             }
             // TransientFailure: retry on the loop's next iteration if
             // we have budget for both more retries AND wall time.
-            fail_reason = r.failure_reason;
+            std::string fail_reason = r.failure_reason;
             if (attempt < opts.max_retries && !budgetExpired()) {
                 std::this_thread::sleep_for(
                     std::chrono::milliseconds(opts.retry_delay_ms));
                 continue;
             }
             result.warnings.push_back(
-                "chunk POST /events/stream failed after " +
+                "POST /events/stream failed after " +
                 std::to_string(attempt + 1) + " attempt(s): " + fail_reason +
-                " — skipping chunk of " + std::to_string(chunk_lines) + " line(s)");
+                " — skipping " + display_name);
+            skipped_out = true;
             return true;
         }
         return true;
@@ -1314,152 +1296,112 @@ UploadResult uploadLogs(const UploadOptions& opts) {
 
     // ── Per-session upload loop ──────────────────────────────────────
     //
-    // For each target session: stream every discovered file, filter
-    // events by session_id, build up an NDJSON chunk in memory,
-    // flush when the chunk hits the line- or byte-cap. shutdown events
-    // are deferred to a separate final chunk so the backend sees a
-    // clean job_start → batches → shutdown arrival order per session.
+    // For each target session: POST each of its files whole, in the
+    // discovery order (oldest rotation first, active file last). A
+    // file lives in its session's subdirectory, so a file maps to
+    // exactly one session — no per-line filtering needed; the backend
+    // validates every line's session_id against the header anyway.
     //
-    // Chunks DON'T align with file boundaries — a session whose data
-    // spans multiple rotated files just flushes when full, regardless
-    // of which file the next line came from. That keeps wire-efficiency
-    // tied to the chunk-size cap, not to the rotator's per-file size.
+    // Lifecycle ordering rides on the file order: job_start is the
+    // first line of the oldest file (POSTed first) and shutdown the
+    // last line of the active file (POSTed last). Arrival order is
+    // thus preserved; ingest-COMPLETION order under the async queue is
+    // the upload-plan U3 ordering chain's job, same as before.
     for (const auto& target : targets) {
         if (auth_failed || budget_aborted || old_backend_404) break;
         const std::string& current_sid = target.session_id;
 
-        // Chunk accumulator for this session. NDJSON: one event per
-        // line, '\n' separator, trailing newline on every line so the
-        // backend's BufferedReader splits cleanly.
-        std::string chunk_buf;
-        chunk_buf.reserve(kChunkByteLimit + 64 * 1024);  // headroom for the final line that pushed us over
-        std::size_t chunk_lines = 0;
-
-        // shutdown events deferred to the end of this session's
-        // chunks — preserves per-session lifecycle ordering on the
-        // backend regardless of which file they actually lived in.
-        std::vector<std::string> deferred_shutdowns;
-
-        std::size_t events_from_session = 0;
+        std::size_t events_from_session = 0;   // known only on legacy sync backends
         bool session_ok = true;
+        bool session_had_skips = false;
+        bool posted_anything = false;
 
         GFL_LOG_DEBUG("[uploadLogs] session ", current_sid, " starting");
-
-        // Helper closure: flush the current chunk and reset. Returns
-        // false to break out when the upload must abort.
-        auto flushSessionChunk = [&]() -> bool {
-            if (chunk_lines == 0) return true;
-            const std::size_t batch_lines = chunk_lines;
-            if (!flushChunk(current_sid, chunk_buf, batch_lines)) {
-                session_ok = false;
-                return false;
-            }
-            events_from_session += batch_lines;
-            chunk_buf.clear();
-            chunk_lines = 0;
-            maybeLogProgress(/*force=*/false);
-            return true;
-        };
 
         for (auto& f : files) {
             if (auth_failed || budget_aborted || old_backend_404) {
                 session_ok = false;
                 break;
             }
-            // v1.2: files are discovered with `session_id` set from
-            // their parent subdir name. Skip files belonging to a
-            // different session before opening — saves the gunzip /
-            // line-by-line scan cost for sessions we're not uploading
-            // in this pass (especially valuable in all_sessions mode
-            // where we visit each file once per matching session).
             if (f.session_id != current_sid) continue;
 
-            const std::string basename = f.path.filename().string();
+            const std::string basename   = f.path.filename().string();
+            const std::string cursor_key = current_sid + "/" + basename;
 
-            NdjsonReader reader(f.path, f.compressed);
-            if (!reader.ok()) {
-                result.warnings.push_back("Could not open " + basename + " — skipping");
+            // Rotated files are immutable once written — skip the ones
+            // a previous run already shipped (crash-resume). The active
+            // file (rotation 0) is never cursor-skipped; completed
+            // sessions were already filtered out above.
+            if (!opts.force && f.rotation_index >= 1 &&
+                cursor.uploaded_files.count(cursor_key) > 0) {
+                result.files_skipped_by_cursor++;
                 continue;
             }
+
+            std::string body = readFileBytes(f.path);
+            if (body.empty()) {
+                result.warnings.push_back("Could not read " + basename + " — skipping");
+                session_had_skips = true;
+                continue;
+            }
+
+            // .log.gz goes on the wire AS-IS; a plain .log (rare — the
+            // discovery pass gzips orphans in place) is gzipped here.
+            std::size_t decompressed_bytes;
+            if (f.compressed) {
+                decompressed_bytes = gzipDecompressedSizeHint(body);
+            } else {
+                decompressed_bytes = body.size();
+                body = gzipString(body);
+                if (body.empty()) {
+                    result.warnings.push_back(
+                        "gzip compression failed for " + basename + " — skipping");
+                    session_had_skips = true;
+                    continue;
+                }
+            }
+            if (decompressed_bytes == 0) continue;   // empty file — nothing to send
+            if (body.size() > kMaxCompressedPostBytes ||
+                decompressed_bytes > kMaxDecompressedFileBytes) {
+                result.warnings.push_back(
+                    basename + " is larger than the per-request limit (" +
+                    std::to_string(body.size()) + " B compressed / " +
+                    std::to_string(decompressed_bytes) + " B raw) — skipping");
+                session_had_skips = true;
+                continue;
+            }
+
+            bool skipped = false;
+            if (!postFile(current_sid, basename, body, decompressed_bytes,
+                          events_from_session, skipped)) {
+                session_ok = false;
+                break;
+            }
+            if (skipped) {
+                session_had_skips = true;
+                continue;
+            }
+            posted_anything = true;
             files_visited.insert(basename);
 
-            std::string line;
-            while (reader.readLine(line)) {
-                if (line.empty()) continue;
-
-                // Cheap session filter. Three cases:
-                //   1. session_id field missing entirely → the line is
-                //      malformed (every gpufl event carries session_id).
-                //      Warn + skip; don't silently lose visibility into
-                //      bad data.
-                //   2. session_id present but doesn't match this target →
-                //      another session's event. Silently skip — that's
-                //      the whole point of the filter.
-                //   3. session_id matches → process below.
-                const std::string line_sid = fastExtractSessionId(line);
-                if (line_sid.empty()) {
-                    result.warnings.push_back(
-                        "Unparseable NDJSON line in " + basename +
-                        " (no session_id field) — skipping");
-                    continue;
-                }
-                if (line_sid != current_sid) continue;
-
-                const std::string type = extractType(line);
-                if (type.empty()) {
-                    result.warnings.push_back(
-                        "Unparseable NDJSON line in " + basename +
-                        " (no type field) — skipping");
-                    continue;
-                }
-                if (type == "shutdown") {
-                    // Hold for the per-session final chunk so the
-                    // backend's lifecycle bookkeeping sees shutdown
-                    // arrive after every batch event.
-                    deferred_shutdowns.push_back(line);
-                    continue;
-                }
-
-                chunk_buf.append(line);
-                chunk_buf.push_back('\n');
-                chunk_lines++;
-
-                // Flush when either cap hits. Checking AFTER append so
-                // we never exceed the byte cap by more than one line.
-                if (chunk_lines >= kChunkLineLimit ||
-                    chunk_buf.size() >= kChunkByteLimit) {
-                    if (!flushSessionChunk()) break;
+            // Persist per-file progress for rotated files so a crash
+            // mid-session resumes after the last shipped file instead
+            // of starting over.
+            if (f.rotation_index >= 1) {
+                cursor.uploaded_files.insert(cursor_key);
+                if (!writeCursor(parts.directory, opts.cursor_filename, cursor)) {
+                    result.warnings.emplace_back(
+                        "Could not write cursor file " + opts.cursor_filename);
                 }
             }
-            if (!session_ok) break;
+            maybeLogProgress(/*force=*/false);
         }
 
-        // Remaining lines (under the cap) become the second-to-last
-        // chunk of this session. Then the deferred shutdowns ride in
-        // the very last chunk on their own — keeps them strictly after
-        // every batch.
-        if (session_ok && chunk_lines > 0) {
-            flushSessionChunk();
-        }
-        if (session_ok && !deferred_shutdowns.empty()) {
-            std::string sd_chunk;
-            sd_chunk.reserve(64 * 1024);
-            for (const auto& l : deferred_shutdowns) {
-                sd_chunk.append(l);
-                sd_chunk.push_back('\n');
-            }
-            const std::size_t sd_lines = deferred_shutdowns.size();
-            if (!flushChunk(current_sid, sd_chunk, sd_lines)) {
-                session_ok = false;
-            } else {
-                events_from_session += sd_lines;
-            }
-        }
-
-        // Mark this session as completed in the cursor if it shipped
-        // cleanly. We persist after each session — a mid-run crash
-        // still lets re-runs skip the sessions that did complete.
-        if (session_ok && events_from_session > 0) {
+        // Mark this session as completed in the cursor only when every
+        // file shipped (a skipped file is a hole — leave the session
+        // incomplete so a re-run retries it). Persisted after each
+        // session so a mid-run crash keeps the finished ones skipped.
+        if (session_ok && posted_anything && !session_had_skips) {
             CompletedSession cs;
             cs.completed_at_iso8601 = nowIso8601Utc();
             cs.events = events_from_session;
@@ -1468,8 +1410,7 @@ UploadResult uploadLogs(const UploadOptions& opts) {
                 result.warnings.emplace_back(
                     "Could not write cursor file " + opts.cursor_filename);
             }
-            GFL_LOG_DEBUG("[uploadLogs] session ", current_sid,
-                          " complete (", events_from_session, " events)");
+            GFL_LOG_DEBUG("[uploadLogs] session ", current_sid, " complete");
         }
     }
 

--- a/include/gpufl/upload/upload_logs.hpp
+++ b/include/gpufl/upload/upload_logs.hpp
@@ -29,19 +29,18 @@ namespace gpufl {
  */
 struct UploadOptions {
     /**
-     * Same shape as `InitOptions::log_path`. Both the directory AND
-     * filename-prefix of the session's NDJSON output. For example,
-     * passing "/tmp/runs/pytorch_demo" causes uploadLogs to look for
+     * Same shape as `InitOptions::log_path`: the session output root.
+     * For example, passing "/tmp/runs/pytorch_demo" causes uploadLogs
+     * to look for
      *
-     *   /tmp/runs/pytorch_demo.device.log         (active)
-     *   /tmp/runs/pytorch_demo.scope.log
-     *   /tmp/runs/pytorch_demo.system.log
-     *   /tmp/runs/pytorch_demo.device.1.log.gz   (rotated, oldest = highest N)
-     *   /tmp/runs/pytorch_demo.scope.1.log.gz
-     *   …
+     *   /tmp/runs/pytorch_demo/<session_id>/device.log[.gz]
+     *   /tmp/runs/pytorch_demo/<session_id>/scope.log[.gz]
+     *   /tmp/runs/pytorch_demo/<session_id>/system.log[.gz]
+     *   /tmp/runs/pytorch_demo/<session_id>/device.1.log.gz
+     *   ...
      *
-     * If the path ends in ".log" the suffix is stripped before glob
-     * (matches LogFileRotator::basePrefix() semantics).
+     * Legacy pre-v1.2 prefix paths are still handled by discovery when
+     * present.
      */
     std::string log_path;
 
@@ -173,10 +172,16 @@ struct UploadResult {
     /** Count of files that were skipped because the cursor said so. */
     std::size_t files_skipped_by_cursor = 0;
 
-    /** Number of NDJSON events POSTed successfully (2xx). */
+    /**
+     * Number of NDJSON events the backend acknowledged synchronously.
+     * Only legacy (pre-Phase 3a) backends report per-line counts at
+     * POST time; against an async-accept backend (202 + spool_id) this
+     * stays 0 — use {@code bytes_uploaded}/{@code files_processed} for
+     * progress reporting instead.
+     */
     std::size_t events_uploaded = 0;
 
-    /** Sum of NDJSON-line bytes successfully uploaded (uncompressed). */
+    /** Sum of NDJSON bytes successfully uploaded (uncompressed). */
     std::size_t bytes_uploaded = 0;
 
     /** Wall time of the upload in milliseconds. */
@@ -219,22 +224,22 @@ struct UploadResult {
  *   - session_id_filter set: upload only that session.
  *   - all_sessions=true: upload every session, oldest-first.
  *
- * Lifecycle ordering is enforced **per session**: for each selected
- * session, `job_start` is POSTed first, all batch events in file
- * order, then `shutdown` last — before any subsequent session begins.
- * This keeps the backend's session-lifecycle bookkeeping consistent
- * even when multiple sessions share a log directory.
- *
- * Files visited in (channel, rotation-index DESC, active) order so
- * per-channel chronological order is preserved within each session.
+ * Upload unit is one rotated file (U1): each `.log.gz` is POSTed in a
+ * single request with its bytes as-is (no decompress/re-chunk pass).
+ * Files go in (channel, rotation-index DESC, active-last) order, so
+ * `job_start` (first line of the oldest file) is POSTed first and
+ * `shutdown` (last line of the active file) last — arrival order per
+ * session is preserved before any subsequent session begins.
  *
  * Cursor file:
  *   - Tracks rotated `.log.gz` files that have shipped (skip on
- *     re-run); active `.log` files are always re-streamed.
+ *     re-run); the active file is always re-sent.
  *   - Tracks `session_id`s that have completed a successful upload.
  *     Default and session_id_filter modes refuse to re-upload a
  *     completed session unless `force=true`. all_sessions mode
  *     silently skips completed sessions unless `force=true`.
+ *     A session with any skipped/failed file is NOT marked completed,
+ *     so a re-run retries it.
  *
  * Local NDJSON files are NEVER deleted by this call.
  */

--- a/python/gpufl/_targeting.py
+++ b/python/gpufl/_targeting.py
@@ -10,7 +10,7 @@ You name the engines in ONE place — the launcher — which spawns one process
 per engine and auto-assigns the ``analysis_id`` + ``pass_index`` +
 ``pass_count`` + engine (via the ``GPUFL_*`` env vars the C++ core reads)::
 
-    gpufl trace --passes Trace,RangeProfiler,PcSampling -- python train.py
+    gpufl trace --passes=Trace,RangeProfiler,PcSampling -- python train.py
 
 Your script stays **engine-agnostic** — ``targeting()`` inherits its assigned
 engine and analysis-group labels from the environment; you only describe the
@@ -114,7 +114,7 @@ def targeting(scope, *, iters=20, warmup=3, tag="",
 
     Context manager. Composes :func:`gpufl.session` (init + shutdown + optional
     upload) with a bounded per-step scope window. **Normally run under the
-    launcher** — ``gpufl trace --passes Trace,RangeProfiler,PcSampling --
+    launcher** — ``gpufl trace --passes=Trace,RangeProfiler,PcSampling --
     python train.py`` — which assigns the engine and the analysis-group labels
     per pass; then this call only describes the WINDOW. See the module
     docstring for the full recipe.

--- a/python/gpufl/cli.py
+++ b/python/gpufl/cli.py
@@ -111,11 +111,10 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     up.add_argument(
         "log_path",
-        help=("Path prefix for the session's logs — same as the "
-              "InitOptions.log_path used when the session ran. Both the "
-              "directory and filename-prefix; e.g. "
-              "'/tmp/runs/pytorch_demo' matches "
-              "'/tmp/runs/pytorch_demo.device.log' plus rotated files."),
+        help=("Output directory for the session's logs; same as the "
+              "InitOptions.log_path used when the session ran. For example, "
+              "'/tmp/runs/pytorch_demo' contains "
+              "'<session_id>/<channel>.log[.gz]' files."),
     )
     up.add_argument(
         "--backend-url", default=None,

--- a/tests/core/test_wire_contract.cpp
+++ b/tests/core/test_wire_contract.cpp
@@ -25,6 +25,7 @@
 #include <string>
 
 #include "gpufl/core/events.hpp"
+#include "gpufl/core/monitor.hpp"
 #include "gpufl/core/version.hpp"
 #include "gpufl/core/model/batch_models.hpp"
 #include "gpufl/core/model/lifecycle_model.hpp"
@@ -53,6 +54,15 @@ namespace {
 // the build.
 TEST(WireContract, WireVersionIsPinned) {
     EXPECT_STREQ(gpufl::kWireVersion, "1");
+}
+
+TEST(WireContract, TraceEngineIsTraceSessionKind) {
+    EXPECT_STREQ(
+        gpufl::ProfilingEngineSessionKind(gpufl::ProfilingEngine::Monitor),
+        "monitor");
+    EXPECT_STREQ(
+        gpufl::ProfilingEngineSessionKind(gpufl::ProfilingEngine::Trace),
+        "trace");
 }
 
 // ── job_start ─────────────────────────────────────────────────────────────

--- a/tests/launcher/test_cli_parse.cpp
+++ b/tests/launcher/test_cli_parse.cpp
@@ -25,7 +25,6 @@ TEST(CliParseTrace, BasicCommand) {
     EXPECT_EQ(r.args->command.size(), 2u);
     EXPECT_EQ(r.args->command[0], "python");
     EXPECT_EQ(r.args->command[1], "train.py");
-    EXPECT_EQ(r.args->profile, "comprehensive");
     EXPECT_FALSE(r.args->verbose);
     EXPECT_FALSE(r.args->quiet);
 }
@@ -67,28 +66,25 @@ TEST(CliParseTrace, VerboseAndQuiet) {
     EXPECT_TRUE(r.args->quiet);
 }
 
-TEST(CliParseTrace, ProfileValid) {
+TEST(CliParseTrace, ProfileFlagRejectedWithMigrationHint) {
     auto r = parseTraceArgs(argsFor({"--profile=light", "--", "./bin"}));
-    ASSERT_TRUE(r.args.has_value()) << r.error;
-    EXPECT_EQ(r.args->profile, "light");
-}
-
-TEST(CliParseTrace, ProfileMonitoringOnly) {
-    auto r = parseTraceArgs(argsFor({"--profile=monitoring-only", "--", "./bin"}));
-    ASSERT_TRUE(r.args.has_value()) << r.error;
-    EXPECT_EQ(r.args->profile, "monitoring-only");
-}
-
-TEST(CliParseTrace, ProfileInvalid) {
-    auto r = parseTraceArgs(argsFor({"--profile=galactic", "--", "./bin"}));
     EXPECT_FALSE(r.args.has_value());
-    EXPECT_NE(r.error.find("invalid --profile"), std::string::npos);
+    EXPECT_NE(r.error.find("--passes=Trace"), std::string::npos);
+}
+
+TEST(CliParseTrace, ProfileFlagSpaceFormRejectedWithMigrationHint) {
+    auto r = parseTraceArgs(argsFor({"--profile=monitoring-only", "--", "./bin"}));
+    EXPECT_FALSE(r.args.has_value());
+    EXPECT_NE(r.error.find("gpufl monitor"), std::string::npos);
 }
 
 TEST(CliParseTrace, UploadFlag) {
     auto r = parseTraceArgs(argsFor({"--upload", "--", "./bin"}));
     ASSERT_TRUE(r.args.has_value()) << r.error;
     EXPECT_TRUE(r.args->upload);
+    EXPECT_EQ(r.args->api_version, "v1");
+    EXPECT_EQ(r.args->log_types, "device,scope,system");
+    EXPECT_EQ(r.args->agent_drain_ms, 3000);
 }
 
 TEST(CliParseTrace, UploadDefaultsFalse) {
@@ -97,31 +93,44 @@ TEST(CliParseTrace, UploadDefaultsFalse) {
     EXPECT_FALSE(r.args->upload);
 }
 
-TEST(CliParseTrace, EngineValid) {
+TEST(CliParseTrace, UploadAgentFlags) {
+    auto r = parseTraceArgs(argsFor({
+        "--upload",
+        "--backend-url=https://api.example.com",
+        "--api-key", "gpfl_key",
+        "--api-version=v2",
+        "--agent-jar=/tmp/agent.jar",
+        "--agent-cursor=/tmp/trace-cursor.json",
+        "--log-types=device,scope",
+        "--agent-drain-ms=500",
+        "--", "./bin"}));
+    ASSERT_TRUE(r.args.has_value()) << r.error;
+    EXPECT_TRUE(r.args->upload);
+    EXPECT_EQ(r.args->backend_url, "https://api.example.com");
+    EXPECT_EQ(r.args->api_key, "gpfl_key");
+    EXPECT_EQ(r.args->api_version, "v2");
+    EXPECT_EQ(r.args->agent_jar, "/tmp/agent.jar");
+    EXPECT_EQ(r.args->agent_cursor, "/tmp/trace-cursor.json");
+    EXPECT_EQ(r.args->log_types, "device,scope");
+    EXPECT_EQ(r.args->agent_drain_ms, 500);
+}
+
+TEST(CliParseTrace, InvalidAgentDrainRejected) {
+    auto r = parseTraceArgs(argsFor({"--agent-drain-ms=-1", "--", "./bin"}));
+    EXPECT_FALSE(r.args.has_value());
+    EXPECT_NE(r.error.find("invalid --agent-drain-ms"), std::string::npos);
+}
+
+TEST(CliParseTrace, EngineFlagRejectedWithMigrationHint) {
     auto r = parseTraceArgs(argsFor({"--engine=Deep", "--", "./bin"}));
-    ASSERT_TRUE(r.args.has_value()) << r.error;
-    EXPECT_EQ(r.args->engine, "Deep");
+    EXPECT_FALSE(r.args.has_value());
+    EXPECT_NE(r.error.find("--passes=Deep"), std::string::npos);
 }
 
-TEST(CliParseTrace, EngineValidMonitor) {
+TEST(CliParseTrace, EngineFlagSpaceFormRejectedWithMigrationHint) {
     auto r = parseTraceArgs(argsFor({"--engine", "Monitor", "--", "./bin"}));
-    ASSERT_TRUE(r.args.has_value()) << r.error;
-    EXPECT_EQ(r.args->engine, "Monitor");
-}
-
-TEST(CliParseTrace, EngineInvalid) {
-    auto r = parseTraceArgs(argsFor({"--engine=hyperdrive", "--", "./bin"}));
     EXPECT_FALSE(r.args.has_value());
-    EXPECT_NE(r.error.find("invalid --engine"), std::string::npos);
-}
-
-TEST(CliParseTrace, EngineLegacyKebabRejected) {
-    // The pre-refactor kebab vocab ("pc-sampling", "pc-sampling-with-sass",
-    // "none") is no longer accepted; the CLI now speaks the canonical
-    // ladder names that gpufl::init() parses for GPUFL_PROFILING_ENGINE.
-    auto r = parseTraceArgs(argsFor({"--engine=pc-sampling", "--", "./bin"}));
-    EXPECT_FALSE(r.args.has_value());
-    EXPECT_NE(r.error.find("invalid --engine"), std::string::npos);
+    EXPECT_NE(r.error.find("--passes=Trace"), std::string::npos);
 }
 
 TEST(CliParseTrace, UnknownFlag) {
@@ -178,7 +187,6 @@ TEST(CliParseTrace, PassesParsedAsList) {
     EXPECT_EQ(r.args->passes[0], "Trace");
     EXPECT_EQ(r.args->passes[1], "PcSampling");
     EXPECT_EQ(r.args->passes[2], "SassMetrics");
-    EXPECT_TRUE(r.args->engine.empty());
 }
 
 TEST(CliParseTrace, PassesTrimsWhitespace) {
@@ -191,8 +199,21 @@ TEST(CliParseTrace, PassesTrimsWhitespace) {
     EXPECT_EQ(r.args->passes[1], "SassMetrics");
 }
 
+TEST(CliParseTrace, PassesDeepPresetParsed) {
+    auto r = parseTraceArgs(argsFor({"--passes=Deep", "--", "./bin"}));
+    ASSERT_TRUE(r.args.has_value()) << r.error;
+    ASSERT_EQ(r.args->passes.size(), 1u);
+    EXPECT_EQ(r.args->passes[0], "Deep");
+}
+
 TEST(CliParseTrace, PassesInvalidEngineRejected) {
     auto r = parseTraceArgs(argsFor({"--passes=Trace,warpdrive", "--", "./bin"}));
+    EXPECT_FALSE(r.args.has_value());
+    EXPECT_NE(r.error.find("invalid --passes"), std::string::npos);
+}
+
+TEST(CliParseTrace, MonitorPassRejected) {
+    auto r = parseTraceArgs(argsFor({"--passes=Monitor", "--", "./bin"}));
     EXPECT_FALSE(r.args.has_value());
     EXPECT_NE(r.error.find("invalid --passes"), std::string::npos);
 }
@@ -203,17 +224,15 @@ TEST(CliParseTrace, PassesEmptyRejected) {
     EXPECT_NE(r.error.find("--passes requires"), std::string::npos);
 }
 
-TEST(CliParseTrace, EngineAndPassesMutuallyExclusive) {
-    auto r = parseTraceArgs(
-        argsFor({"--engine=Deep", "--passes=Trace", "--", "./bin"}));
+TEST(CliParseTrace, DeepPresetCannotBeCombined) {
+    auto r = parseTraceArgs(argsFor({"--passes=Trace,Deep", "--", "./bin"}));
     EXPECT_FALSE(r.args.has_value());
-    EXPECT_NE(r.error.find("mutually exclusive"), std::string::npos);
+    EXPECT_NE(r.error.find("cannot be combined"), std::string::npos);
 }
 
 TEST(ResolvePassPlan, ExplicitPassesWin) {
     TraceArgs a;
     a.passes = {"Trace", "SassMetrics"};
-    a.engine = "";  // empty — passes take precedence regardless
     const auto plan = resolvePassPlan(a);
     ASSERT_EQ(plan.size(), 2u);
     EXPECT_EQ(plan[0], "Trace");
@@ -222,7 +241,7 @@ TEST(ResolvePassPlan, ExplicitPassesWin) {
 
 TEST(ResolvePassPlan, DeepExpandsToDefaultPlan) {
     TraceArgs a;
-    a.engine = "Deep";
+    a.passes = {"Deep"};
     const auto plan = resolvePassPlan(a);
     ASSERT_EQ(plan.size(), 3u);
     EXPECT_EQ(plan[0], "Trace");
@@ -230,21 +249,19 @@ TEST(ResolvePassPlan, DeepExpandsToDefaultPlan) {
     EXPECT_EQ(plan[2], "SassMetrics");
 }
 
-TEST(ResolvePassPlan, SingleExplicitEngineIsOnePass) {
+TEST(ResolvePassPlan, SingleExplicitPassIsOnePass) {
     TraceArgs a;
-    a.engine = "PcSampling";
+    a.passes = {"PcSampling"};
     const auto plan = resolvePassPlan(a);
     ASSERT_EQ(plan.size(), 1u);
     EXPECT_EQ(plan[0], "PcSampling");
 }
 
-TEST(ResolvePassPlan, NoEngineIsOneDefaultPass) {
-    // No --engine, no --passes → one pass with an empty engine string, i.e.
-    // "use the profile's default engine" — the legacy single-pass behavior.
+TEST(ResolvePassPlan, NoPassesIsTracePass) {
     TraceArgs a;
     const auto plan = resolvePassPlan(a);
     ASSERT_EQ(plan.size(), 1u);
-    EXPECT_TRUE(plan[0].empty());
+    EXPECT_EQ(plan[0], "Trace");
 }
 
 // ── gpufl upload ────────────────────────────────────────────────────────

--- a/tests/upload/test_upload_logs.cpp
+++ b/tests/upload/test_upload_logs.cpp
@@ -1,15 +1,15 @@
 // End-to-end tests for gpufl::uploadLogs.
 //
-// v1.2 wire format: the client POSTs gzipped NDJSON chunks to
-// /api/v1/events/stream — each chunk carries N events (one per line)
-// with X-GpuFlight-Session-Id in the header. The capture server here
+// U1 wire model: ONE gzipped NDJSON POST per rotated log file to
+// /api/v1/events/stream, X-GpuFlight-Session-Id in the header, the
+// file's bytes shipped as-is (no client-side chunking or per-line
+// filtering — the backend validates per line). The capture server here
 // listens on that single route, decompresses the body, and exposes
-// both per-chunk and per-line views so tests can assert on either
-// granularity.
+// both per-request and per-line views so tests can assert on either
+// granularity. ("Chunk" in the helper names = one captured request.)
 //
-// Earlier drafts of this file tested the per-event wire format (one
-// EventWrapper-wrapped POST per event to /api/v1/events/{type}). That
-// path was removed in v1.2 — see upload_logs.cpp.
+// Earlier revisions tested the per-event EventWrapper format (removed
+// in v1.2) and the 5000-line client-side chunking (removed in U1).
 
 #include <gtest/gtest.h>
 
@@ -292,19 +292,24 @@ std::string makeMinimalSession(const fs::path& root,
                                const std::string& sid = "s1") {
     const fs::path session_dir = root / sid;
     fs::create_directories(session_dir);
-    // Rotated (older) — device channel only, gzipped
+    // Rotated (older) — device channel only, gzipped. job_start is
+    // Channel::All in the client, so it heads every channel's oldest
+    // file; one copy is enough for the device chain here.
     writeLog(session_dir / "device.1.log.gz", {
         R"({"type":"job_start","session_id":")" + sid + R"(","app":"test","pid":1,"ts_ns":100})",
         R"({"type":"kernel_event_batch","session_id":")" + sid + R"(","batch_id":1,"rows":[[0,1,0,1000,101,0,32,1]]})",
     }, /*gzip=*/true);
-    // Active device .log — newer events
+    // Active device .log — newer events. shutdown is Channel::All in
+    // the client: every channel's active file ends with a copy.
     writeLog(session_dir / "device.log", {
         R"({"type":"kernel_event_batch","session_id":")" + sid + R"(","batch_id":2,"rows":[[2000,2,0,1500,102,0,64,1]]})",
         R"({"type":"shutdown","session_id":")" + sid + R"(","app":"test","pid":1,"ts_ns":9999})",
     });
-    // Scope channel, active only
+    // Scope channel, active only — carries its own shutdown copy, like
+    // the real logger writes.
     writeLog(session_dir / "scope.log", {
         R"({"type":"scope_event_batch","session_id":")" + sid + R"(","batch_id":1,"rows":[[0,1,1,0,0],[5000,1,1,1,0]]})",
+        R"({"type":"shutdown","session_id":")" + sid + R"(","app":"test","pid":1,"ts_ns":9999})",
     });
     return root.string();
 }
@@ -332,35 +337,36 @@ TEST(UploadLogs, UploadsAllEventsAcrossChannelsAndRotation) {
 
     EXPECT_TRUE(result.success) << "warnings: "
         << (result.warnings.empty() ? "<none>" : result.warnings.front());
-    EXPECT_EQ(result.events_uploaded, 5u)
-        << "Expected 5 NDJSON events across all chunks (job_start, "
-        << "two kernel batches, one scope batch, one shutdown).";
+    EXPECT_EQ(result.events_uploaded, 6u)
+        << "Expected 6 NDJSON events across all files (job_start, two "
+        << "kernel batches, one scope batch, two shutdown copies).";
     EXPECT_EQ(result.files_processed, 3u);  // device.1.log.gz + device.log + scope.log
     EXPECT_TRUE(result.warnings.empty()) << "Unexpected warnings on happy path";
 
-    const auto events = srv.allEvents();
-    ASSERT_EQ(events.size(), 5u);
+    // One POST per file — the U1 contract.
+    EXPECT_EQ(srv.snapshot().size(), 3u);
 
-    // job_start must arrive first (so the backend creates the session
-    // row before any event references its session_id). shutdown must
-    // arrive last (deferred to end of session's chunks).
+    const auto events = srv.allEvents();
+    ASSERT_EQ(events.size(), 6u);
+
+    // job_start must arrive first (first line of the oldest file of the
+    // first channel). The last file's last line is its shutdown copy —
+    // files go (channel asc, rotation desc, active last).
     EXPECT_EQ(events.front().first, "job_start");
     EXPECT_EQ(events.back().first,  "shutdown");
 
     fs::remove_all(tmp);
 }
 
-TEST(UploadLogs, AsyncAccept202_UsesChunkLinesAsAcceptedCount) {
+TEST(UploadLogs, AsyncAccept202_NoEventCounts_SpoolIdsRecorded) {
     // Phase 3a+ backends return HTTP 202 with
     // `{accepted_for_processing, spool_id}` and do NOT carry per-line
     // accepted/rejected counts. The client must:
     //   - treat the 202 as success (no warning),
-    //   - credit chunk_lines to events_uploaded (since the server
-    //     hasn't run per-line dispatch yet),
+    //   - leave events_uploaded at 0 (nothing was dispatched yet —
+    //     bytes/files are the progress numbers on this path),
     //   - stash spool_id into UploadResult.spool_ids so operators can
-    //     correlate with backend logs.
-    // The "accepted + rejected != chunk_lines" mismatch warning that
-    // applies to the legacy sync path MUST stay quiet on this path.
+    //     correlate with backend logs (one per file POST).
     const fs::path tmp = fs::temp_directory_path() / "gpufl_upload_test_async";
     fs::remove_all(tmp);
     const std::string log_path = makeMinimalSession(tmp);
@@ -377,18 +383,17 @@ TEST(UploadLogs, AsyncAccept202_UsesChunkLinesAsAcceptedCount) {
 
     EXPECT_TRUE(result.success) << "warnings: "
         << (result.warnings.empty() ? "<none>" : result.warnings.front());
-    EXPECT_EQ(result.events_uploaded, 5u)
-        << "Async path must use locally-tracked chunk_lines as the "
-        << "accepted count when the response has no `accepted` field.";
+    EXPECT_EQ(result.events_uploaded, 0u)
+        << "Async-accept responses carry no per-line counts — "
+        << "events_uploaded must stay 0 rather than guess.";
+    EXPECT_GT(result.bytes_uploaded, 0u);
+    EXPECT_EQ(result.files_processed, 3u);
     EXPECT_TRUE(result.warnings.empty())
-        << "Async path must not emit the legacy 'mismatch' warning: "
+        << "Async path must not emit warnings: "
         << (result.warnings.empty() ? "<none>" : result.warnings.front());
-    EXPECT_FALSE(result.spool_ids.empty())
-        << "Each 202 response should add one spool_id to UploadResult.";
-    // Every recorded spool_id must be non-empty (the server stub
-    // generates "spool-<seq>").
+    EXPECT_EQ(result.spool_ids.size(), 3u)
+        << "Each 202 response should add one spool_id (one per file).";
     for (const auto& sid : result.spool_ids) {
-        EXPECT_FALSE(sid.empty());
         EXPECT_NE(sid.find("spool-"), std::string::npos);
     }
     fs::remove_all(tmp);
@@ -466,28 +471,23 @@ TEST(UploadLogs, AuthHeaderAndVersionHeadersPresentOnEveryChunk) {
     fs::remove_all(tmp);
 }
 
-TEST(UploadLogs, EveryLineInChunkMatchesSessionIdHeader) {
-    // Backend defense-in-depth: every line's session_id MUST match
-    // the X-GpuFlight-Session-Id header. We exercise that here by
-    // verifying client-side filtering — only s1's lines end up in
-    // the chunk despite the on-disk file containing other sessions'
-    // events too (synthetically interleaved).
+TEST(UploadLogs, FileBodyShipsAsIs_SessionValidationIsServerSide) {
+    // U1 ships the file's bytes verbatim — there is no per-line
+    // client-side filtering anymore. A corrupted file containing
+    // another session's lines therefore reaches the wire as-is; the
+    // BACKEND rejects mismatched lines (it has always validated every
+    // line's session_id against the X-GpuFlight-Session-Id header).
+    // Normal operation never produces such files — the rotator writes
+    // only the active session_id into <sid>/<channel>.log.
     const fs::path tmp = fs::temp_directory_path() / "gpufl_upload_test_filter";
     fs::remove_all(tmp);
     fs::create_directories(tmp);
 
-    // Defense-in-depth test: a session's directory should contain
-    // only its own session_id's lines. We simulate a corrupted file
-    // (intentionally including s2 events in s1's dir) and verify the
-    // per-line client-side filter catches them so the wire only carries
-    // s1's lines. Normal operation never produces such files — the
-    // rotator writes only the active session_id into <sid>/<channel>.log.
     fs::create_directories(tmp / "s1");
     writeLog(tmp / "s1" / "device.log", {
         R"({"type":"job_start","session_id":"s1","ts_ns":1})",
-        R"({"type":"kernel_event_batch","session_id":"s2","rows":[]})",   // wrong session — must be skipped
+        R"({"type":"kernel_event_batch","session_id":"s2","rows":[]})",   // wrong session — server's problem
         R"({"type":"kernel_event_batch","session_id":"s1","rows":[]})",
-        R"({"type":"shutdown","session_id":"s2","ts_ns":99})",            // wrong session
         R"({"type":"shutdown","session_id":"s1","ts_ns":99})",
     });
 
@@ -503,15 +503,11 @@ TEST(UploadLogs, EveryLineInChunkMatchesSessionIdHeader) {
     ASSERT_TRUE(result.success);
 
     const auto chunks = srv.snapshot();
-    ASSERT_FALSE(chunks.empty());
-    for (const auto& c : chunks) {
-        EXPECT_EQ(c.session_id, "s1");
-        for (const auto& [type, sid] : c.events) {
-            EXPECT_EQ(sid, "s1")
-                << "Every line in the chunk must match the header's "
-                << "session_id — s2 events should never reach the wire.";
-        }
-    }
+    ASSERT_EQ(chunks.size(), 1u) << "One file → one POST.";
+    EXPECT_EQ(chunks.front().session_id, "s1");
+    EXPECT_EQ(chunks.front().lines.size(), 4u)
+        << "The body is the file verbatim — including the s2 line the "
+        << "backend will reject per-line.";
 
     fs::remove_all(tmp);
 }
@@ -662,7 +658,7 @@ TEST(UploadLogs, TransientFailureRetriesThenSucceeds) {
 
     const auto result = gpufl::uploadLogs(opts);
     EXPECT_TRUE(result.success) << "Should retry past the transient 500.";
-    EXPECT_EQ(result.events_uploaded, 5u);
+    EXPECT_EQ(result.events_uploaded, 6u);
 }
 
 TEST(UploadLogs, MissingLogDirReturnsFailureNotThrow) {
@@ -700,7 +696,11 @@ TEST(UploadLogs, EmptyLogDirIsSuccessNoOp) {
     fs::remove_all(tmp);
 }
 
-TEST(UploadLogs, MalformedNdjsonLineSkippedWithWarning) {
+TEST(UploadLogs, MalformedLinesShipAsIs_ServerJudgesPerLine) {
+    // No client-side line parsing in U1 — a malformed line ships with
+    // its file and the backend records it as a per-line rejection
+    // (skip-and-continue; it never reaches SQL). The client neither
+    // warns nor drops anything locally.
     const fs::path tmp = fs::temp_directory_path() / "gpufl_upload_test_bad_line";
     fs::remove_all(tmp);
     fs::create_directories(tmp);
@@ -708,7 +708,7 @@ TEST(UploadLogs, MalformedNdjsonLineSkippedWithWarning) {
     fs::create_directories(tmp / "s1");
     writeLog(tmp / "s1" / "device.log", {
         R"({"type":"job_start","session_id":"s1"})",
-        "this is not json at all — should be skipped with a warning",
+        "this is not json at all - the backend rejects it per-line",
         R"({"type":"kernel_event_batch","session_id":"s1","rows":[]})",
         R"({"type":"shutdown","session_id":"s1"})",
     });
@@ -722,8 +722,9 @@ TEST(UploadLogs, MalformedNdjsonLineSkippedWithWarning) {
 
     const auto result = gpufl::uploadLogs(opts);
     EXPECT_TRUE(result.success);
-    EXPECT_EQ(result.events_uploaded, 3u);
-    EXPECT_FALSE(result.warnings.empty()) << "Should warn about the bad line";
+    EXPECT_EQ(srv.snapshot().size(), 1u);
+    EXPECT_EQ(srv.allLines().size(), 4u)
+        << "All 4 lines (including the malformed one) ship verbatim.";
 
     fs::remove_all(tmp);
 }
@@ -967,24 +968,23 @@ TEST(UploadLogs, JobStartFirstShutdownLast) {
     const auto events = srv.allEvents();
     ASSERT_EQ(events.size(), 4u);
     EXPECT_EQ(events.front().first, "job_start")
-        << "job_start must be the first NDJSON line shipped (within "
-        << "the session's first chunk).";
+        << "job_start must be the first NDJSON line shipped — it heads "
+        << "the oldest rotated file, which is POSTed first.";
     EXPECT_EQ(events.back().first, "shutdown")
-        << "shutdown must be the last NDJSON line shipped (deferred "
-        << "to the session's final chunk regardless of which file it "
-        << "lived in on disk).";
+        << "shutdown must be the last NDJSON line shipped — it tails "
+        << "the active file, which is POSTed last.";
 
     fs::remove_all(tmp);
 }
 
 // ─────────────────────────────────────────────────────────────────────
-// Chunking — verifies the chunk-size cap drives flush behavior.
+// File-unit upload — one POST per file regardless of line count.
 // ─────────────────────────────────────────────────────────────────────
 
-TEST(UploadLogs, ManyEventsSplitIntoMultipleChunks) {
-    // Generate enough events that they can't fit in a single 5000-line
-    // chunk. We use a much smaller threshold for the test by writing
-    // 6000+ lines, which guarantees ≥2 chunks regardless of byte size.
+TEST(UploadLogs, ManyEventsShipInOneRequestPerFile) {
+    // U1 regression guard: a file with far more lines than the old
+    // 5000-line chunk cap still ships in exactly ONE request — the
+    // rotator's file size is the upload unit now.
     const fs::path tmp = fs::temp_directory_path() / "gpufl_upload_test_chunks";
     fs::remove_all(tmp);
     fs::create_directories(tmp);
@@ -1014,15 +1014,9 @@ TEST(UploadLogs, ManyEventsSplitIntoMultipleChunks) {
     EXPECT_EQ(result.events_uploaded, static_cast<std::size_t>(kLines + 2));
 
     const auto chunks = srv.snapshot();
-    EXPECT_GE(chunks.size(), 2u)
-        << "5500+ events should split into multiple chunks at the "
-        << "5000-line cap.";
-    // Sanity: no chunk should exceed the line cap.
-    for (const auto& c : chunks) {
-        EXPECT_LE(c.lines.size(), 5000u);
-    }
-    // shutdown still arrives last — verifies deferred-shutdown logic
-    // survives chunking.
+    ASSERT_EQ(chunks.size(), 1u)
+        << "One file must ship as one request — no client-side chunking.";
+    EXPECT_EQ(chunks.front().lines.size(), static_cast<std::size_t>(kLines + 2));
     EXPECT_EQ(chunks.back().events.back().first, "shutdown");
 
     fs::remove_all(tmp);


### PR DESCRIPTION
## Description
Stabilize trace capture and upload flow

- Simplify `gpufl trace` CLI around `--passes` and remove the old trace engine/profile flow.
- Fix trace output layout so session logs are written directly under the session directory and compressed to `.log.gz`.
- Add live upload-agent handling for trace sessions.
- Improve CUPTI trace stability by flushing activity records more reliably and deduplicating duplicate kernel correlation IDs.
- Update upload/chunk handling, CLI help, examples, and related tests.

Add artifact storage for source chunks

- Add artifact storage configuration and local/GCS artifact store implementations.
- Add codec and transaction helpers for source artifact chunk handling.
- Add migration for SASS source artifacts.
- Wire artifact handling into ingestion and related DAO paths.
- Add tests for artifact codec, artifact transactions, local disk storage, GCS storage, and ingestion behavior.


## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Documentation update

## Testing
## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas