### PR TITLE
Refactor trace launcher shutdown handling

### DIFF
--- a/daemon/launcher/CMakeLists.txt
+++ b/daemon/launcher/CMakeLists.txt
@@ -22,6 +22,7 @@ add_executable(gpufl_launcher
     main.cpp
     agent_launcher.cpp
     cli_parse.cpp
+    trace_command_common.cpp
     ${GPUFL_LAUNCHER_TRACE_IMPL}
     monitor_command.cpp
     ../monitor/monitor_runner.cpp
@@ -35,6 +36,18 @@ set_target_properties(gpufl_launcher PROPERTIES OUTPUT_NAME gpufl)
 # Most of gpufl's object files are unreferenced from the launcher and
 # get DCE'd at link time with --gc-sections.
 target_link_libraries(gpufl_launcher PRIVATE gpufl::gpufl)
+
+# trace_command_common.cpp inspects and rewrites .log.gz files when it needs
+# to synthesize a missing shutdown marker after an injected trace exits.
+if(TARGET ZLIB::ZLIB)
+    target_link_libraries(gpufl_launcher PRIVATE ZLIB::ZLIB)
+elseif(TARGET zlibstatic)
+    target_link_libraries(gpufl_launcher PRIVATE zlibstatic)
+    target_include_directories(gpufl_launcher PRIVATE
+        ${zlib_SOURCE_DIR}
+        ${zlib_BINARY_DIR}
+    )
+endif()
 
 target_include_directories(gpufl_launcher PRIVATE
     ${CMAKE_CURRENT_SOURCE_DIR}

--- a/daemon/launcher/trace_command.cpp
+++ b/daemon/launcher/trace_command.cpp
@@ -1,113 +1,26 @@
-// Implements `gpufl trace [opts] -- <command>...`:
-//   1. Resolves the path to the inject shared library
-//      (libgpufl_inject.so) adjacent to /proc/self/exe.
-//   2. Builds the output directory (~/.gpufl/traces/{ts}_{sid}/ by default).
-//   3. Sets the env vars from inject_entry.hpp so the inject lib's
-//      constructor can drive gpufl::init().
-//   4. fork() + execvp() the target; waitpid() in the parent.
-//   5. Prints a one-line summary and returns the appropriate exit code.
-//
-// Linux-only — uses fork(), execvp(), /proc/self/exe, LD_PRELOAD.
+// POSIX implementation of the tiny platform layer behind `gpufl trace`.
+// The orchestration lives in trace_command_common.cpp.
 
 #include "trace_command.hpp"
 
-#include <sys/stat.h>
 #include <sys/types.h>
 #include <sys/wait.h>
 #include <unistd.h>
 
 #include <cerrno>
-#include <chrono>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <ctime>
 #include <filesystem>
-#include <iomanip>
-#include <random>
-#include <sstream>
 #include <string>
-#include <thread>
 #include <vector>
 
-#include "agent_launcher.hpp"
 #include "gpufl/core/env_vars.hpp"
-#include "gpufl/core/logger/file_compressor.hpp"
-#include "gpufl/inject/inject_entry.hpp"
-
-namespace fs = std::filesystem;
+#include "trace_command_common.hpp"
 
 namespace gpufl::launcher {
-
 namespace {
-
-// Resolve /proc/self/exe → absolute path of the `gpufl` binary.
-fs::path selfExe() {
-    char buf[4096];
-    ssize_t n = ::readlink("/proc/self/exe", buf, sizeof(buf) - 1);
-    if (n <= 0) return {};
-    buf[n] = '\0';
-    return fs::path(buf);
-}
-
-// Candidate paths for libgpufl_inject.so relative to the launcher
-// binary, in search order. Centralized so the not-found error can
-// echo back exactly what we tried (saves a debug round-trip).
-//
-// Build tree:        build/daemon/launcher/gpufl  +  build/libgpufl_inject.so
-// Install (CMake):   bin/gpufl                    +  lib/libgpufl_inject.so
-// Install one-liner: ~/.local/bin/gpufl           +  ~/.local/lib/gpufl/libgpufl_inject.so
-std::vector<fs::path> injectLibCandidates(const fs::path& exe) {
-    const fs::path dir = exe.parent_path();
-    const auto kName = "libgpufl_inject.so";
-    return {
-        dir / kName,                                          // colocated
-        dir.parent_path() / kName,                            // one up
-        dir.parent_path().parent_path() / kName,              // two up (default CMake build root)
-        dir.parent_path() / "lib" / kName,                    // <build>/<subdir>/../lib
-        dir.parent_path() / "lib" / "gpufl" / kName,          // install one-liner
-        dir.parent_path().parent_path() / "lib" / kName,      // bin/../lib install layout
-    };
-}
-
-fs::path findInjectLib(const fs::path& exe) {
-    for (const auto& c : injectLibCandidates(exe)) {
-        if (std::error_code ec; fs::exists(c, ec)) return fs::canonical(c, ec);
-    }
-    return {};
-}
-
-std::string makeSessionId() {
-    static std::mt19937_64 rng{
-        static_cast<uint64_t>(
-            std::chrono::steady_clock::now().time_since_epoch().count())};
-    uint64_t v = rng();
-    std::ostringstream os;
-    os << std::hex << std::setw(8) << std::setfill('0') << (v & 0xffffffffu);
-    return os.str();
-}
-
-// 128-bit UUID-shaped id shared by all passes of one multi-pass analysis.
-// Opaque to the backend (it only groups by string equality), so the exact
-// layout doesn't matter — just full-width randomness for collision safety
-// across accounts (makeSessionId's 32 bits is fine for a local dir name but
-// too narrow to group analyses on the backend).
-std::string makeAnalysisId() {
-    static std::mt19937_64 rng{
-        static_cast<uint64_t>(
-            std::chrono::steady_clock::now().time_since_epoch().count()) ^
-        0x9e3779b97f4a7c15ULL};
-    const uint64_t a = rng();
-    const uint64_t b = rng();
-    char buf[40];
-    std::snprintf(buf, sizeof(buf), "%08x-%04x-%04x-%04x-%012llx",
-                  static_cast<unsigned>(a >> 32),
-                  static_cast<unsigned>((a >> 16) & 0xffff),
-                  static_cast<unsigned>(a & 0xffff),
-                  static_cast<unsigned>((b >> 48) & 0xffff),
-                  static_cast<unsigned long long>(b & 0xffffffffffffULL));
-    return buf;
-}
 
 std::string makeTimestamp() {
     auto t = std::time(nullptr);
@@ -118,296 +31,108 @@ std::string makeTimestamp() {
     return buf;
 }
 
-fs::path defaultOutputDir(const std::string& session_id) {
-    const char* home = std::getenv("HOME");
-    const fs::path root = home && *home ? fs::path(home) : fs::path("/tmp");
-    return root / ".gpufl" / "traces" / (makeTimestamp() + "_" + session_id);
-}
+class PosixTracePlatform final : public TracePlatform {
+   public:
+    const char* platformName() const override { return "POSIX"; }
+    const char* injectLibraryName() const override { return "libgpufl_inject.so"; }
 
-std::string baseName(const std::string& path) {
-    auto pos = path.find_last_of('/');
-    return pos == std::string::npos ? path : path.substr(pos + 1);
-}
-
-void setEnvOrDie(const char* k, const std::string& v) {
-    if (::setenv(k, v.c_str(), /*overwrite=*/1) != 0) {
-        std::fprintf(stderr,
-                     "gpufl: setenv %s failed: %s\n", k, std::strerror(errno));
-        std::exit(2);
-    }
-}
-
-int repairUncompressedLogs(const fs::path& root) {
-    std::error_code root_ec;
-    if (root.empty() || !fs::exists(root, root_ec)) return 0;
-
-    gpufl::GzipFileCompressor compressor;
-    int repaired = 0;
-    std::error_code iter_ec;
-    for (fs::recursive_directory_iterator it(root, fs::directory_options::skip_permission_denied, iter_ec), end;
-         !iter_ec && it != end;
-         it.increment(iter_ec)) {
-        std::error_code entry_ec;
-        if (!it->is_regular_file(entry_ec)) continue;
-        const fs::path path = it->path();
-        if (path.extension() != ".log") continue;
-
-        std::error_code size_ec;
-        const auto size = fs::file_size(path, size_ec);
-        if (size_ec) continue;
-        if (size == 0) {
-            std::error_code remove_ec;
-            fs::remove(path, remove_ec);
-            continue;
-        }
-
-        const fs::path gz_path(path.string() + ".gz");
-        std::error_code exists_ec;
-        if (fs::exists(gz_path, exists_ec)) {
-            std::error_code remove_ec;
-            fs::remove(path, remove_ec);
-            continue;
-        }
-
-        if (compressor.compress(path.string())) {
-            ++repaired;
-            std::error_code remaining_ec;
-            if (fs::exists(path, remaining_ec)) {
-                std::error_code remove_ec;
-                fs::remove(path, remove_ec);
-            }
-        }
-    }
-    return repaired;
-}
-
-}  // namespace
-
-int runTrace(const TraceArgs& args) {
-    const fs::path exe = selfExe();
-    if (exe.empty()) {
-        std::fprintf(stderr,
-                     "gpufl: cannot resolve /proc/self/exe (Linux required)\n");
-        return 3;
+    fs::path selfExe() const override {
+        char buf[4096];
+        ssize_t n = ::readlink("/proc/self/exe", buf, sizeof(buf) - 1);
+        if (n <= 0) return {};
+        buf[n] = '\0';
+        return fs::path(buf);
     }
 
-    const fs::path inject_lib = findInjectLib(exe);
-    if (inject_lib.empty()) {
-        std::fprintf(stderr,
-                     "gpufl: cannot find libgpufl_inject.so adjacent to %s\n",
-                     exe.string().c_str());
-        std::fprintf(stderr, "       searched:\n");
-        for (const auto& c : injectLibCandidates(exe)) {
-            std::fprintf(stderr, "         %s\n", c.string().c_str());
-        }
-        return 3;
+    std::vector<fs::path> injectLibCandidates(const fs::path& exe) const override {
+        const fs::path dir = exe.parent_path();
+        const auto kName = "libgpufl_inject.so";
+        return {
+            dir / kName,                                          // colocated
+            dir.parent_path() / kName,                            // one up
+            dir.parent_path().parent_path() / kName,              // two up
+            dir.parent_path() / "lib" / kName,                    // build lib dir
+            dir.parent_path() / "lib" / "gpufl" / kName,          // install one-liner
+            dir.parent_path().parent_path() / "lib" / kName,      // bin/../lib
+        };
     }
 
-    // Resolve the capture plan (explicit --passes, --passes=Deep expanded, or
-    // the default Trace pass) — the shared source of truth lives in cli_parse.
-    const std::vector<std::string> plan = resolvePassPlan(args);
-    const bool multipass = plan.size() > 1;
-
-    // One analysis_id shared by every pass lets the backend stitch the isolated
-    // passes into a single kernel view. Single-pass runs get none and keep the
-    // legacy {ts}_{sid} dir name.
-    const std::string analysis_id = multipass ? makeAnalysisId() : std::string();
-    const std::string dir_tag = multipass ? analysis_id : makeSessionId();
-
-    const fs::path output_dir = args.output_dir.empty()
-                              ? defaultOutputDir(dir_tag)
-                              : fs::path(args.output_dir);
-
-    std::error_code ec;
-    fs::create_directories(output_dir, ec);
-    if (ec) {
-        std::fprintf(stderr, "gpufl: cannot create %s: %s\n",
-                     output_dir.string().c_str(), ec.message().c_str());
-        return 2;
-    }
-    const fs::path agent_output_dir = fs::weakly_canonical(output_dir, ec);
-    const fs::path upload_dir = ec ? output_dir : agent_output_dir;
-
-    const std::string app_name = args.name.empty()
-                               ? baseName(args.command.front())
-                               : args.name;
-
-    // ── Env shared by every pass: set once, inherited by each child. The log
-    //    dir is shared too — each pass's process writes under its OWN
-    //    session-id subdir (Logger's <dir>/<session_id>/ layout), so the
-    //    uploader discovers N sessions and the backend groups them by
-    //    analysis_id. LD_PRELOAD keeps any value the user already set. ──
-    std::string ld_preload = inject_lib.string();
-    if (const char* prev = std::getenv(gpufl::env::kLdPreload); prev && *prev) {
-        ld_preload = std::string(prev) + ":" + ld_preload;
+    fs::path defaultOutputDir(const std::string& tag) const override {
+        const char* home = std::getenv("HOME");
+        const fs::path root = home && *home ? fs::path(home) : fs::path("/tmp");
+        return root / ".gpufl" / "traces" / (makeTimestamp() + "_" + tag);
     }
 
-    setEnvOrDie(gpufl::env::kLdPreload, ld_preload);
-    setEnvOrDie(gpufl::env::kCudaInjection64Path, inject_lib.string());
-    setEnvOrDie(gpufl::env::kNvtxInjection64Path, inject_lib.string());
-    setEnvOrDie(gpufl::env::kInject, "1");
-    setEnvOrDie(gpufl::env::kAppName, app_name);
-    setEnvOrDie(gpufl::env::kLogDir, output_dir.string());
-    setEnvOrDie(gpufl::env::kInjectProfile, gpufl::inject::kProfileComprehensive);
-    setEnvOrDie(gpufl::env::kInjectUpload, "0");
-
-    AgentProcess agent;
-    if (args.upload) {
-        const fs::path cursor = args.agent_cursor.empty()
-                              ? upload_dir / "cursor.json"
-                              : fs::path(args.agent_cursor);
-
-        AgentOptions agent_opts;
-        agent_opts.source_folders = upload_dir.string();
-        agent_opts.log_types = args.log_types;
-        agent_opts.cursor_file = cursor.string();
-        agent_opts.backend_url = resolveOption(args.backend_url, gpufl::env::kBackendUrl);
-        agent_opts.api_key = resolveOption(args.api_key, gpufl::env::kApiKey);
-        agent_opts.api_version = args.api_version;
-        agent_opts.agent_jar = args.agent_jar;
-
-        std::string error;
-        if (!configureAgentEnvironment(agent_opts, error)) {
-            std::fprintf(stderr, "gpufl trace --upload: %s\n", error.c_str());
-            return 2;
-        }
-
-        AgentLaunchPlan plan;
-        if (!buildAgentLaunchPlan(agent_opts, plan, error)) {
-            std::fprintf(stderr, "gpufl trace --upload: %s\n", error.c_str());
-            return 2;
-        }
-        if (!args.quiet) {
-            std::fprintf(stderr, "[gpufl] starting agent: %s\n",
-                         plan.description.c_str());
-        }
-        if (!agent.start(plan.command, error)) {
-            std::fprintf(stderr, "gpufl trace --upload: %s\n", error.c_str());
-            return 3;
-        }
+    std::string defaultAppName(const std::string& command0) const override {
+        auto pos = command0.find_last_of('/');
+        return pos == std::string::npos ? command0 : command0.substr(pos + 1);
     }
 
-    if (multipass) {
-        setEnvOrDie(env::kAnalysisId, analysis_id);
-        setEnvOrDie(env::kPassCount, std::to_string(plan.size()));
+    bool setEnv(const char* key, const std::string& value,
+                std::string& error) const override {
+        if (::setenv(key, value.c_str(), /*overwrite=*/1) == 0) return true;
+        error = "setenv " + std::string(key) + " failed: " + std::strerror(errno);
+        return false;
     }
 
-    if (!args.quiet) {
-        std::fprintf(stderr, "[gpufl] capturing → %s\n",
-                     output_dir.string().c_str());
-        if (multipass) {
-            std::fprintf(stderr, "[gpufl] multi-pass analysis %s — %zu passes:",
-                         analysis_id.c_str(), plan.size());
-            for (const auto& e : plan) std::fprintf(stderr, " %s", e.c_str());
-            std::fputc('\n', stderr);
+    bool prepareInjectionEnv(const fs::path& inject_lib,
+                             std::string& error) const override {
+        std::string ld_preload = inject_lib.string();
+        if (const char* prev = std::getenv(env::kLdPreload); prev && *prev) {
+            ld_preload = std::string(prev) + ":" + ld_preload;
         }
-        if (args.verbose) {
-            std::fprintf(stderr, "[gpufl] inject lib: %s\n",
-                         inject_lib.string().c_str());
-            std::fprintf(stderr, "[gpufl] app_name: %s\n", app_name.c_str());
-        }
+        return setEnv(env::kLdPreload, ld_preload, error);
     }
 
-    // ── Run the workload once per pass. A failing pass does NOT abort the
-    //    rest (a partial analysis still captures the passes that worked); the
-    //    first non-zero pass becomes the launcher's exit code. ──
-    int overall_rc = 0;
-    for (size_t i = 0; i < plan.size(); ++i) {
-        const std::string& engine = plan[i];
-
-        // Per-pass engine. The default no-flag path resolves to Trace.
-        setEnvOrDie(gpufl::env::kProfilingEngine, engine);
-        if (multipass) {
-            setEnvOrDie(gpufl::env::kPassIndex, std::to_string(i));
-        }
-
-        const std::string what =
-            multipass ? ("pass " + std::to_string(i + 1) + "/" +
-                         std::to_string(plan.size()) + " (" + engine + ")")
-                      : std::string("target");
-
-        if (!args.quiet && multipass) {
-            std::fprintf(stderr, "\n[gpufl] ── %s ──\n", what.c_str());
-            if (engine == "PcSampling") {
-                std::fprintf(stderr,
-                    "[gpufl] note: PcSampling needs admin / NVIDIA CP \"allow GPU "
-                    "performance counters to all users\"; this pass reports \"needs "
-                    "admin\" and yields no PC data if unprivileged.\n");
-            }
-        }
-
-        const auto t_start = std::chrono::steady_clock::now();
-
+    TraceProcessResult runProcess(
+            const std::vector<std::string>& command) const override {
+        TraceProcessResult out;
         pid_t pid = ::fork();
         if (pid < 0) {
-            std::fprintf(stderr, "gpufl: fork failed: %s\n", std::strerror(errno));
-            return 2;
+            out.launcher_error = true;
+            out.rc = 2;
+            out.error = std::string("fork failed: ") + std::strerror(errno);
+            return out;
         }
         if (pid == 0) {
-            // Child: execvp the target. The env we just set is inherited.
             std::vector<char*> argv;
-            argv.reserve(args.command.size() + 1);
-            for (auto& s : args.command) argv.push_back(const_cast<char*>(s.c_str()));
+            argv.reserve(command.size() + 1);
+            for (const auto& s : command) {
+                argv.push_back(const_cast<char*>(s.c_str()));
+            }
             argv.push_back(nullptr);
-            ::execvp(args.command.front().c_str(), argv.data());
-            // execvp only returns on failure.
+            execvp(command.front().c_str(), argv.data());
             std::fprintf(stderr, "gpufl: cannot exec %s: %s\n",
-                         args.command.front().c_str(), std::strerror(errno));
+                         command.front().c_str(), std::strerror(errno));
             std::_Exit(127);
         }
 
         int status = 0;
         while (::waitpid(pid, &status, 0) < 0) {
             if (errno == EINTR) continue;
-            std::fprintf(stderr, "gpufl: waitpid failed: %s\n", std::strerror(errno));
-            return 2;
+            out.launcher_error = true;
+            out.rc = 2;
+            out.error = std::string("waitpid failed: ") + std::strerror(errno);
+            return out;
         }
 
-        const auto t_elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
-                             std::chrono::steady_clock::now() - t_start)
-                             .count();
-
-        int rc;
         if (WIFEXITED(status)) {
-            rc = WEXITSTATUS(status);
-            if (!args.quiet) {
-                std::fprintf(stderr, "[gpufl] %s exited (rc=%d) in %.2fs\n",
-                             what.c_str(), rc, t_elapsed / 1000.0);
-            }
+            out.rc = WEXITSTATUS(status);
         } else if (WIFSIGNALED(status)) {
-            rc = 128 + WTERMSIG(status);
-            if (!args.quiet) {
-                std::fprintf(stderr, "[gpufl] %s killed by signal %d in %.2fs\n",
-                             what.c_str(), WTERMSIG(status), t_elapsed / 1000.0);
-            }
+            out.signaled = true;
+            out.signal = WTERMSIG(status);
+            out.rc = 128 + out.signal;
         } else {
-            rc = 1;
+            out.rc = 1;
         }
+        return out;
+    }
+};
 
-        // First failing pass sets the exit code; keep going so later passes
-        // still run and the analysis is as complete as possible.
-        if (rc != 0 && overall_rc == 0) overall_rc = rc;
-    }
+}  // namespace
 
-    if (!args.quiet) {
-        std::fprintf(stderr, "[gpufl] inspect: %s\n", output_dir.string().c_str());
-    }
-    if (args.upload && args.agent_drain_ms > 0) {
-        if (!args.quiet) {
-            std::fprintf(stderr, "[gpufl] waiting %.2fs for agent drain\n",
-                         args.agent_drain_ms / 1000.0);
-        }
-        std::this_thread::sleep_for(std::chrono::milliseconds(args.agent_drain_ms));
-    }
-    if (args.upload) {
-        agent.stop();
-    }
-    const int repaired_logs = repairUncompressedLogs(output_dir);
-    if (!args.quiet && repaired_logs > 0) {
-        std::fprintf(stderr, "[gpufl] compressed %d log file(s)\n", repaired_logs);
-    }
-
-    return overall_rc;
+int runTrace(const TraceArgs& args) {
+    return runTraceCommon(args, PosixTracePlatform{});
 }
 
 }  // namespace gpufl::launcher

--- a/daemon/launcher/trace_command_common.cpp
+++ b/daemon/launcher/trace_command_common.cpp
@@ -1,0 +1,594 @@
+#include "trace_command_common.hpp"
+
+#include <zlib.h>
+
+#include <algorithm>
+#include <chrono>
+#include <cctype>
+#include <cstdio>
+#include <cstdlib>
+#include <ctime>
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <random>
+#include <sstream>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#include "agent_launcher.hpp"
+#include "gpufl/core/env_vars.hpp"
+#include "gpufl/core/json/json.hpp"
+#include "gpufl/core/logger/file_compressor.hpp"
+#include "gpufl/inject/inject_entry.hpp"
+
+namespace gpufl::launcher {
+namespace {
+
+fs::path findInjectLib(const TracePlatform& platform, const fs::path& exe) {
+    for (const auto& c : platform.injectLibCandidates(exe)) {
+        std::error_code ec;
+        if (fs::exists(c, ec)) return fs::weakly_canonical(c, ec);
+    }
+    return {};
+}
+
+bool setEnvOrPrint(const TracePlatform& platform,
+                   const char* key,
+                   const std::string& value) {
+    std::string error;
+    if (platform.setEnv(key, value, error)) return true;
+    std::fprintf(stderr, "gpufl: %s\n", error.c_str());
+    return false;
+}
+
+std::string makeSessionId() {
+    static std::mt19937_64 rng{
+        static_cast<uint64_t>(
+            std::chrono::steady_clock::now().time_since_epoch().count())};
+    uint64_t v = rng();
+    std::ostringstream os;
+    os << std::hex << std::setw(8) << std::setfill('0') << (v & 0xffffffffu);
+    return os.str();
+}
+
+std::string makeAnalysisId() {
+    static std::mt19937_64 rng{
+        static_cast<uint64_t>(
+            std::chrono::steady_clock::now().time_since_epoch().count()) ^
+        0x9e3779b97f4a7c15ULL};
+    const uint64_t a = rng();
+    const uint64_t b = rng();
+    char buf[40];
+    std::snprintf(buf, sizeof(buf), "%08x-%04x-%04x-%04x-%012llx",
+                  static_cast<unsigned>(a >> 32),
+                  static_cast<unsigned>((a >> 16) & 0xffff),
+                  static_cast<unsigned>(a & 0xffff),
+                  static_cast<unsigned>((b >> 48) & 0xffff),
+                  static_cast<unsigned long long>(b & 0xffffffffffffULL));
+    return buf;
+}
+
+int64_t nowNs() {
+    return std::chrono::duration_cast<std::chrono::nanoseconds>(
+            std::chrono::system_clock::now().time_since_epoch()).count();
+}
+
+bool isPlainLog(const fs::path& path) {
+    return path.extension() == ".log";
+}
+
+bool isGzipLog(const fs::path& path) {
+    if (path.extension() != ".gz") return false;
+    return path.stem().extension() == ".log";
+}
+
+template <typename Fn>
+void readPlainLines(const fs::path& path, Fn&& fn) {
+    std::ifstream in(path);
+    std::string line;
+    while (std::getline(in, line)) {
+        if (!line.empty() && line.back() == '\r') line.pop_back();
+        fn(line);
+    }
+}
+
+template <typename Fn>
+void readGzipLines(const fs::path& path, Fn&& fn) {
+    gzFile gz = gzopen(path.string().c_str(), "rb");
+    if (!gz) return;
+
+    char buf[4096];
+    std::string line;
+    while (gzgets(gz, buf, sizeof(buf)) != nullptr) {
+        line.append(buf);
+        if (!line.empty() && line.back() == '\n') {
+            line.pop_back();
+            if (!line.empty() && line.back() == '\r') line.pop_back();
+            fn(line);
+            line.clear();
+        }
+    }
+    if (!line.empty()) {
+        if (!line.empty() && line.back() == '\r') line.pop_back();
+        fn(line);
+    }
+    gzclose(gz);
+}
+
+template <typename Fn>
+void readLogLines(const fs::path& path, Fn&& fn) {
+    if (isGzipLog(path)) {
+        readGzipLines(path, std::forward<Fn>(fn));
+    } else if (isPlainLog(path)) {
+        readPlainLines(path, std::forward<Fn>(fn));
+    }
+}
+
+struct SessionLifecycleInfo {
+    bool saw_job_start = false;
+    bool saw_shutdown = false;
+    int pid = 0;
+    std::string app = "unknown";
+    int64_t job_start_ts_ns = 0;
+};
+
+struct SyntheticShutdownContext {
+    int exit_code = 0;
+    bool signaled = false;
+    int signal = 0;
+};
+
+void inspectLifecycleLine(const std::string& line, SessionLifecycleInfo& info) {
+    if (line.find("\"type\":\"shutdown\"") != std::string::npos) {
+        info.saw_shutdown = true;
+        return;
+    }
+    if (info.saw_job_start ||
+        line.find("\"type\":\"job_start\"") == std::string::npos) {
+        return;
+    }
+
+    const json::JsonValue doc = json::parseJson(line);
+    if (!doc.is_object()) return;
+
+    const std::string type = doc.value<std::string>("type", "");
+    if (type != "job_start" || info.saw_job_start) return;
+
+    info.saw_job_start = true;
+    info.pid = doc.value<int>("pid", 0);
+    info.app = doc.value<std::string>("app", "unknown");
+    info.job_start_ts_ns = doc.value<int64_t>("ts_ns", 0);
+}
+
+bool decompressGzipToFile(const fs::path& gz_path, const fs::path& out_path) {
+    gzFile gz = gzopen(gz_path.string().c_str(), "rb");
+    if (!gz) return false;
+    std::ofstream out(out_path, std::ios::binary | std::ios::trunc);
+    if (!out.is_open()) {
+        gzclose(gz);
+        return false;
+    }
+
+    char buf[64 * 1024];
+    int n = 0;
+    while ((n = gzread(gz, buf, sizeof(buf))) > 0) {
+        out.write(buf, n);
+    }
+    const int err = gzclose(gz);
+    out.close();
+    return n == 0 && err == Z_OK && out.good();
+}
+
+std::string syntheticShutdownLine(const std::string& session_id,
+                                  const SessionLifecycleInfo& info,
+                                  const SyntheticShutdownContext& context) {
+    const bool crashed = context.signaled || context.exit_code != 0;
+    std::ostringstream os;
+    os << "{\"type\":\"shutdown\""
+       << ",\"pid\":" << info.pid
+       << ",\"app\":\"" << json::escape(info.app) << "\""
+       << ",\"session_id\":\"" << json::escape(session_id) << "\""
+       << ",\"ts_ns\":" << nowNs()
+       << ",\"synthetic\":true"
+       << ",\"exit_code\":" << context.exit_code
+       << ",\"signaled\":" << (context.signaled ? "true" : "false")
+       << ",\"signal\":" << context.signal
+       << ",\"crashed\":" << (crashed ? "true" : "false")
+       << "}";
+    return os.str();
+}
+
+bool appendLine(const fs::path& path, const std::string& line) {
+    std::ofstream out(path, std::ios::out | std::ios::app);
+    if (!out.is_open()) return false;
+    out << line << '\n';
+    return out.good();
+}
+
+bool appendLineToGzipLog(const fs::path& gz_path, const std::string& line) {
+    const fs::path dir = gz_path.parent_path();
+    const fs::path tmp_plain = dir / ".gpufl.synthetic-shutdown.system.log";
+    const fs::path tmp_gz(tmp_plain.string() + ".gz");
+
+    std::error_code ec;
+    fs::remove(tmp_plain, ec);
+    fs::remove(tmp_gz, ec);
+
+    if (!decompressGzipToFile(gz_path, tmp_plain)) {
+        fs::remove(tmp_plain, ec);
+        return false;
+    }
+    if (!appendLine(tmp_plain, line)) {
+        fs::remove(tmp_plain, ec);
+        return false;
+    }
+
+    GzipFileCompressor compressor;
+    if (!compressor.compress(tmp_plain.string())) {
+        fs::remove(tmp_plain, ec);
+        fs::remove(tmp_gz, ec);
+        return false;
+    }
+    fs::remove(tmp_plain, ec);
+
+    const fs::path backup(gz_path.string() + ".bak");
+    fs::remove(backup, ec);
+    fs::rename(gz_path, backup, ec);
+    if (ec) {
+        fs::remove(tmp_gz, ec);
+        return false;
+    }
+    fs::rename(tmp_gz, gz_path, ec);
+    if (ec) {
+        std::error_code restore_ec;
+        fs::rename(backup, gz_path, restore_ec);
+        fs::remove(tmp_gz, ec);
+        return false;
+    }
+    fs::remove(backup, ec);
+    fs::remove(tmp_plain, ec);
+    return true;
+}
+
+bool appendSyntheticShutdown(const fs::path& session_dir,
+                             const std::string& session_id,
+                             const SessionLifecycleInfo& info,
+                             const SyntheticShutdownContext& context) {
+    const std::string line = syntheticShutdownLine(session_id, info, context);
+    const fs::path system_gz = session_dir / "system.log.gz";
+    const fs::path system_log = session_dir / "system.log";
+
+    std::error_code ec;
+    if (fs::exists(system_gz, ec)) {
+        return appendLineToGzipLog(system_gz, line);
+    }
+    return appendLine(system_log, line);
+}
+
+bool isSystemLog(const fs::path& path) {
+    if (!isPlainLog(path) && !isGzipLog(path)) return false;
+
+    std::string name = path.filename().string();
+    if (name.size() > 3 && name.compare(name.size() - 3, 3, ".gz") == 0) {
+        name.resize(name.size() - 3);
+    }
+    if (name.size() <= 4 || name.compare(name.size() - 4, 4, ".log") != 0) {
+        return false;
+    }
+    name.resize(name.size() - 4);
+
+    if (name == "system") return true;
+    if (name.rfind("system.", 0) != 0) return false;
+    const std::string suffix = name.substr(std::string("system.").size());
+    if (suffix.empty()) return false;
+    return std::all_of(suffix.begin(), suffix.end(),
+                       [](unsigned char c) { return std::isdigit(c); });
+}
+
+void inspectLifecycleFiles(const std::vector<fs::path>& paths,
+                           SessionLifecycleInfo& info) {
+    for (const fs::path& path : paths) {
+        readLogLines(path, [&](const std::string& line) {
+            inspectLifecycleLine(line, info);
+        });
+        if (info.saw_shutdown) break;
+    }
+}
+
+int ensureTraceCompletionMarkers(const fs::path& output_dir,
+                                 const int64_t min_job_start_ts_ns,
+                                 const SyntheticShutdownContext& context) {
+    std::error_code ec;
+    if (output_dir.empty() || !fs::exists(output_dir, ec)) return 0;
+
+    int synthesized = 0;
+    for (const auto& session_entry : fs::directory_iterator(output_dir, ec)) {
+        if (ec) break;
+        if (!session_entry.is_directory(ec)) continue;
+
+        const fs::path session_dir = session_entry.path();
+        const std::string session_id = session_dir.filename().string();
+        if (session_id.empty() || session_id.front() == '.') continue;
+
+        std::vector<fs::path> system_logs;
+        std::vector<fs::path> fallback_logs;
+        SessionLifecycleInfo info;
+        std::error_code inner_ec;
+        for (const auto& file_entry : fs::directory_iterator(session_dir, inner_ec)) {
+            if (inner_ec) break;
+            if (!file_entry.is_regular_file(inner_ec)) continue;
+            const fs::path path = file_entry.path();
+            if (!isPlainLog(path) && !isGzipLog(path)) continue;
+            if (isSystemLog(path)) {
+                system_logs.push_back(path);
+            } else {
+                fallback_logs.push_back(path);
+            }
+        }
+
+        if (!system_logs.empty()) {
+            inspectLifecycleFiles(system_logs, info);
+        } else {
+            inspectLifecycleFiles(fallback_logs, info);
+        }
+
+        if (info.saw_job_start && !info.saw_shutdown &&
+            info.job_start_ts_ns >= min_job_start_ts_ns &&
+            appendSyntheticShutdown(session_dir, session_id, info, context)) {
+            ++synthesized;
+        }
+    }
+    return synthesized;
+}
+
+int repairUncompressedLogs(const fs::path& root) {
+    std::error_code root_ec;
+    if (root.empty() || !fs::exists(root, root_ec)) return 0;
+
+    GzipFileCompressor compressor;
+    int repaired = 0;
+    std::error_code iter_ec;
+    for (fs::recursive_directory_iterator it(root, fs::directory_options::skip_permission_denied, iter_ec), end;
+         !iter_ec && it != end;
+         it.increment(iter_ec)) {
+        std::error_code entry_ec;
+        if (!it->is_regular_file(entry_ec)) continue;
+        const fs::path path = it->path();
+        if (path.extension() != ".log") continue;
+
+        std::error_code size_ec;
+        const auto size = fs::file_size(path, size_ec);
+        if (size_ec) continue;
+        if (size == 0) {
+            std::error_code remove_ec;
+            fs::remove(path, remove_ec);
+            continue;
+        }
+
+        const fs::path gz_path(path.string() + ".gz");
+        std::error_code exists_ec;
+        if (fs::exists(gz_path, exists_ec)) {
+            std::error_code remove_ec;
+            fs::remove(path, remove_ec);
+            continue;
+        }
+
+        if (compressor.compress(path.string())) {
+            ++repaired;
+            std::error_code remaining_ec;
+            if (fs::exists(path, remaining_ec)) {
+                std::error_code remove_ec;
+                fs::remove(path, remove_ec);
+            }
+        }
+    }
+    return repaired;
+}
+
+}  // namespace
+
+int runTraceCommon(const TraceArgs& args, const TracePlatform& platform) {
+    const fs::path exe = platform.selfExe();
+    if (exe.empty()) {
+        std::fprintf(stderr, "gpufl: cannot resolve launcher path (%s)\n",
+                     platform.platformName());
+        return 3;
+    }
+
+    const fs::path inject_lib = findInjectLib(platform, exe);
+    if (inject_lib.empty()) {
+        std::fprintf(stderr,
+                     "gpufl: cannot find %s adjacent to %s\n",
+                     platform.injectLibraryName(), exe.string().c_str());
+        std::fprintf(stderr, "       searched:\n");
+        for (const auto& c : platform.injectLibCandidates(exe)) {
+            std::fprintf(stderr, "         %s\n", c.string().c_str());
+        }
+        return 3;
+    }
+
+    const std::vector<std::string> plan = resolvePassPlan(args);
+    const bool multipass = plan.size() > 1;
+
+    const std::string analysis_id = multipass ? makeAnalysisId() : std::string();
+    const std::string dir_tag = multipass ? analysis_id : makeSessionId();
+
+    const fs::path output_dir = args.output_dir.empty()
+                              ? platform.defaultOutputDir(dir_tag)
+                              : fs::path(args.output_dir);
+
+    std::error_code ec;
+    fs::create_directories(output_dir, ec);
+    if (ec) {
+        std::fprintf(stderr, "gpufl: cannot create %s: %s\n",
+                     output_dir.string().c_str(), ec.message().c_str());
+        return 2;
+    }
+    const fs::path agent_output_dir = fs::weakly_canonical(output_dir, ec);
+    const fs::path upload_dir = ec ? output_dir : agent_output_dir;
+
+    const std::string app_name = args.name.empty()
+                               ? platform.defaultAppName(args.command.front())
+                               : args.name;
+
+    std::string error;
+    if (!platform.prepareInjectionEnv(inject_lib, error)) {
+        std::fprintf(stderr, "gpufl: %s\n", error.c_str());
+        return 2;
+    }
+
+    if (!setEnvOrPrint(platform, env::kCudaInjection64Path, inject_lib.string()) ||
+        !setEnvOrPrint(platform, env::kNvtxInjection64Path, inject_lib.string()) ||
+        !setEnvOrPrint(platform, env::kInject, "1") ||
+        !setEnvOrPrint(platform, env::kAppName, app_name) ||
+        !setEnvOrPrint(platform, env::kLogDir, output_dir.string()) ||
+        !setEnvOrPrint(platform, env::kInjectProfile, inject::kProfileComprehensive) ||
+        !setEnvOrPrint(platform, env::kInjectUpload, "0")) {
+        return 2;
+    }
+
+    AgentProcess agent;
+    if (args.upload) {
+        const fs::path cursor = args.agent_cursor.empty()
+                              ? upload_dir / "cursor.json"
+                              : fs::path(args.agent_cursor);
+
+        AgentOptions agent_opts;
+        agent_opts.source_folders = upload_dir.string();
+        agent_opts.log_types = args.log_types;
+        agent_opts.cursor_file = cursor.string();
+        agent_opts.backend_url = resolveOption(args.backend_url, env::kBackendUrl);
+        agent_opts.api_key = resolveOption(args.api_key, env::kApiKey);
+        agent_opts.api_version = args.api_version;
+        agent_opts.agent_jar = args.agent_jar;
+
+        if (!configureAgentEnvironment(agent_opts, error)) {
+            std::fprintf(stderr, "gpufl trace --upload: %s\n", error.c_str());
+            return 2;
+        }
+
+        AgentLaunchPlan agent_plan;
+        if (!buildAgentLaunchPlan(agent_opts, agent_plan, error)) {
+            std::fprintf(stderr, "gpufl trace --upload: %s\n", error.c_str());
+            return 2;
+        }
+        if (!args.quiet) {
+            std::fprintf(stderr, "[gpufl] starting agent: %s\n",
+                         agent_plan.description.c_str());
+        }
+        if (!agent.start(agent_plan.command, error)) {
+            std::fprintf(stderr, "gpufl trace --upload: %s\n", error.c_str());
+            return 3;
+        }
+    }
+
+    if (multipass) {
+        if (!setEnvOrPrint(platform, env::kAnalysisId, analysis_id) ||
+            !setEnvOrPrint(platform, env::kPassCount, std::to_string(plan.size()))) {
+            return 2;
+        }
+    }
+
+    if (!args.quiet) {
+        std::fprintf(stderr, "[gpufl] capturing -> %s\n", output_dir.string().c_str());
+        if (multipass) {
+            std::fprintf(stderr, "[gpufl] multi-pass analysis %s - %zu passes:",
+                         analysis_id.c_str(), plan.size());
+            for (const auto& e : plan) std::fprintf(stderr, " %s", e.c_str());
+            std::fputc('\n', stderr);
+        }
+        if (args.verbose) {
+            std::fprintf(stderr, "[gpufl] inject lib: %s\n",
+                         inject_lib.string().c_str());
+            std::fprintf(stderr, "[gpufl] app_name: %s\n", app_name.c_str());
+        }
+    }
+
+    int overall_rc = 0;
+    for (size_t i = 0; i < plan.size(); ++i) {
+        const std::string& engine = plan[i];
+
+        if (!setEnvOrPrint(platform, env::kProfilingEngine, engine)) {
+            return 2;
+        }
+        if (multipass &&
+            !setEnvOrPrint(platform, env::kPassIndex, std::to_string(i))) {
+            return 2;
+        }
+
+        const std::string what =
+            multipass ? "pass " + std::to_string(i + 1) + "/" +
+                            std::to_string(plan.size()) + " (" + engine + ")"
+                      : std::string("target");
+
+        if (!args.quiet && multipass) {
+            std::fprintf(stderr, "\n[gpufl] -- %s --\n", what.c_str());
+            if (engine == "PcSampling") {
+                std::fprintf(stderr,
+                    "[gpufl] note: PcSampling needs admin / NVIDIA CP \"allow GPU "
+                    "performance counters to all users\"; this pass reports \"needs "
+                    "admin\" and yields no PC data if unprivileged.\n");
+            }
+        }
+
+        const int64_t pass_start_ns = nowNs();
+        const auto t_start = std::chrono::steady_clock::now();
+        const TraceProcessResult run = platform.runProcess(args.command);
+        const auto t_elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
+                std::chrono::steady_clock::now() - t_start).count();
+
+        if (run.launcher_error) {
+            std::fprintf(stderr, "gpufl: %s\n", run.error.c_str());
+            return run.rc;
+        }
+
+        if (!args.quiet) {
+            if (run.signaled) {
+                std::fprintf(stderr, "[gpufl] %s killed by signal %d in %.2fs\n",
+                             what.c_str(), run.signal, t_elapsed / 1000.0);
+            } else {
+                std::fprintf(stderr, "[gpufl] %s exited (rc=%d) in %.2fs\n",
+                             what.c_str(), run.rc, t_elapsed / 1000.0);
+            }
+        }
+
+        if (run.rc != 0 && overall_rc == 0) overall_rc = run.rc;
+
+        SyntheticShutdownContext shutdown_context;
+        shutdown_context.exit_code = run.rc;
+        shutdown_context.signaled = run.signaled;
+        shutdown_context.signal = run.signal;
+        const int synthesized = ensureTraceCompletionMarkers(
+                output_dir, pass_start_ns, shutdown_context);
+        if (!args.quiet && synthesized > 0) {
+            std::fprintf(stderr, "[gpufl] wrote %d synthetic shutdown marker(s)\n",
+                         synthesized);
+        }
+    }
+
+    if (!args.quiet) {
+        std::fprintf(stderr, "[gpufl] inspect: %s\n", output_dir.string().c_str());
+    }
+    if (args.upload && args.agent_drain_ms > 0) {
+        if (!args.quiet) {
+            std::fprintf(stderr, "[gpufl] waiting %.2fs for agent drain\n",
+                         args.agent_drain_ms / 1000.0);
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(args.agent_drain_ms));
+    }
+    if (args.upload) {
+        agent.stop();
+    }
+
+    const int repaired_logs = repairUncompressedLogs(output_dir);
+    if (!args.quiet && repaired_logs > 0) {
+        std::fprintf(stderr, "[gpufl] compressed %d log file(s)\n", repaired_logs);
+    }
+
+    return overall_rc;
+}
+
+}  // namespace gpufl::launcher

--- a/daemon/launcher/trace_command_common.hpp
+++ b/daemon/launcher/trace_command_common.hpp
@@ -1,0 +1,43 @@
+#pragma once
+
+#include "cli_parse.hpp"
+
+#include <filesystem>
+#include <string>
+#include <vector>
+
+namespace gpufl::launcher {
+
+namespace fs = std::filesystem;
+
+struct TraceProcessResult {
+    int rc = 1;
+    bool signaled = false;
+    int signal = 0;
+    bool launcher_error = false;
+    std::string error;
+};
+
+class TracePlatform {
+   public:
+    virtual ~TracePlatform() = default;
+
+    virtual const char* platformName() const = 0;
+    virtual const char* injectLibraryName() const = 0;
+
+    virtual fs::path selfExe() const = 0;
+    virtual std::vector<fs::path> injectLibCandidates(const fs::path& exe) const = 0;
+    virtual fs::path defaultOutputDir(const std::string& tag) const = 0;
+    virtual std::string defaultAppName(const std::string& command0) const = 0;
+
+    virtual bool setEnv(const char* key, const std::string& value,
+                        std::string& error) const = 0;
+    virtual bool prepareInjectionEnv(const fs::path& inject_lib,
+                                     std::string& error) const = 0;
+    virtual TraceProcessResult runProcess(
+            const std::vector<std::string>& command) const = 0;
+};
+
+int runTraceCommon(const TraceArgs& args, const TracePlatform& platform);
+
+}  // namespace gpufl::launcher

--- a/daemon/launcher/trace_command_win.cpp
+++ b/daemon/launcher/trace_command_win.cpp
@@ -1,18 +1,5 @@
-// Windows implementation of `gpufl trace [opts] -- <command>...`.
-//
-//   1. Resolve gpufl_inject.dll adjacent to the launcher exe
-//      (GetModuleFileNameW instead of /proc/self/exe).
-//   2. Build the output dir (%USERPROFILE%\.gpufl\traces\{ts}_{sid}\ default).
-//   3. Set GPUFL_* + CUDA_INJECTION64_PATH + NVTX_INJECTION64_PATH so the
-//      driver loads the inject DLL and calls InitializeInjection.
-//      NOTE: no LD_PRELOAD — Windows has no preload symbol interposition,
-//      so the launch/sync interpose waits (the Linux early-kernel safety
-//      net) do NOT exist here; we rely purely on the CUDA injection ABI,
-//      which the driver invokes during cuInit, before the app's launches.
-//   4. CreateProcessW the target; WaitForSingleObject; GetExitCodeProcess.
-//   5. Print a one-line summary and return the target's exit code.
-//
-// Windows-only — selected by daemon/launcher/CMakeLists.txt on WIN32.
+// Windows implementation of the tiny platform layer behind `gpufl trace`.
+// The orchestration lives in trace_command_common.cpp.
 
 #include "trace_command.hpp"
 
@@ -24,137 +11,27 @@
 #endif
 #include <windows.h>
 
-#include <chrono>
 #include <cstdio>
 #include <cstdlib>
 #include <ctime>
 #include <filesystem>
-#include <iomanip>
-#include <random>
-#include <sstream>
 #include <string>
-#include <thread>
 #include <vector>
 
-#include "agent_launcher.hpp"
-#include "gpufl/core/env_vars.hpp"
-#include "gpufl/core/logger/file_compressor.hpp"
-#include "gpufl/inject/inject_entry.hpp"
-
-namespace fs = std::filesystem;
+#include "trace_command_common.hpp"
 
 namespace gpufl::launcher {
-
 namespace {
-
-// Absolute path of the running gpufl.exe.
-fs::path selfExe() {
-    wchar_t buf[32768];
-    const DWORD n = GetModuleFileNameW(nullptr, buf, static_cast<DWORD>(sizeof(buf) / sizeof(buf[0])));
-    if (n == 0 || n >= sizeof(buf) / sizeof(buf[0])) return {};
-    return fs::path(std::wstring(buf, n));
-}
-
-// Candidate paths for gpufl_inject.dll relative to the launcher binary,
-// in search order. The not-found error echoes every path tried.
-//
-// Build tree (VS): build\daemon\launcher\<Cfg>\gpufl.exe + the DLL is copied
-// next to it by the CMake POST_BUILD step, so "colocated" resolves first.
-// Install: bin\gpufl.exe + bin\gpufl_inject.dll (DLLs live beside the exe
-// on Windows, not in lib\).
-std::vector<fs::path> injectLibCandidates(const fs::path& exe) {
-    const fs::path dir = exe.parent_path();
-    const auto kName = L"gpufl_inject.dll";
-    return {
-        dir / kName,                                          // colocated (primary on Windows)
-        dir.parent_path() / kName,                            // one up
-        dir.parent_path().parent_path() / kName,              // two up
-        dir.parent_path().parent_path().parent_path() / kName,// three up (VS <Cfg> subdir)
-        dir.parent_path() / "bin" / kName,                    // ../bin
-        dir.parent_path().parent_path() / "bin" / kName,      // ../../bin
-    };
-}
-
-fs::path findInjectLib(const fs::path& exe) {
-    for (const auto& c : injectLibCandidates(exe)) {
-        if (std::error_code ec; fs::exists(c, ec)) return fs::weakly_canonical(c, ec);
-    }
-    return {};
-}
-
-std::string makeSessionId() {
-    static std::mt19937_64 rng{
-        static_cast<uint64_t>(
-            std::chrono::steady_clock::now().time_since_epoch().count())};
-    const uint64_t v = rng();
-    std::ostringstream os;
-    os << std::hex << std::setw(8) << std::setfill('0') << (v & 0xffffffffu);
-    return os.str();
-}
-
-// 128-bit UUID-shaped id shared by all passes of one multi-pass analysis.
-// Opaque to the backend (it only groups by string equality); makeSessionId's
-// 32 bits is fine for a local dir name but too narrow to group analyses on the
-// backend, so use full-width randomness here. (Mirrors the Linux launcher.)
-std::string makeAnalysisId() {
-    static std::mt19937_64 rng{
-        static_cast<uint64_t>(
-            std::chrono::steady_clock::now().time_since_epoch().count()) ^
-        0x9e3779b97f4a7c15ULL};
-    const uint64_t a = rng();
-    const uint64_t b = rng();
-    char buf[40];
-    std::snprintf(buf, sizeof(buf), "%08x-%04x-%04x-%04x-%012llx",
-                  static_cast<unsigned>(a >> 32),
-                  static_cast<unsigned>((a >> 16) & 0xffff),
-                  static_cast<unsigned>(a & 0xffff),
-                  static_cast<unsigned>((b >> 48) & 0xffff),
-                  static_cast<unsigned long long>(b & 0xffffffffffffULL));
-    return buf;
-}
 
 std::string makeTimestamp() {
     const auto t = std::time(nullptr);
     std::tm tm{};
-    localtime_s(&tm, &t);  // Windows: (tm*, time_t*) — reversed from POSIX
+    localtime_s(&tm, &t);
     char buf[32];
     std::strftime(buf, sizeof(buf), "%Y%m%d-%H%M%S", &tm);
     return buf;
 }
 
-fs::path defaultOutputDir(const std::string& session_id) {
-    fs::path root;
-    if (const char* up = std::getenv("USERPROFILE"); up && *up) {
-        root = fs::path(up);
-    } else if (const char* hd = std::getenv("HOMEDRIVE")) {
-        if (const char* hp = std::getenv("HOMEPATH")) root = fs::path(std::string(hd) + hp);
-    }
-    if (root.empty()) root = fs::temp_directory_path();
-    return root / ".gpufl" / "traces" / (makeTimestamp() + "_" + session_id);
-}
-
-std::string baseName(const std::string& path) {
-    const auto pos = path.find_last_of("/\\");  // accept either separator
-    std::string name = pos == std::string::npos ? path : path.substr(pos + 1);
-    // Drop a trailing .exe for a cleaner default session name.
-    if (name.size() > 4) {
-        const std::string ext = name.substr(name.size() - 4);
-        if (ext == ".exe" || ext == ".EXE") name.resize(name.size() - 4);
-    }
-    return name;
-}
-
-void setEnvOrDie(const char* k, const std::string& v) {
-    if (!SetEnvironmentVariableA(k, v.c_str())) {
-        std::fprintf(stderr, "gpufl: SetEnvironmentVariable %s failed (err=%lu)\n",
-                     k, static_cast<unsigned long>(GetLastError()));
-        std::exit(2);
-    }
-}
-
-// Quote one argument per the CommandLineToArgvW rules so CreateProcess
-// reconstructs argv exactly (handles spaces, quotes, trailing backslashes).
-// Algorithm per MSDN "Everyone quotes command line arguments the wrong way".
 void appendQuotedArg(const std::string& arg, std::string& cmd) {
     if (!arg.empty() && arg.find_first_of(" \t\n\v\"") == std::string::npos) {
         cmd += arg;
@@ -165,11 +42,11 @@ void appendQuotedArg(const std::string& arg, std::string& cmd) {
         unsigned backslashes = 0;
         while (it != arg.end() && *it == '\\') { ++it; ++backslashes; }
         if (it == arg.end()) {
-            cmd.append(backslashes * 2, '\\');  // escape all before closing quote
+            cmd.append(backslashes * 2, '\\');
             break;
         }
         if (*it == '"') {
-            cmd.append(backslashes * 2 + 1, '\\');  // escape backslashes + the quote
+            cmd.append(backslashes * 2 + 1, '\\');
             cmd += '"';
         } else {
             cmd.append(backslashes, '\\');
@@ -190,232 +67,93 @@ std::string buildCommandLine(const std::vector<std::string>& command) {
 
 std::wstring widen(const std::string& s) {
     if (s.empty()) return {};
-    const int n = MultiByteToWideChar(CP_ACP, 0, s.data(), static_cast<int>(s.size()), nullptr, 0);
+    const int n = MultiByteToWideChar(CP_ACP, 0, s.data(),
+                                      static_cast<int>(s.size()), nullptr, 0);
     std::wstring w(n, L'\0');
-    MultiByteToWideChar(CP_ACP, 0, s.data(), static_cast<int>(s.size()), w.data(), n);
+    MultiByteToWideChar(CP_ACP, 0, s.data(), static_cast<int>(s.size()),
+                        w.data(), n);
     return w;
 }
 
-int repairUncompressedLogs(const fs::path& root) {
-    std::error_code root_ec;
-    if (root.empty() || !fs::exists(root, root_ec)) return 0;
+class WindowsTracePlatform final : public TracePlatform {
+   public:
+    const char* platformName() const override { return "Windows"; }
+    const char* injectLibraryName() const override { return "gpufl_inject.dll"; }
 
-    GzipFileCompressor compressor;
-    int repaired = 0;
-    std::error_code iter_ec;
-    for (fs::recursive_directory_iterator it(root, fs::directory_options::skip_permission_denied, iter_ec), end;
-         !iter_ec && it != end;
-         it.increment(iter_ec)) {
-        std::error_code entry_ec;
-        if (!it->is_regular_file(entry_ec)) continue;
-        const fs::path path = it->path();
-        if (path.extension() != ".log") continue;
+    fs::path selfExe() const override {
+        wchar_t buf[32768];
+        const DWORD n = GetModuleFileNameW(
+                nullptr, buf, static_cast<DWORD>(sizeof(buf) / sizeof(buf[0])));
+        if (n == 0 || n >= sizeof(buf) / sizeof(buf[0])) return {};
+        return fs::path(std::wstring(buf, n));
+    }
 
-        std::error_code size_ec;
-        const auto size = fs::file_size(path, size_ec);
-        if (size_ec) continue;
-        if (size == 0) {
-            std::error_code remove_ec;
-            fs::remove(path, remove_ec);
-            continue;
-        }
+    std::vector<fs::path> injectLibCandidates(const fs::path& exe) const override {
+        const fs::path dir = exe.parent_path();
+        const auto kName = L"gpufl_inject.dll";
+        return {
+            dir / kName,                                           // colocated
+            dir.parent_path() / kName,                             // one up
+            dir.parent_path().parent_path() / kName,               // two up
+            dir.parent_path().parent_path().parent_path() / kName, // VS cfg dir
+            dir.parent_path() / "bin" / kName,                     // ../bin
+            dir.parent_path().parent_path() / "bin" / kName,       // ../../bin
+        };
+    }
 
-        const fs::path gz_path(path.string() + ".gz");
-        std::error_code exists_ec;
-        if (fs::exists(gz_path, exists_ec)) {
-            std::error_code remove_ec;
-            fs::remove(path, remove_ec);
-            continue;
-        }
-
-        if (compressor.compress(path.string())) {
-            ++repaired;
-            std::error_code remaining_ec;
-            if (fs::exists(path, remaining_ec)) {
-                std::error_code remove_ec;
-                fs::remove(path, remove_ec);
+    fs::path defaultOutputDir(const std::string& tag) const override {
+        fs::path root;
+        if (const char* up = std::getenv("USERPROFILE"); up && *up) {
+            root = fs::path(up);
+        } else if (const char* hd = std::getenv("HOMEDRIVE")) {
+            if (const char* hp = std::getenv("HOMEPATH")) {
+                root = fs::path(std::string(hd) + hp);
             }
         }
-    }
-    return repaired;
-}
-
-}  // namespace
-
-int runTrace(const TraceArgs& args) {
-    const fs::path exe = selfExe();
-    if (exe.empty()) {
-        std::fprintf(stderr, "gpufl: cannot resolve module path\n");
-        return 3;
+        if (root.empty()) root = fs::temp_directory_path();
+        return root / ".gpufl" / "traces" / (makeTimestamp() + "_" + tag);
     }
 
-    const fs::path inject_lib = findInjectLib(exe);
-    if (inject_lib.empty()) {
-        std::fprintf(stderr,
-                     "gpufl: cannot find gpufl_inject.dll adjacent to %s\n",
-                     exe.string().c_str());
-        std::fprintf(stderr, "       searched:\n");
-        for (const auto& c : injectLibCandidates(exe)) {
-            std::fprintf(stderr, "         %s\n", c.string().c_str());
+    std::string defaultAppName(const std::string& command0) const override {
+        const auto pos = command0.find_last_of("/\\");
+        std::string name = pos == std::string::npos ? command0 : command0.substr(pos + 1);
+        if (name.size() > 4) {
+            const std::string ext = name.substr(name.size() - 4);
+            if (ext == ".exe" || ext == ".EXE") name.resize(name.size() - 4);
         }
-        return 3;
+        return name;
     }
 
-    // Resolve the capture plan (explicit --passes, --passes=Deep expanded, or
-    // the default Trace pass) — the shared source of truth lives in cli_parse.
-    const std::vector<std::string> plan = resolvePassPlan(args);
-    const bool multipass = plan.size() > 1;
-
-    // One analysis_id shared by every pass lets the backend stitch the isolated
-    // passes into a single kernel view. Single-pass runs get none and keep the
-    // legacy {ts}_{sid} dir name.
-    const std::string analysis_id = multipass ? makeAnalysisId() : std::string();
-    const std::string dir_tag = multipass ? analysis_id : makeSessionId();
-
-    const fs::path output_dir = args.output_dir.empty()
-                              ? defaultOutputDir(dir_tag)
-                              : fs::path(args.output_dir);
-
-    std::error_code ec;
-    fs::create_directories(output_dir, ec);
-    if (ec) {
-        std::fprintf(stderr, "gpufl: cannot create %s: %s\n",
-                     output_dir.string().c_str(), ec.message().c_str());
-        return 2;
+    bool setEnv(const char* key, const std::string& value,
+                std::string& error) const override {
+        if (SetEnvironmentVariableA(key, value.c_str())) return true;
+        error = "SetEnvironmentVariable " + std::string(key) + " failed (err=" +
+                std::to_string(static_cast<unsigned long>(GetLastError())) + ")";
+        return false;
     }
-    const fs::path agent_output_dir = fs::weakly_canonical(output_dir, ec);
-    const fs::path upload_dir = ec ? output_dir : agent_output_dir;
 
-    const std::string app_name = args.name.empty()
-                               ? baseName(args.command.front())
-                               : args.name;
-
-    // When the driver loads gpufl_inject.dll into the target, the loader must
-    // resolve the DLL's own dependencies (cupti64*.dll, nvperf_host.dll —
-    // copied next to the DLL by the build). Prepend the inject DLL's directory
-    // to the child's PATH so they're found regardless of whether the driver
-    // uses LOAD_WITH_ALTERED_SEARCH_PATH. (OpenSSL is already on PATH; nvml is
-    // in System32.)
-    {
+    bool prepareInjectionEnv(const fs::path& inject_lib,
+                             std::string& error) const override {
         std::string path = inject_lib.parent_path().string();
         if (const char* prev = std::getenv("PATH"); prev && *prev) {
             path += ';';
             path += prev;
         }
-        setEnvOrDie("PATH", path);
+        return setEnv("PATH", path, error);
     }
 
-    // No LD_PRELOAD on Windows — the driver loads the DLL via the injection
-    // path. We still set both CUDA + NVTX injection vars to the same DLL.
-    // These (and the shared log dir) are set once and inherited by every
-    // child; each pass's process writes under its OWN session-id subdir, so
-    // the uploader discovers N sessions grouped by analysis_id.
-    setEnvOrDie(env::kCudaInjection64Path, inject_lib.string());
-    setEnvOrDie(env::kNvtxInjection64Path, inject_lib.string());
-    setEnvOrDie(env::kInject, "1");
-    setEnvOrDie(env::kAppName, app_name);
-    setEnvOrDie(env::kLogDir, output_dir.string());
-    setEnvOrDie(env::kInjectProfile, inject::kProfileComprehensive);
-    setEnvOrDie(env::kInjectUpload, "0");
+    TraceProcessResult runProcess(
+            const std::vector<std::string>& command) const override {
+        TraceProcessResult out;
 
-    AgentProcess agent;
-    if (args.upload) {
-        const fs::path cursor = args.agent_cursor.empty()
-                              ? upload_dir / "cursor.json"
-                              : fs::path(args.agent_cursor);
-
-        AgentOptions agent_opts;
-        agent_opts.source_folders = upload_dir.string();
-        agent_opts.log_types = args.log_types;
-        agent_opts.cursor_file = cursor.string();
-        agent_opts.backend_url = resolveOption(args.backend_url, gpufl::env::kBackendUrl);
-        agent_opts.api_key = resolveOption(args.api_key, gpufl::env::kApiKey);
-        agent_opts.api_version = args.api_version;
-        agent_opts.agent_jar = args.agent_jar;
-
-        std::string error;
-        if (!configureAgentEnvironment(agent_opts, error)) {
-            std::fprintf(stderr, "gpufl trace --upload: %s\n", error.c_str());
-            return 2;
-        }
-
-        AgentLaunchPlan plan;
-        if (!buildAgentLaunchPlan(agent_opts, plan, error)) {
-            std::fprintf(stderr, "gpufl trace --upload: %s\n", error.c_str());
-            return 2;
-        }
-        if (!args.quiet) {
-            std::fprintf(stderr, "[gpufl] starting agent: %s\n",
-                         plan.description.c_str());
-        }
-        if (!agent.start(plan.command, error)) {
-            std::fprintf(stderr, "gpufl trace --upload: %s\n", error.c_str());
-            return 3;
-        }
-    }
-
-    if (multipass) {
-        setEnvOrDie(env::kAnalysisId, analysis_id);
-        setEnvOrDie(env::kPassCount, std::to_string(plan.size()));
-    }
-
-    if (!args.quiet) {
-        std::fprintf(stderr, "[gpufl] capturing -> %s\n", output_dir.string().c_str());
-        if (multipass) {
-            std::fprintf(stderr, "[gpufl] multi-pass analysis %s - %zu passes:",
-                         analysis_id.c_str(), plan.size());
-            for (const auto& e : plan) std::fprintf(stderr, " %s", e.c_str());
-            std::fputc('\n', stderr);
-        }
-        if (args.verbose) {
-            std::fprintf(stderr, "[gpufl] inject dll: %s\n", inject_lib.string().c_str());
-            std::fprintf(stderr, "[gpufl] app_name: %s\n", app_name.c_str());
-        }
-    }
-
-    // ── Run the workload once per pass. A failing pass does NOT abort the
-    //    rest (a partial analysis still captures the passes that worked); the
-    //    first non-zero pass becomes the launcher's exit code. ──
-    int overall_rc = 0;
-    for (size_t i = 0; i < plan.size(); ++i) {
-        const std::string& engine = plan[i];
-
-        // Per-pass engine. The default no-flag path resolves to Trace.
-        setEnvOrDie(env::kProfilingEngine, engine);
-        if (multipass) {
-            setEnvOrDie(env::kPassIndex, std::to_string(i));
-        }
-
-        const std::string what =
-            multipass ? ("pass " + std::to_string(i + 1) + "/" +
-                         std::to_string(plan.size()) + " (" + engine + ")")
-                      : std::string("target");
-
-        if (!args.quiet && multipass) {
-            std::fprintf(stderr, "\n[gpufl] -- %s --\n", what.c_str());
-            if (engine == "PcSampling") {
-                std::fprintf(stderr,
-                    "[gpufl] note: PcSampling needs admin / NVIDIA CP \"allow GPU "
-                    "performance counters to all users\"; this pass reports \"needs "
-                    "admin\" and yields no PC data if unprivileged.\n");
-            }
-        }
-
-        // CreateProcessW wants a mutable command-line buffer and may modify it,
-        // so rebuild it per pass. lpApplicationName = null so the program is
-        // resolved from the command line (incl. PATH), mirroring execvp.
-        std::wstring cmdline = widen(buildCommandLine(args.command));
-        std::vector cmdbuf(cmdline.begin(), cmdline.end());
+        std::wstring cmdline = widen(buildCommandLine(command));
+        std::vector<wchar_t> cmdbuf(cmdline.begin(), cmdline.end());
         cmdbuf.push_back(L'\0');
 
         STARTUPINFOW si{};
         si.cb = sizeof(si);
         PROCESS_INFORMATION pi{};
 
-        const auto t_start = std::chrono::steady_clock::now();
-
-        // The env we set via SetEnvironmentVariable is inherited because
-        // lpEnvironment is null (child gets a copy of our environment block).
         if (!CreateProcessW(/*lpApplicationName=*/nullptr,
                             cmdbuf.data(),
                             /*procAttrs=*/nullptr, /*threadAttrs=*/nullptr,
@@ -424,10 +162,11 @@ int runTrace(const TraceArgs& args) {
                             /*lpEnvironment=*/nullptr,
                             /*lpCurrentDirectory=*/nullptr,
                             &si, &pi)) {
-            std::fprintf(stderr, "gpufl: cannot launch %s (CreateProcess err=%lu)\n",
-                         args.command.front().c_str(),
-                         static_cast<unsigned long>(GetLastError()));
-            return 2;
+            out.launcher_error = true;
+            out.rc = 2;
+            out.error = "cannot launch " + command.front() + " (CreateProcess err=" +
+                        std::to_string(static_cast<unsigned long>(GetLastError())) + ")";
+            return out;
         }
 
         WaitForSingleObject(pi.hProcess, INFINITE);
@@ -437,40 +176,15 @@ int runTrace(const TraceArgs& args) {
         CloseHandle(pi.hThread);
         CloseHandle(pi.hProcess);
 
-        const auto t_elapsed = std::chrono::duration_cast<std::chrono::milliseconds>(
-                             std::chrono::steady_clock::now() - t_start).count();
+        out.rc = static_cast<int>(exit_code);
+        return out;
+    }
+};
 
-        if (!args.quiet) {
-            std::fprintf(stderr, "[gpufl] %s exited (rc=%lu) in %.2fs\n",
-                         what.c_str(), static_cast<unsigned long>(exit_code),
-                         t_elapsed / 1000.0);
-        }
+}  // namespace
 
-        // First failing pass sets the exit code; keep going so later passes
-        // still run and the analysis is as complete as possible.
-        if (exit_code != 0 && overall_rc == 0)
-            overall_rc = static_cast<int>(exit_code);
-    }
-
-    if (!args.quiet) {
-        std::fprintf(stderr, "[gpufl] inspect: %s\n", output_dir.string().c_str());
-    }
-    if (args.upload && args.agent_drain_ms > 0) {
-        if (!args.quiet) {
-            std::fprintf(stderr, "[gpufl] waiting %.2fs for agent drain\n",
-                         args.agent_drain_ms / 1000.0);
-        }
-        std::this_thread::sleep_for(std::chrono::milliseconds(args.agent_drain_ms));
-    }
-    if (args.upload) {
-        agent.stop();
-    }
-    const int repaired_logs = repairUncompressedLogs(output_dir);
-    if (!args.quiet && repaired_logs > 0) {
-        std::fprintf(stderr, "[gpufl] compressed %d log file(s)\n", repaired_logs);
-    }
-
-    return overall_rc;
+int runTrace(const TraceArgs& args) {
+    return runTraceCommon(args, WindowsTracePlatform{});
 }
 
 }  // namespace gpufl::launcher

--- a/include/gpufl/upload/upload_logs.cpp
+++ b/include/gpufl/upload/upload_logs.cpp
@@ -257,6 +257,11 @@ std::vector<DiscoveredFile> discoverFiles(const PathParts& parts) {
         for (const auto& entry : fs::directory_iterator(session_entry.path(), ec)) {
             if (!entry.is_regular_file(ec)) continue;
             const std::string fname = entry.path().filename().string();
+            // Dot-files are never session data — notably a leftover
+            // .gpufl.synthetic-shutdown temp from an interrupted launcher
+            // marker append would otherwise parse as a bogus channel and
+            // re-upload the whole system log.
+            if (fname.empty() || fname.front() == '.') continue;
             DiscoveredFile df;
             if (!parseLogFilename(fname, df.channel, df.rotation_index, df.compressed)) {
                 continue;
@@ -656,7 +661,9 @@ std::string readFileBytes(const fs::path& p) {
 /// Decompressed size of a gzip stream from its ISIZE trailer (last 4
 /// bytes, little-endian, mod 2^32). Exact for our single-member files
 /// (the rotator caps them at Logger::kDefaultRotateBytes = 64 MiB, far
-/// under 4 GB). 0 = unknown/empty.
+/// under 4 GB) — but GARBAGE for a truncated file (the last 4 bytes are
+/// then mid-stream data, not a trailer), so a suspicious hint must be
+/// verified by verifyGzip() before acting on it. 0 = unknown/empty.
 std::size_t gzipDecompressedSizeHint(const std::string& gz) {
     if (gz.size() < 18) return 0;   // 10-byte header + 8-byte trailer
     const auto* p = reinterpret_cast<const unsigned char*>(gz.data()) + gz.size() - 4;
@@ -664,6 +671,49 @@ std::size_t gzipDecompressedSizeHint(const std::string& gz) {
            (static_cast<std::size_t>(p[1]) << 8) |
            (static_cast<std::size_t>(p[2]) << 16) |
            (static_cast<std::size_t>(p[3]) << 24);
+}
+
+/// Outcome of verifyGzip — only consulted when the ISIZE hint exceeds
+/// the size limit, which for our single-member rotated files means
+/// either a genuinely huge file or (far more likely) a TRUNCATED one
+/// from a killed session, whose trailer bytes are garbage.
+struct GzipVerifyResult {
+    bool ok      = false;   // decompresses cleanly within `limit`
+    bool corrupt = false;   // stream is truncated / not valid gzip
+};
+
+/// Stream-decompress `path` counting output bytes (nothing buffered).
+/// Distinguishes "actually too big" from "truncated/corrupt" so the
+/// user gets an honest message instead of a misleading size error.
+GzipVerifyResult verifyGzip(const fs::path& path, std::size_t limit) {
+    GzipVerifyResult out;
+    gzFile gz = gzopen(path.string().c_str(), "rb");
+    if (!gz) {
+        out.corrupt = true;
+        return out;
+    }
+    char buf[64 * 1024];
+    std::size_t total = 0;
+    int n;
+    while ((n = gzread(gz, buf, sizeof(buf))) > 0) {
+        total += static_cast<std::size_t>(n);
+        if (total > limit) {
+            gzclose(gz);
+            return out;   // genuinely too big (ok=false, corrupt=false)
+        }
+    }
+    // n == 0 → clean EOF; n < 0 → stream error (truncation lands here,
+    // and gzread also returns -1 mid-stream for an unexpected EOF).
+    if (n < 0) {
+        out.corrupt = true;
+    } else {
+        int errnum = Z_OK;
+        gzerror(gz, &errnum);
+        out.ok      = (errnum == Z_OK || errnum == Z_STREAM_END);
+        out.corrupt = !out.ok;
+    }
+    gzclose(gz);
+    return out;
 }
 
 /// Outcome of a single stream-chunk POST. Drives the retry / abort
@@ -1361,14 +1411,32 @@ UploadResult uploadLogs(const UploadOptions& opts) {
                 }
             }
             if (decompressed_bytes == 0) continue;   // empty file — nothing to send
-            if (body.size() > kMaxCompressedPostBytes ||
-                decompressed_bytes > kMaxDecompressedFileBytes) {
+            if (body.size() > kMaxCompressedPostBytes) {
                 result.warnings.push_back(
-                    basename + " is larger than the per-request limit (" +
-                    std::to_string(body.size()) + " B compressed / " +
-                    std::to_string(decompressed_bytes) + " B raw) — skipping");
+                    basename + " exceeds the per-request size limit (" +
+                    std::to_string(body.size()) + " B compressed) — skipping");
                 session_had_skips = true;
                 continue;
+            }
+            if (decompressed_bytes > kMaxDecompressedFileBytes) {
+                // For a .gz the size came from the ISIZE trailer, which is
+                // garbage on a truncated file (killed session) — verify by
+                // decompressing before refusing, so the warning tells the
+                // truth about WHICH problem this file has.
+                const GzipVerifyResult v = f.compressed
+                    ? verifyGzip(f.path, kMaxDecompressedFileBytes)
+                    : GzipVerifyResult{};
+                if (!v.ok) {
+                    result.warnings.push_back(v.corrupt
+                        ? basename + " is truncated or corrupt (incomplete gzip "
+                          "stream — likely a killed session); cannot upload"
+                        : basename + " exceeds the backend's decompressed size "
+                          "limit — skipping");
+                    session_had_skips = true;
+                    continue;
+                }
+                // Hint was garbage but the stream verifies clean and small —
+                // ship it.
             }
 
             bool skipped = false;


### PR DESCRIPTION
## Description
- Split `gpufl trace` orchestration into shared `trace_command_common` logic plus small POSIX/Windows platform adapters.
- Add launcher-side synthetic shutdown marker repair for trace sessions that exit without a client-written shutdown event.
- Preserve crash semantics by writing synthetic marker metadata: `exit_code`, `signaled`, `signal`, and `crashed`.
- Limit marker repair to sessions created during the current pass, so reused `--output` directories do not backfill old sessions.
- Optimize lifecycle scanning to prefer `system.log(.gz)` instead of scanning large device logs.
- Harden upload discovery by skipping dot-files to avoid temp log files being treated as uploadable channels.
## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Documentation update

## Testing
## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas