### PR TITLE
Enhance PcSampling to have kernel events data.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,6 +84,7 @@ target_sources(gpufl PRIVATE
     include/gpufl/core/sass_compressor.cpp
     include/gpufl/core/logger/logger.cpp
     include/gpufl/core/logger/log_rotator.cpp
+    include/gpufl/core/logger/log_salvage.cpp
     include/gpufl/core/logger/file_log_sink.cpp
     include/gpufl/upload/upload_logs.cpp
     include/gpufl/core/host_info.cpp

--- a/daemon/launcher/trace_command_common.cpp
+++ b/daemon/launcher/trace_command_common.cpp
@@ -22,6 +22,7 @@
 #include "gpufl/core/env_vars.hpp"
 #include "gpufl/core/json/json.hpp"
 #include "gpufl/core/logger/file_compressor.hpp"
+#include "gpufl/core/logger/log_salvage.hpp"
 #include "gpufl/inject/inject_entry.hpp"
 
 namespace gpufl::launcher {
@@ -360,8 +361,10 @@ int repairUncompressedLogs(const fs::path& root) {
     std::error_code root_ec;
     if (root.empty() || !fs::exists(root, root_ec)) return 0;
 
+    const auto salvaged = salvageSessionTempDirs(root);
+    int repaired = salvaged.salvaged;
+
     GzipFileCompressor compressor;
-    int repaired = 0;
     std::error_code iter_ec;
     for (fs::recursive_directory_iterator it(root, fs::directory_options::skip_permission_denied, iter_ec), end;
          !iter_ec && it != end;
@@ -369,6 +372,9 @@ int repairUncompressedLogs(const fs::path& root) {
         std::error_code entry_ec;
         if (!it->is_regular_file(entry_ec)) continue;
         const fs::path path = it->path();
+        // .tmp contents were handled by the salvage pass above; a dir
+        // that survived it is still held - leave it alone.
+        if (path.parent_path().filename() == ".tmp") continue;
         if (path.extension() != ".log") continue;
 
         std::error_code size_ec;
@@ -385,28 +391,25 @@ int repairUncompressedLogs(const fs::path& root) {
         if (fs::exists(gz_path, exists_ec)) {
             std::error_code remove_ec;
             if (!removeWithRetry(path, remove_ec)) {
-                std::fprintf(stderr,
-                             "[gpufl] warning: could not remove stale %s "
-                             "(%s) - its .gz holds the same data\n",
-                             path.string().c_str(),
-                             remove_ec.message().c_str());
+                // Held without delete sharing - truncate so the data
+                // exists only in the .gz; the empty husk is swept by a
+                // later pass once the holder lets go.
+                std::ofstream trunc(path, std::ios::out | std::ios::trunc);
+                if (!trunc) {
+                    std::fprintf(stderr,
+                                 "[gpufl] warning: could not remove stale %s "
+                                 "(%s) - its .gz holds the same data\n",
+                                 path.string().c_str(),
+                                 remove_ec.message().c_str());
+                }
             }
             continue;
         }
 
         if (compressor.compress(path.string())) {
+            // compress() removes (or truncates) the original itself and
+            // logs when it can't - nothing left to do here.
             ++repaired;
-            std::error_code remaining_ec;
-            if (fs::exists(path, remaining_ec)) {
-                std::error_code remove_ec;
-                if (!removeWithRetry(path, remove_ec)) {
-                    std::fprintf(stderr,
-                                 "[gpufl] warning: could not remove %s after "
-                                 "compressing (%s)\n",
-                                 path.string().c_str(),
-                                 remove_ec.message().c_str());
-                }
-            }
         }
     }
     return repaired;

--- a/daemon/launcher/trace_command_win.cpp
+++ b/daemon/launcher/trace_command_win.cpp
@@ -153,15 +153,28 @@ class WindowsTracePlatform final : public TracePlatform {
         STARTUPINFOW si{};
         si.cb = sizeof(si);
         PROCESS_INFORMATION pi{};
+        HANDLE job = CreateJobObjectW(nullptr, nullptr);
+        if (job) {
+            JOBOBJECT_EXTENDED_LIMIT_INFORMATION limits{};
+            limits.BasicLimitInformation.LimitFlags =
+                    JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+            if (!SetInformationJobObject(
+                    job, JobObjectExtendedLimitInformation, &limits,
+                    sizeof(limits))) {
+                CloseHandle(job);
+                job = nullptr;
+            }
+        }
 
         if (!CreateProcessW(/*lpApplicationName=*/nullptr,
                             cmdbuf.data(),
                             /*procAttrs=*/nullptr, /*threadAttrs=*/nullptr,
                             /*inheritHandles=*/TRUE,
-                            /*creationFlags=*/0,
+                            /*creationFlags=*/CREATE_SUSPENDED,
                             /*lpEnvironment=*/nullptr,
                             /*lpCurrentDirectory=*/nullptr,
                             &si, &pi)) {
+            if (job) CloseHandle(job);
             out.launcher_error = true;
             out.rc = 2;
             out.error = "cannot launch " + command.front() + " (CreateProcess err=" +
@@ -169,12 +182,19 @@ class WindowsTracePlatform final : public TracePlatform {
             return out;
         }
 
+        if (job && !AssignProcessToJobObject(job, pi.hProcess)) {
+            CloseHandle(job);
+            job = nullptr;
+        }
+        ResumeThread(pi.hThread);
+
         WaitForSingleObject(pi.hProcess, INFINITE);
 
         DWORD exit_code = 1;
         GetExitCodeProcess(pi.hProcess, &exit_code);
         CloseHandle(pi.hThread);
         CloseHandle(pi.hProcess);
+        if (job) CloseHandle(job);
 
         out.rc = static_cast<int>(exit_code);
         return out;

--- a/include/gpufl/backends/nvidia/engine/pc_sampling_engine.cpp
+++ b/include/gpufl/backends/nvidia/engine/pc_sampling_engine.cpp
@@ -9,6 +9,7 @@
 #include <chrono>
 #include <cstdio>
 #include <cstdlib>
+#include <cstring>
 #include <iostream>
 #include <thread>
 
@@ -17,6 +18,7 @@
 #include "gpufl/core/activity_record.hpp"
 #include "gpufl/core/common.hpp"
 #include "gpufl/core/debug_logger.hpp"
+#include "gpufl/core/env_vars.hpp"
 #include "gpufl/core/ring_buffer.hpp"
 #include "gpufl/core/teardown_flag.hpp"
 
@@ -144,7 +146,18 @@ bool PcSamplingEngine::initialize(const MonitorOptions& opts,
     sampling_api_ready_.store(false);
     sampling_api_started_.store(false);
     sampling_api_blocked_.store(false);
-    GFL_LOG_DEBUG("[PcSamplingEngine] initialized");
+
+    // Kernel-timeline collection mode. PC/SASS already has launch-callback
+    // kernel rows, so keep the periodic CUPTI path light by default; the
+    // stop/flush/start drain is useful for experiments but has proven timing
+    // sensitive with some PyTorch/CUPTI combinations.
+    kernel_collect_ = KernelCollect::None;
+    if (const char* v = std::getenv(env::kPcKernelCollect)) {
+        if (std::strcmp(v, "all") == 0) kernel_collect_ = KernelCollect::All;
+        else if (std::strcmp(v, "none") == 0) kernel_collect_ = KernelCollect::None;
+    }
+    GFL_LOG_DEBUG("[PcSamplingEngine] initialized (kernel_collect=",
+                  static_cast<int>(kernel_collect_), ")");
     return true;
 }
 
@@ -211,9 +224,11 @@ void PcSamplingEngine::start() {
 
 void PcSamplingEngine::StartCycleThread_() {
     if (cycle_thread_running_.exchange(true)) return;
-    // First cycle waits a full interval - collecting 250 ms after arming
-    // would split the warmup into a tiny first batch for nothing.
-    last_cycle_ns_.store(detail::GetTimestampNs(), std::memory_order_relaxed);
+    // Let the first plain-thread drain happen on the first 250 ms tick. The
+    // final Windows-injected teardown path cannot safely flush activity, so
+    // waiting a whole second here drops short sessions.
+    last_kernel_drain_ns_.store(0, std::memory_order_relaxed);
+    last_sample_collect_ns_.store(0, std::memory_order_relaxed);
     GFL_LOG_DEBUG("[PC Sampling] launching collection cycle thread");
     cycle_thread_ = std::thread([this] {
         GFL_LOG_DEBUG("[PC Sampling] cycle thread running");
@@ -260,13 +275,11 @@ void PcSamplingEngine::stop() {
 }
 
 void PcSamplingEngine::drainData() {
-    // Periodic armed-GetData on the engine's cycle thread. Deferring ALL
-    // collection to session stop loses the whole session on Windows-
-    // injected runs: by then process-exit teardown is underway and the
-    // PCSampling data calls fail with CUPTI_ERROR_UNKNOWN. Collecting here
-    // (and on launch ticks - shared throttle) bounds the loss to one
-    // window. No PCSamplingStop mid-run: sampling stays armed and GetData
-    // returns completed kernels' samples (KERNEL_SERIALIZED).
+    // Periodic collection on the engine's cycle thread (deferring all of it to
+    // session stop loses the session to process-exit teardown). Two paths by
+    // kernel_collect_: light = armed GetData (no Stop; KERNEL_SERIALIZED still
+    // returns completed kernels' samples); heavy = DrainKernelsAndCollect_,
+    // which Stops to force a kernel-activity flush for a full timeline.
     if (pc_sampling_method_ != Method::SamplingAPI) return;
     if (!sampling_api_started_.load()) return;
 
@@ -275,7 +288,58 @@ void PcSamplingEngine::drainData() {
     if (!ctx_.cuda_ctx) return;
     if (cuCtxSetCurrent(ctx_.cuda_ctx) != CUDA_SUCCESS) return;
 
-    MaybePeriodicCollect_("cycle", /*force=*/false);
+    // Drain kernel activity (heavy: stop->flush->start) only when explicitly
+    // requested; otherwise just collect PC samples (light).
+    const bool want_drain =
+        kernel_collect_ == KernelCollect::All &&
+        !drain_unavailable_.load(std::memory_order_relaxed);
+    if (want_drain) {
+        DrainKernelsAndCollect_();
+    } else {
+        MaybePeriodicCollect_("cycle", /*force=*/false);
+    }
+}
+
+void PcSamplingEngine::DrainKernelsAndCollect_() {
+    const int64_t now = detail::GetTimestampNs();
+    const int64_t last = last_kernel_drain_ns_.load(std::memory_order_relaxed);
+    if (last != 0 && now - last < kCollectIntervalNs) return;
+    if (!sampling_lifecycle_mu_.try_lock()) return;
+    std::lock_guard lk(sampling_lifecycle_mu_, std::adopt_lock);
+    if (!sampling_api_started_.load()) return;
+    last_kernel_drain_ns_.store(now, std::memory_order_relaxed);
+
+    // Stop sampling: required because a forced activity flush returns zero
+    // kernel records while PC sampling is armed (driver 590+). Stop/Start
+    // mid-run are privileged (INSUFFICIENT_PRIVILEGES under a non-elevated
+    // run) — on that error, stop draining for the session and let armed
+    // GetData carry the PC samples. Restart after the flush; it succeeds
+    // even with kernels running (unlike the initial arm).
+    CUpti_PCSamplingStopParams sp = {};
+    sp.size = sizeof(sp);
+    sp.ctx = ctx_.cuda_ctx;
+    const CUptiResult rStop = cuptiPCSamplingStop(&sp);
+    if (rStop != CUPTI_SUCCESS) {
+        if (IsInsufficientPrivilege(rStop)) {
+            drain_unavailable_.store(true, std::memory_order_relaxed);
+            GFL_LOG_DEBUG("[PC Sampling] kernel drain needs elevation (stop=",
+                          rStop, "); falling back to sample-only collection.");
+        }
+        return;  // sampling is still armed (Stop failed)
+    }
+
+    cuptiActivityFlushAll(CUPTI_ACTIVITY_FLAG_FLUSH_FORCED);
+    CollectPcSamplingData_();
+
+    CUpti_PCSamplingStartParams stp = {};
+    stp.size = sizeof(stp);
+    stp.ctx = ctx_.cuda_ctx;
+    if (const CUptiResult rStart = cuptiPCSamplingStart(&stp);
+        rStart != CUPTI_SUCCESS) {
+        sampling_api_started_.store(false);
+        LogCuptiErrorIfFailed(this->name(), "cuptiPCSamplingStart(drain-restart)",
+                              rStart);
+    }
 }
 
 void PcSamplingEngine::shutdown() {
@@ -558,7 +622,8 @@ void PcSamplingEngine::MaybePeriodicCollect_(const char* reason,
 
     if (!force) {
         const int64_t now = detail::GetTimestampNs();
-        const int64_t last = last_cycle_ns_.load(std::memory_order_relaxed);
+        const int64_t last =
+            last_sample_collect_ns_.load(std::memory_order_relaxed);
         if (last != 0 && now - last < kCollectIntervalNs) return;
     }
 
@@ -567,7 +632,8 @@ void PcSamplingEngine::MaybePeriodicCollect_(const char* reason,
     if (!sampling_lifecycle_mu_.try_lock()) return;
     std::lock_guard lk(sampling_lifecycle_mu_, std::adopt_lock);
     if (!sampling_api_started_.load()) return;
-    last_cycle_ns_.store(detail::GetTimestampNs(), std::memory_order_relaxed);
+    last_sample_collect_ns_.store(detail::GetTimestampNs(),
+                                  std::memory_order_relaxed);
 
     GFL_LOG_DEBUG("[PC Sampling] periodic collect (", reason ? reason : "?",
                   force ? ", forced" : "", ")");
@@ -739,6 +805,15 @@ void PcSamplingEngine::CollectPcSamplingData_() {
                             std::snprintf(out.function_name,
                                           sizeof(out.function_name), "%s",
                                           pc.functionName);
+                            if (std::strlen(pc.functionName) >=
+                                sizeof(out.function_name)) {
+                                GFL_LOG_DEBUG(
+                                    "[PC Sampling] function name truncated in "
+                                    "ActivityRecord; using original CUPTI "
+                                    "functionName for source correlation "
+                                    "(len=", std::strlen(pc.functionName),
+                                    ")");
+                            }
                         } else {
                             std::snprintf(out.function_name,
                                           sizeof(out.function_name), "unknown");
@@ -757,11 +832,12 @@ void PcSamplingEngine::CollectPcSamplingData_() {
                                 cubinSize = it->second.data.size();
                             }
                         }
-                        if (cubinData) {
+                        if (cubinData && cubinSize > 0 && pc.functionName &&
+                            pc.functionName[0] != '\0') {
                             GFL_LOG_DEBUG("start getting source correlation");
                             auto [fileName, dirName, lineNumber] =
                                 nvidia::CuptiSass::sampleSourceCorrelation(
-                                    cubinData, cubinSize, out.function_name,
+                                    cubinData, cubinSize, pc.functionName,
                                     pc.pcOffset);
                             if (!fileName.empty()) {
                                 const std::string fullPath =

--- a/include/gpufl/backends/nvidia/engine/pc_sampling_engine.hpp
+++ b/include/gpufl/backends/nvidia/engine/pc_sampling_engine.hpp
@@ -82,8 +82,19 @@ class PcSamplingEngine final : public IProfilingEngine {
         SamplingAPI, // cuptiPCSampling* API (newer GPUs)
     };
 
+    // Kernel-timeline collection strategy (GPUFL_PC_KERNEL_COLLECT).
+    enum class KernelCollect {
+        None,  // PC samples only; PC/SASS uses launch-callback kernel rows
+        All,   // experimental stop/flush/start drain every cycle
+    };
+
     bool EnableSamplingFeatures_();
     void StartPcSampling_();
+    /// One drain cycle on a plain thread (KernelCollect::All): stop → forced
+    /// activity flush (pulls kernel records that don't surface while sampling
+    /// is armed) → GetData → restart. Elevated-only; on a privilege failure it
+    /// disables draining for the session and falls back to armed GetData.
+    void DrainKernelsAndCollect_();
     /// @param sync_device cudaDeviceSynchronize before stopping. Callers on
     ///        plain threads pass true; the CUPTI-callback path passes false -
     ///        cudart inside a CUPTI callback can re-enter the driver, and in
@@ -114,6 +125,13 @@ class PcSamplingEngine final : public IProfilingEngine {
     std::atomic<bool> produced_data_{false};
     bool privilege_probed_ = false;
 
+    // Kernel-timeline collection mode, parsed once from GPUFL_PC_KERNEL_COLLECT
+    // in initialize(). drain_unavailable_ latches when a mid-run stop/flush
+    // returns INSUFFICIENT_PRIVILEGES so we stop retrying and degrade to
+    // armed-GetData (sample-only) collection.
+    KernelCollect kernel_collect_ = KernelCollect::None;
+    std::atomic<bool> drain_unavailable_{false};
+
     // Serializes the start/stop/collect lifecycle across its callers: the
     // engine's own cycle thread, scope-begin re-arms on app threads, and
     // session stop/shutdown. Without it a cycle's Stop could interleave
@@ -125,8 +143,13 @@ class PcSamplingEngine final : public IProfilingEngine {
     // cuptiPCSamplingStop, so this errs small; each collect is one
     // stop→GetData→start cycle (~sub-ms) on the app thread.
     static constexpr int64_t kCollectIntervalNs = 1'000'000'000;  // 1 s
-    // Last periodic collect (cycle), wall ns. 0 = none yet.
-    std::atomic<int64_t> last_cycle_ns_{0};
+    // Last sample-only GetData collect, wall ns. This is intentionally
+    // separate from last_kernel_drain_ns_: launch callbacks may sample often,
+    // but they must not starve the plain-thread stop/flush/start drain that
+    // pulls kernel activity records.
+    std::atomic<int64_t> last_sample_collect_ns_{0};
+    // Last kernel activity drain (stop -> flush -> start), wall ns.
+    std::atomic<int64_t> last_kernel_drain_ns_{0};
 
     // The engine owns its collection cadence: the monitor collector thread
     // (which calls drainData) spends whole sessions inside synchronous

--- a/include/gpufl/backends/nvidia/engine/pc_sampling_with_sass_engine.cpp
+++ b/include/gpufl/backends/nvidia/engine/pc_sampling_with_sass_engine.cpp
@@ -36,7 +36,7 @@ namespace {
 // PC sampling is always the fallback, so a Deep session is never unsafe.
 bool ShouldAttemptSassInDeep() {
     // Manual escape hatch: force PC-sampling-only regardless of hardware.
-    if (const char* e = std::getenv(gpufl::env::kDeepPcOnly);
+    if (const char* e = std::getenv(env::kDeepPcOnly);
         e && e[0] != '\0' && e[0] != '0') {
         return false;
     }

--- a/include/gpufl/backends/nvidia/sampler/cupti_sass.cpp
+++ b/include/gpufl/backends/nvidia/sampler/cupti_sass.cpp
@@ -3,6 +3,7 @@
 #include <cupti_pcsampling.h>
 
 #include <cstdlib>
+#include <cstring>
 
 #include "gpufl/core/debug_logger.hpp"
 
@@ -24,6 +25,15 @@ SourceCorrelation CuptiSass::sampleSourceCorrelation(const void* cubin,
                                                      size_t cubinSize,
                                                      const char* functionName,
                                                      uint64_t pcOffset) {
+    if (!cubin || cubinSize == 0 || !functionName || functionName[0] == '\0') {
+        GFL_LOG_ERROR(
+            "[SASS Metrics] skipping cuptiGetSassToSourceCorrelation: "
+            "invalid input (cubin=", cubin, ", cubinSize=", cubinSize,
+            ", functionName=", (functionName ? functionName : "<null>"),
+            ", pcOffset=", pcOffset, ")");
+        return {};
+    }
+
     CUpti_GetSassToSourceCorrelationParams params = {
         CUpti_GetSassToSourceCorrelationParamsSize};
     params.cubin = cubin;
@@ -36,7 +46,10 @@ SourceCorrelation CuptiSass::sampleSourceCorrelation(const void* cubin,
         const char* err;
         cuptiGetResultString(res, &err);
         GFL_LOG_ERROR("[SASS Metrics] cuptiGetSassToSourceCorrelation FAILED: ",
-                      err);
+                      err, " (cubin=", cubin, ", cubinSize=", cubinSize,
+                      ", functionNameLen=", std::strlen(functionName),
+                      ", pcOffset=", pcOffset, ", params.size=",
+                      params.size, ")");
         return {};
     }
 

--- a/include/gpufl/core/env_vars.hpp
+++ b/include/gpufl/core/env_vars.hpp
@@ -66,6 +66,15 @@ constexpr const char* kInjectUseConstructor = "GPUFL_INJECT_USE_CONSTRUCTOR";
 // embedding callers, but reachable for `gpufl trace` runs.
 constexpr const char* kDebugOutput          = "GPUFL_DEBUG";
 
+// Override the per-file log rotation threshold in bytes (default:
+// Logger::kDefaultRotateBytes = 64 MiB). Mainly for tests - a tiny value
+// exercises rotation without writing tens of MB.
+constexpr const char* kLogRotateBytes       = "GPUFL_LOG_ROTATE_BYTES";
+
+// Opt-in ("1", "true", "yes", "on"): flush each log line immediately.
+// Useful when diagnosing whether missing records are buffered in userspace.
+constexpr const char* kFlushLogsAlways      = "GPUFL_FLUSH_LOGS_ALWAYS";
+
 // ── Inject-lib timing knobs (tuning / debugging the injection lifecycle) ────
 constexpr const char* kInjectShutdownDelayMs = "GPUFL_INJECT_SHUTDOWN_DELAY_MS";
 constexpr const char* kInjectSyncWaitMs      = "GPUFL_INJECT_SYNC_WAIT_MS";
@@ -92,6 +101,15 @@ constexpr const char* kEagerModuleLoading = "GPUFL_EAGER_MODULE_LOADING";
 constexpr const char* kAnalysisId = "GPUFL_ANALYSIS_ID";
 constexpr const char* kPassIndex  = "GPUFL_PASS_INDEX";
 constexpr const char* kPassCount  = "GPUFL_PASS_COUNT";
+
+// PC sampling knobs ───────────────────────────────────────────────────────
+// Kernel-timeline collection strategy for the standalone PcSampling pass:
+//   "none" - PC samples only; PC/SASS kernel rows come from launch callbacks
+//            (default)
+//   "all"  - experimental mid-run stop->flush->start activity drain
+// Draining can be timing sensitive on some CUPTI/PyTorch combinations; on
+// privilege failures the engine falls back to sample-only collection.
+constexpr const char* kPcKernelCollect = "GPUFL_PC_KERNEL_COLLECT";
 
 // ── Deep engine knobs ───────────────────────────────────────────────────────
 constexpr const char* kDeepPcOnly  = "GPUFL_DEEP_PC_ONLY";

--- a/include/gpufl/core/gpufl.cpp
+++ b/include/gpufl/core/gpufl.cpp
@@ -325,6 +325,22 @@ bool init(const InitOptions& opts) {
     logOpts.session_id = rt->session_id;
     logOpts.system_sample_rate_ms = g_opts.system_sample_rate_ms;
     logOpts.flush_always = g_opts.flush_logs_always;
+    if (const char* v = std::getenv(env::kFlushLogsAlways)) {
+        std::string flag(v);
+        std::transform(flag.begin(), flag.end(), flag.begin(),
+                       [](unsigned char c) {
+                           return static_cast<char>(std::tolower(c));
+                       });
+        if (flag == "1" || flag == "true" || flag == "yes" ||
+            flag == "on") {
+            logOpts.flush_always = true;
+        }
+    }
+    if (const char* v = std::getenv(env::kLogRotateBytes)) {
+        if (const auto bytes = std::strtoull(v, nullptr, 10); bytes > 0) {
+            logOpts.rotate_bytes = static_cast<std::size_t>(bytes);
+        }
+    }
 
     g_lastLogPath = logPath;
     g_lastSessionId = rt->session_id;

--- a/include/gpufl/core/logger/file_compressor.cpp
+++ b/include/gpufl/core/logger/file_compressor.cpp
@@ -28,58 +28,70 @@ bool removeWithRetry(const fs::path& p, std::error_code& ec) {
 }
 }  // namespace
 
+bool GzipFileCompressor::compressTo(const std::string& src,
+                                    const std::string& dst) {
+    if (src.empty() || dst.empty()) return false;
+
+    std::ifstream in(src, std::ios::binary);
+    if (!in) return false;
+
+    gzFile gz = gzopen(dst.c_str(), "wb");
+    if (!gz) return false;
+
+    bool ok = true;
+    char buf[65536];
+    while (in) {
+        in.read(buf, sizeof(buf));
+        const auto n = static_cast<unsigned>(in.gcount());
+        if (n > 0 && gzwrite(gz, buf, n) != static_cast<int>(n)) {
+            ok = false;
+            break;
+        }
+    }
+    if (in.bad()) ok = false;
+    if (gzclose(gz) != Z_OK) ok = false;
+    if (!ok) {
+        std::error_code ec;
+        fs::remove(dst, ec);
+    }
+    return ok;
+}
+
 bool GzipFileCompressor::compress(const std::string& path) {
     if (path.empty()) return false;
 
     const std::string outPath = path + ".gz";
 
-    // Scope the input stream tightly so it's closed BEFORE we try to
-    // remove the source. On Windows, fs::remove fails with
-    // ERROR_SHARING_VIOLATION while any handle to the file is still
-    // open - which would leave the uncompressed source next to the
-    // new .gz, and the uploader would then read both and upload the
-    // same events twice. (Linux's unlink-while-open is forgiving so
-    // this only manifested on Windows, but the explicit scope is
-    // correct on every platform.)
-    bool ok = true;
-    {
-        std::ifstream in(path, std::ios::binary);
-        if (!in) return false;
-
-        gzFile gz = gzopen(outPath.c_str(), "wb");
-        if (!gz) return false;
-
-        char buf[65536];
-        while (in) {
-            in.read(buf, sizeof(buf));
-            const auto n = static_cast<unsigned>(in.gcount());
-            if (n > 0 && gzwrite(gz, buf, n) != static_cast<int>(n)) {
-                ok = false;
-                break;
-            }
-        }
-        gzclose(gz);
-        // in's dtor runs here, closing the source handle on every
-        // platform - safe to fs::remove below.
-    }
+    // compressTo only READS the source; its stream is closed before the
+    // remove below. On Windows, fs::remove fails with
+    // ERROR_SHARING_VIOLATION while any other handle to the file is
+    // open - which would leave the uncompressed source next to the new
+    // .gz, and the uploader would then read both and upload the same
+    // events twice.
+    const bool ok = compressTo(path, outPath);
+    if (!ok) return false;
 
     std::error_code ec;
-    if (ok) {
-        if (!removeWithRetry(path, ec)) {
-            // A holder outlived the retries (a tail, an editor, an AV
-            // scan, an uploader). The data is safe - the .gz is
-            // complete - but a stale .log now sits next to it; the
-            // launcher repair and the uploader's discovery both remove
-            // it later. Log it so the leftover is explainable.
+    if (!removeWithRetry(path, ec)) {
+        // A holder outlived the retries (a tail, an editor, an AV scan).
+        // Windows lets nobody delete a file held without delete sharing -
+        // but write sharing is common, so TRUNCATE the original instead:
+        // the data then exists exactly once (in the .gz) and the leftover
+        // is an empty husk that any later cleanup removes once the holder
+        // lets go.
+        std::ofstream trunc(path, std::ios::out | std::ios::trunc);
+        if (trunc) {
+            GFL_LOG_DEBUG("[Logger] compressed '", path,
+                          "' - original was held, truncated to empty "
+                          "instead of removed.");
+        } else {
             GFL_LOG_ERROR("[Logger] compressed '", path,
-                          "' but could not remove the original (",
-                          ec.message(),
+                          "' but could not remove or truncate the original "
+                          "(", ec.message(),
                           ") - stale .log left next to the .gz.");
         }
-    } else {
-        fs::remove(outPath, ec);
     }
-    return ok;
+    return true;
 }
 
 }  // namespace gpufl

--- a/include/gpufl/core/logger/file_compressor.hpp
+++ b/include/gpufl/core/logger/file_compressor.hpp
@@ -7,12 +7,19 @@ namespace gpufl {
 class IFileCompressor {
    public:
     virtual ~IFileCompressor() = default;
+    /// Compress `path` to `path + ".gz"` and remove (or truncate) the
+    /// original. Suited for files we own outright.
     virtual bool compress(const std::string& path) = 0;
+    /// Compress `src` into `dst` WITHOUT touching `src` - a pure read of
+    /// the source, so it succeeds even while another process holds it.
+    virtual bool compressTo(const std::string& src,
+                            const std::string& dst) = 0;
 };
 
 class GzipFileCompressor final : public IFileCompressor {
    public:
     bool compress(const std::string& path) override;
+    bool compressTo(const std::string& src, const std::string& dst) override;
 };
 
 }  // namespace gpufl

--- a/include/gpufl/core/logger/file_log_sink.cpp
+++ b/include/gpufl/core/logger/file_log_sink.cpp
@@ -5,6 +5,7 @@
 #include "gpufl/core/debug_logger.hpp"
 #include "gpufl/core/logger/file_compressor.hpp"
 #include "gpufl/core/logger/log_rotator.hpp"
+#include "gpufl/core/logger/log_salvage.hpp"
 
 namespace gpufl {
 namespace fs = std::filesystem;
@@ -188,6 +189,10 @@ FileLogSink::FileLogSink(const Logger::Options& opt) {
     chanDevice_ = std::make_unique<FileChannel>("device", opt);
     chanScope_  = std::make_unique<FileChannel>("scope",  opt);
     chanSystem_ = std::make_unique<FileChannel>("system", opt);
+    LogRotationOptions r{};
+    r.base_path = opt.base_path;
+    r.session_id = opt.session_id;
+    temp_dir_ = LogFileRotator(r, nullptr).tempDir();
 }
 
 FileLogSink::~FileLogSink() { close(); }
@@ -205,6 +210,29 @@ void FileLogSink::close() {
     chanDevice_.reset();
     chanScope_.reset();
     chanSystem_.reset();
+    // Every channel has exported and dropped its active file - the
+    // shared session temp dir can go now (loud on failure, swept by the
+    // launcher's salvage pass otherwise).
+    if (!temp_dir_.empty()) {
+        const fs::path session_dir = fs::path(temp_dir_).parent_path();
+        const auto salvage = salvageSessionTempDir(session_dir);
+        if (salvage.deferred > 0 || sessionTempDirHasDeferredData(session_dir)) {
+            GFL_LOG_ERROR("[Logger] session temp dir '", temp_dir_,
+                          "' still contains deferred log data (salvaged=",
+                          salvage.salvaged, ", deferred=", salvage.deferred,
+                          ") - leaving it for the next salvage pass.");
+            temp_dir_.clear();
+            return;
+        }
+        std::error_code ec;
+        fs::remove_all(temp_dir_, ec);
+        if (ec) {
+            GFL_LOG_ERROR("[Logger] could not remove session temp dir '",
+                          temp_dir_, "' (", ec.message(),
+                          ") - safe to delete once no process holds it.");
+        }
+        temp_dir_.clear();
+    }
 }
 
 FileLogSink::FileChannel* FileLogSink::resolveChannel(Channel ch) const {

--- a/include/gpufl/core/logger/file_log_sink.hpp
+++ b/include/gpufl/core/logger/file_log_sink.hpp
@@ -88,6 +88,9 @@ class FileLogSink final : public ILogSink {
     std::unique_ptr<FileChannel> chanDevice_;
     std::unique_ptr<FileChannel> chanScope_;
     std::unique_ptr<FileChannel> chanSystem_;
+    // The shared session `.tmp` dir, removed once in close() after every
+    // channel has finalized (its own actives would block earlier removal).
+    std::string temp_dir_;
 };
 
 }  // namespace gpufl

--- a/include/gpufl/core/logger/log_rotator.cpp
+++ b/include/gpufl/core/logger/log_rotator.cpp
@@ -1,8 +1,14 @@
 #include "gpufl/core/logger/log_rotator.hpp"
 
 #include <algorithm>
+#include <chrono>
 #include <filesystem>
+#include <fstream>
 #include <sstream>
+#include <thread>
+
+#include "gpufl/core/debug_logger.hpp"
+#include "gpufl/core/logger/log_salvage.hpp"
 
 namespace gpufl {
 namespace fs = std::filesystem;
@@ -24,9 +30,11 @@ std::string LogFileRotator::sessionDir() const {
     return p.string();
 }
 
+std::string LogFileRotator::tempDir() const { return sessionDir() + "/.tmp"; }
+
 std::string LogFileRotator::activePath() const {
     std::ostringstream oss;
-    oss << sessionDir() << "/" << opt_.channel_name << ".log";
+    oss << tempDir() << "/" << opt_.channel_name << ".log";
     return oss.str();
 }
 
@@ -36,70 +44,100 @@ std::string LogFileRotator::rotatedPath(std::size_t index) const {
     return oss.str();
 }
 
-void LogFileRotator::rotate() const {
-    const std::size_t maxFiles = std::max<std::size_t>(opt_.max_files, 1);
-    const std::string active = activePath();
-
-    {
-        const std::string oldest = rotatedPath(maxFiles);
-        std::error_code ec;
-        fs::remove(oldest, ec);
-        fs::remove(oldest + ".gz", ec);
-    }
-
-    for (std::size_t i = maxFiles; i > 1; --i) {
-        const std::string fromBase = rotatedPath(i - 1);
-        const std::string toBase = rotatedPath(i);
-        if (std::error_code ec; fs::exists(fromBase + ".gz", ec)) {
-            fs::rename(fromBase + ".gz", toBase + ".gz", ec);
-        } else if (fs::exists(fromBase, ec)) {
-            fs::rename(fromBase, toBase, ec);
-        }
-    }
-
-    {
-        const std::string rotated = rotatedPath(1);
-        if (std::error_code ec; fs::exists(active, ec)) {
-            fs::rename(active, rotated, ec);
-            if (opt_.compress_rotated && compressor_ && fs::exists(rotated, ec)) {
-                compressor_->compress(rotated);
-            }
-        }
-    }
-}
-
-void LogFileRotator::compressActive() const {
-    // Defensive guards. Each branch is a no-op rather than an error -
-    // compress-on-shutdown is best-effort: a session that crashed
-    // before opening any channel, or that opted out of compression,
-    // is still a valid session and shouldn't surface failure.
-    if (!opt_.compress_rotated) return;
-    if (!compressor_) return;
-
+LogFileRotator::ExportWindowResult LogFileRotator::exportWindow_() const {
     const std::string active = activePath();
     std::error_code ec;
-    if (!fs::exists(active, ec)) return;
+    if (!fs::exists(active, ec)) return ExportWindowResult::NoData;
+    if (fs::file_size(active, ec) == 0) return ExportWindowResult::NoData;
 
-    // Empty file → nothing useful to compress. Remove so the session
-    // dir doesn't leak a zero-byte .log alongside potentially-real
-    // .log.gz files from earlier rotations within the same session.
-    if (fs::file_size(active, ec) == 0) {
-        fs::remove(active, ec);
-        return;
+    // Append-style monotonic index (higher = newer). Published files and
+    // unpublished .tmp staging both count, so a failed publish cannot be
+    // overwritten by the next rotation.
+    const std::size_t next =
+        nextLogWindowIndex(fs::path(sessionDir()), opt_.channel_name);
+
+    if (!compressor_) {
+        const std::string target = rotatedPath(next);
+        fs::rename(active, target, ec);
+        if (ec) {
+            GFL_LOG_ERROR("[Logger] window export: publish failed for '",
+                          active, "' (", ec.message(),
+                          ") - deferred in the active file.");
+            return ExportWindowResult::DeferredInActive;
+        }
+        pruneLogWindows(fs::path(sessionDir()), opt_.channel_name,
+                        opt_.max_files);
+        return ExportWindowResult::Published;
     }
 
-    compressor_->compress(active);
+    const std::string target = rotatedPath(next) + ".gz";
+    std::ostringstream stg;
+    stg << tempDir() << "/" << opt_.channel_name << "." << next << ".log.gz";
+    const std::string staging = stg.str();
 
-    // Belt-and-suspenders: if compress() reports success but the
-    // source file is somehow still there (Windows file-locking edge
-    // case, async filesystem, etc.), force-remove it. Leaving both
-    // <channel>.log and <channel>.log.gz behind would cause the
-    // uploader to read both and upload duplicates. Better to lose a
-    // few bytes than emit two copies of every event.
-    std::error_code rm_ec;
-    if (fs::exists(active, rm_ec)) {
-        fs::remove(active, rm_ec);
+    // 1. gzip the active file into staging (inside .tmp) - a pure READ of
+    // the active file, immune to holders. The session root never sees a
+    // partial file.
+    if (!compressor_->compressTo(active, staging)) {
+        std::error_code rm_ec;
+        fs::remove(staging, rm_ec);
+        GFL_LOG_ERROR("[Logger] window export: compress failed for '", active,
+                      "' - deferred to the next write.");
+        return ExportWindowResult::DeferredInActive;
     }
+
+    // 2. Truncate the active file BEFORE publishing the export: if this
+    // is denied (holder without write sharing - rare), drop staging and
+    // defer. The data then exists exactly once, in the active file.
+    {
+        std::ofstream trunc(active, std::ios::out | std::ios::trunc);
+        if (!trunc) {
+            std::error_code rm_ec;
+            fs::remove(staging, rm_ec);
+            GFL_LOG_ERROR("[Logger] window export: truncate denied for '",
+                          active, "' - deferred to the next write.");
+            return ExportWindowResult::DeferredInActive;
+        }
+    }
+
+    // 3. Publish: staging → <channel>.<N>.log.gz in the session root.
+    // Consumers only ever see the finished file. If the rename is blocked
+    // (AV grabbing brand-new files), the data survives in staging and the
+    // launcher's salvage pass publishes it later.
+    bool published = false;
+    for (int attempt = 0; attempt < 3; ++attempt) {
+        fs::rename(staging, target, ec);
+        if (!ec) {
+            published = true;
+            break;
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(100 << attempt));
+    }
+    if (!published) {
+        GFL_LOG_ERROR("[Logger] window export: publish failed for '", staging,
+                      "' (", ec.message(),
+                      ") - left for the salvage pass.");
+        return ExportWindowResult::StagedForSalvage;
+    }
+
+    pruneLogWindows(fs::path(sessionDir()), opt_.channel_name, opt_.max_files);
+    return ExportWindowResult::Published;
 }
+
+void LogFileRotator::rotate() const { exportWindow_(); }
+
+void LogFileRotator::compressActive() const {
+    const ExportWindowResult result = exportWindow_();
+    // Best-effort removal of this channel's (now exported) active file.
+    // If exportWindow_ deferred in the active file, leave it for the salvage
+    // path instead of deleting the only copy of the window.
+    if (result == ExportWindowResult::DeferredInActive) return;
+    // The shared .tmp dir itself is removed once by FileLogSink::close()
+    // after EVERY channel has closed - other channels' actives are still
+    // open while the first one finalizes.
+    std::error_code ec;
+    fs::remove(activePath(), ec);
+}
+
 
 }  // namespace gpufl

--- a/include/gpufl/core/logger/log_rotator.hpp
+++ b/include/gpufl/core/logger/log_rotator.hpp
@@ -32,23 +32,47 @@ class LogFileRotator {
    public:
     LogFileRotator(LogRotationOptions opt, IFileCompressor* compressor);
 
+    /**
+     * The active file lives in the session's TEMP subdir
+     * (`<session>/.tmp/<channel>.log`), never in the session root. The
+     * root only ever receives FINISHED `.gz` files, exported atomically -
+     * so consumers (uploader, analyzer, UI) can read the session at any
+     * time without seeing half-written or stale-duplicate files, and an
+     * un-deletable leftover is an obviously-garbage `.tmp` dir instead of
+     * a data file that shadows real content.
+     */
     [[nodiscard]] std::string activePath() const;
-    void rotate()const;
 
     /**
-     * Compress the active `.log` file in place to `.log.gz` and remove
-     * the original. Called on clean shutdown (FileLogSink::close →
-     * Logger::close → gpufl::shutdown) so a finished session leaves
-     * behind only compressed files. No-op when:
-     *   - compress_rotated is false (caller opted out)
-     *   - the active file doesn't exist (never opened)
-     *   - a compressor isn't configured (defense)
+     * Export the current window. The active file is never renamed or
+     * deleted - operations on it are limited to READ (gzip) and TRUNCATE,
+     * which work even while another process holds the file:
+     *   1. gzip active → `.tmp/<channel>.<N>.log.gz` (staging, pure read)
+     *   2. truncate active (restart the window)
+     *   3. move staging → `<session>/<channel>.<N>.log.gz` (fresh name at
+     *      a monotonic index - no shifting, no overwrite hazard)
+     * Any failed step logs and defers: data stays exactly-once (in the
+     * active file or in staging, both inside `.tmp`, which consumers
+     * ignore), and the next write or the launcher's salvage pass retries.
+     */
+    void rotate() const;
+
+    /**
+     * Finalize this channel on clean shutdown (FileLogSink::close →
+     * Logger::close → gpufl::shutdown): export the last window like
+     * rotate() and drop the channel's active file. The shared `.tmp` dir
+     * is removed separately via removeTempDir() once all channels closed.
      *
-     * On crash (i.e. shutdown never runs), the uncompressed .log is
-     * left intact - the uploader lazily compresses on first read so
-     * the on-wire format is uniform.
+     * On crash (shutdown never runs) the active `.log` stays in `.tmp` -
+     * the launcher repair / uploader salvage exports it on first sight.
      */
     void compressActive() const;
+
+    /**
+     * The session temp dir: `<base_path>/<session_id>/.tmp`. Removed
+     * wholesale by FileLogSink::close() after every channel finalized.
+     */
+    [[nodiscard]] std::string tempDir() const;
 
    private:
     /**
@@ -57,6 +81,16 @@ class LogFileRotator {
      */
     [[nodiscard]] std::string sessionDir() const;
     [[nodiscard]] std::string rotatedPath(std::size_t index) const;
+
+    enum class ExportWindowResult {
+        NoData,
+        Published,
+        StagedForSalvage,
+        DeferredInActive,
+    };
+
+    /** Shared body of rotate()/compressActive(). */
+    ExportWindowResult exportWindow_() const;
 
     LogRotationOptions opt_;
     IFileCompressor* compressor_ = nullptr;  // non-owning

--- a/include/gpufl/core/logger/log_salvage.cpp
+++ b/include/gpufl/core/logger/log_salvage.cpp
@@ -1,0 +1,255 @@
+#include "gpufl/core/logger/log_salvage.hpp"
+
+#include <algorithm>
+#include <fstream>
+#include <set>
+#include <system_error>
+#include <vector>
+
+#include "gpufl/core/logger/file_compressor.hpp"
+
+namespace gpufl {
+namespace fs = std::filesystem;
+namespace {
+
+bool parseWindowName(const std::string& filename,
+                     std::string& channel,
+                     std::size_t& index,
+                     bool& compressed) {
+    std::string rest = filename;
+    compressed = false;
+    if (rest.size() > 3 && rest.compare(rest.size() - 3, 3, ".gz") == 0) {
+        compressed = true;
+        rest.erase(rest.size() - 3);
+    }
+    if (rest.size() <= 4 || rest.compare(rest.size() - 4, 4, ".log") != 0) {
+        return false;
+    }
+    rest.erase(rest.size() - 4);
+
+    const auto dot = rest.find_last_of('.');
+    if (dot == std::string::npos) {
+        channel = rest;
+        index = 0;
+        return !channel.empty();
+    }
+    try {
+        const auto parsed = std::stoull(rest.substr(dot + 1));
+        if (parsed == 0) return false;
+        channel = rest.substr(0, dot);
+        index = static_cast<std::size_t>(parsed);
+        return !channel.empty();
+    } catch (...) {
+        channel = rest;
+        index = 0;
+        return !channel.empty();
+    }
+}
+
+void scanMaxIndex(const fs::path& dir,
+                  const std::string& channel,
+                  std::size_t& max_index) {
+    std::error_code ec;
+    if (!fs::exists(dir, ec) || !fs::is_directory(dir, ec)) return;
+    for (const auto& entry : fs::directory_iterator(dir, ec)) {
+        std::error_code e_ec;
+        if (!entry.is_regular_file(e_ec)) continue;
+        std::string ch;
+        std::size_t idx = 0;
+        bool compressed = false;
+        if (!parseWindowName(entry.path().filename().string(), ch, idx,
+                             compressed)) {
+            continue;
+        }
+        if (ch == channel && idx > max_index) max_index = idx;
+    }
+}
+
+std::vector<std::size_t> publishedWindowIndices(const fs::path& session_dir,
+                                                const std::string& channel) {
+    std::set<std::size_t> indices;
+    std::error_code ec;
+    if (!fs::exists(session_dir, ec) || !fs::is_directory(session_dir, ec)) {
+        return {};
+    }
+    for (const auto& entry : fs::directory_iterator(session_dir, ec)) {
+        std::error_code e_ec;
+        if (!entry.is_regular_file(e_ec)) continue;
+        std::string ch;
+        std::size_t idx = 0;
+        bool compressed = false;
+        if (parseWindowName(entry.path().filename().string(), ch, idx,
+                            compressed) &&
+            ch == channel && idx > 0) {
+            indices.insert(idx);
+        }
+    }
+    return {indices.begin(), indices.end()};
+}
+
+bool removeOrTruncate(const fs::path& p) {
+    std::error_code ec;
+    fs::remove(p, ec);
+    if (!ec || !fs::exists(p, ec)) return true;
+
+    std::ofstream trunc(p, std::ios::out | std::ios::trunc);
+    return static_cast<bool>(trunc);
+}
+
+bool tempDirHasDeferredData(const fs::path& tmp) {
+    std::error_code ec;
+    if (!fs::exists(tmp, ec) || !fs::is_directory(tmp, ec)) return false;
+
+    for (const auto& entry : fs::directory_iterator(tmp, ec)) {
+        std::error_code e_ec;
+        if (!entry.is_regular_file(e_ec)) continue;
+        const auto size = fs::file_size(entry.path(), e_ec);
+        if (e_ec || size > 0) return true;
+
+        std::error_code rm_ec;
+        fs::remove(entry.path(), rm_ec);
+    }
+    return ec != std::error_code{};
+}
+
+void removeTempDirIfClean(const fs::path& tmp) {
+    if (tempDirHasDeferredData(tmp)) return;
+    std::error_code ec;
+    fs::remove_all(tmp, ec);
+}
+
+}  // namespace
+
+std::size_t nextLogWindowIndex(const fs::path& session_dir,
+                               const std::string& channel) {
+    std::size_t max_index = 0;
+    scanMaxIndex(session_dir, channel, max_index);
+    scanMaxIndex(session_dir / ".tmp", channel, max_index);
+    return max_index + 1;
+}
+
+void pruneLogWindows(const fs::path& session_dir,
+                     const std::string& channel,
+                     const std::size_t max_files) {
+    if (max_files == 0) return;
+    auto indices = publishedWindowIndices(session_dir, channel);
+    if (indices.size() <= max_files) return;
+    const std::size_t remove_count = indices.size() - max_files;
+    for (std::size_t i = 0; i < remove_count; ++i) {
+        const auto idx = indices[i];
+        const fs::path base =
+            session_dir / (channel + "." + std::to_string(idx) + ".log");
+        std::error_code ec;
+        fs::remove(base, ec);
+        fs::remove(base.string() + ".gz", ec);
+    }
+}
+
+LogSalvageResult salvageSessionTempDir(const fs::path& session_dir) {
+    LogSalvageResult result;
+    const fs::path tmp = session_dir / ".tmp";
+    std::error_code ec;
+    if (!fs::exists(tmp, ec) || !fs::is_directory(tmp, ec)) return result;
+
+    std::vector<fs::path> entries;
+    for (const auto& entry : fs::directory_iterator(tmp, ec)) {
+        std::error_code e_ec;
+        if (entry.is_regular_file(e_ec)) entries.push_back(entry.path());
+    }
+    std::sort(entries.begin(), entries.end());
+
+    GzipFileCompressor compressor;
+    bool staged_publish_blocked = false;
+    for (const auto& path : entries) {
+        std::error_code e_ec;
+        if (!fs::exists(path, e_ec) || !fs::is_regular_file(path, e_ec)) {
+            continue;
+        }
+
+        std::string channel;
+        std::size_t idx = 0;
+        bool compressed = false;
+        const std::string name = path.filename().string();
+        if (!parseWindowName(name, channel, idx, compressed)) {
+            ++result.deferred;
+            continue;
+        }
+
+        if (compressed) {
+            if (idx == 0) idx = nextLogWindowIndex(session_dir, channel);
+            fs::path target =
+                session_dir /
+                (channel + "." + std::to_string(idx) + ".log.gz");
+            if (fs::exists(target, e_ec)) {
+                idx = nextLogWindowIndex(session_dir, channel);
+                target = session_dir /
+                         (channel + "." + std::to_string(idx) + ".log.gz");
+            }
+            std::error_code mv_ec;
+            fs::rename(path, target, mv_ec);
+            if (mv_ec) {
+                ++result.deferred;
+                staged_publish_blocked = true;
+            } else {
+                ++result.salvaged;
+            }
+            continue;
+        }
+
+        if (staged_publish_blocked) {
+            ++result.deferred;
+            continue;
+        }
+
+        std::error_code sz_ec;
+        const auto size = fs::file_size(path, sz_ec);
+        if (sz_ec) {
+            ++result.deferred;
+            continue;
+        }
+        if (size == 0) {
+            std::error_code rm_ec;
+            fs::remove(path, rm_ec);
+            continue;
+        }
+
+        idx = nextLogWindowIndex(session_dir, channel);
+        const fs::path target =
+            session_dir / (channel + "." + std::to_string(idx) + ".log.gz");
+        if (!compressor.compressTo(path.string(), target.string())) {
+            ++result.deferred;
+            std::error_code rm_ec;
+            fs::remove(target, rm_ec);
+            continue;
+        }
+        ++result.salvaged;
+        if (!removeOrTruncate(path)) ++result.deferred;
+    }
+
+    if (result.deferred == 0) {
+        removeTempDirIfClean(tmp);
+    }
+    return result;
+}
+
+LogSalvageResult salvageSessionTempDirs(const fs::path& root) {
+    LogSalvageResult total;
+    std::error_code ec;
+    if (root.empty() || !fs::exists(root, ec) || !fs::is_directory(root, ec)) {
+        return total;
+    }
+    for (const auto& session : fs::directory_iterator(root, ec)) {
+        std::error_code s_ec;
+        if (!session.is_directory(s_ec)) continue;
+        const auto r = salvageSessionTempDir(session.path());
+        total.salvaged += r.salvaged;
+        total.deferred += r.deferred;
+    }
+    return total;
+}
+
+bool sessionTempDirHasDeferredData(const fs::path& session_dir) {
+    return tempDirHasDeferredData(session_dir / ".tmp");
+}
+
+}  // namespace gpufl

--- a/include/gpufl/core/logger/log_salvage.hpp
+++ b/include/gpufl/core/logger/log_salvage.hpp
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <cstddef>
+#include <filesystem>
+#include <string>
+
+namespace gpufl {
+
+struct LogSalvageResult {
+    int salvaged = 0;
+    int deferred = 0;
+};
+
+/**
+ * Return the next append-style window index for `channel` in a session.
+ * Both published root files and unpublished `.tmp` staging files count, so
+ * a failed publish cannot be overwritten by the next rotation.
+ */
+std::size_t nextLogWindowIndex(const std::filesystem::path& session_dir,
+                               const std::string& channel);
+
+/** Remove oldest published windows once more than `max_files` exist. */
+void pruneLogWindows(const std::filesystem::path& session_dir,
+                     const std::string& channel,
+                     std::size_t max_files);
+
+/** Publish staged `.tmp/*.log.gz` files and export non-empty `.tmp/*.log`. */
+LogSalvageResult salvageSessionTempDir(
+    const std::filesystem::path& session_dir);
+
+/** Apply salvageSessionTempDir() to each session directory under `root`. */
+LogSalvageResult salvageSessionTempDirs(
+    const std::filesystem::path& root);
+
+/** True when a session `.tmp` directory still holds uploadable data. */
+bool sessionTempDirHasDeferredData(
+    const std::filesystem::path& session_dir);
+
+}  // namespace gpufl

--- a/include/gpufl/core/monitor.cpp
+++ b/include/gpufl/core/monitor.cpp
@@ -144,22 +144,30 @@ static BatchBuffer<MemoryAllocEventBatchRow>     g_memAllocBatch;
 static uint64_t g_syncBatchId     = 0;
 static uint64_t g_memAllocBatchId = 0;
 
-static void flushBatches(Logger& logger, const std::string& session_id) {
+enum class FlushBatchesMode {
+    Fast,
+    Full,
+};
+
+static void flushBatches(Logger& logger, const std::string& session_id,
+                         FlushBatchesMode mode = FlushBatchesMode::Fast) {
     // Dictionary MUST be written before any batch that references its
     // name_id / kernel_id / function_id / metric_id entries, otherwise
     // readers see rows that reference undefined dictionary IDs.
     //
-    // We call flushDictionary twice: once at the top for source content
-    // and disassembly (which also reference dict IDs but are rare), and
-    // again immediately before each batch emission. This closes a race
-    // where the app thread could intern a new scope name AFTER the
-    // initial flushDictionary call but BEFORE the batch flush - the
+    // We call flushDictionary at the top for any full-mode source content
+    // and disassembly (which also reference dict IDs), and again immediately
+    // before each batch emission. This closes a race where the app thread
+    // could intern a new scope name AFTER the initial flushDictionary call
+    // but BEFORE the batch flush - the
     // new name would be pushed into g_scopeBatch but remain dirty in
     // the dict, producing an ordering bug where scope_event_batch
     // references name_ids 2-5 before their dict_update is emitted.
     g_dictManager.flushDictionary(logger, session_id);
-    g_dictManager.flushSourceContent(logger, session_id);
-    g_dictManager.flushDisassembly(logger, session_id);
+    if (mode == FlushBatchesMode::Full) {
+        g_dictManager.flushSourceContent(logger, session_id);
+        g_dictManager.flushDisassembly(logger, session_id);
+    }
     if (!g_kernelBatch.empty()) {
         g_dictManager.flushDictionary(logger, session_id);
         logger.write(model::KernelEventBatchModel(
@@ -818,7 +826,7 @@ void CollectorLoop() {
     if (Runtime* rt = runtime(); rt && rt->logger) {
         drainSyntheticKernels(rt);
         emitExecutionSignatures(rt);
-        flushBatches(*rt->logger, rt->session_id);
+        flushBatches(*rt->logger, rt->session_id, FlushBatchesMode::Full);
     }
     GFL_LOG_DEBUG("[CollectorLoop] END");
 }
@@ -827,6 +835,7 @@ void Monitor::Initialize(const MonitorOptions& opts) {
     if (g_initialized.exchange(true)) return;
 
     // Reset batch state for this session
+    g_monitorBuffer.resetDroppedCount();
     g_dictManager.reset();
     g_dictManager.enable_source_collection = opts.enable_source_collection;
     g_kernelBatch.clear();
@@ -902,9 +911,15 @@ void Monitor::Shutdown() {
             // when CollectorLoop already drained them - the map is cleared.
             drainSyntheticKernels(rt);
             emitExecutionSignatures(rt);
-            flushBatches(*rt->logger, rt->session_id);
+            flushBatches(*rt->logger, rt->session_id, FlushBatchesMode::Full);
         }
         GFL_LOG_DEBUG("Monitor::Shutdown: post-join drained=", drained);
+    }
+
+    if (const size_t dropped = g_monitorBuffer.resetDroppedCount();
+        dropped > 0) {
+        GFL_LOG_ERROR("Monitor::Shutdown: dropped ", dropped,
+                      " monitor record(s) due to ring-buffer backpressure");
     }
 
     GFL_LOG_DEBUG("Monitor::Shutdown: adapter.reset()");

--- a/include/gpufl/core/ring_buffer.hpp
+++ b/include/gpufl/core/ring_buffer.hpp
@@ -3,6 +3,7 @@
 #include <array>
 #include <atomic>
 #include <cstddef>
+#include <cstdint>
 #include <thread>
 #include <type_traits>
 
@@ -30,6 +31,8 @@ class RingBuffer {
     alignas(CACHE_LINE_SIZE) std::atomic<size_t> head_{0};
 
     alignas(CACHE_LINE_SIZE) size_t tail_{0};
+
+    alignas(CACHE_LINE_SIZE) std::atomic<size_t> dropped_{0};
 
    public:
     bool Push(const T& item) {
@@ -66,6 +69,7 @@ class RingBuffer {
         if (!slot->state.compare_exchange_strong(expected, SlotState::WRITING,
                                                  std::memory_order_acquire,
                                                  std::memory_order_relaxed)) {
+            dropped_.fetch_add(1, std::memory_order_relaxed);
             return false;
         }
 
@@ -91,6 +95,14 @@ class RingBuffer {
 
         tail_++;
         return true;
+    }
+
+    size_t droppedCount() const {
+        return dropped_.load(std::memory_order_relaxed);
+    }
+
+    size_t resetDroppedCount() {
+        return dropped_.exchange(0, std::memory_order_relaxed);
     }
 };
 }  // namespace gpufl

--- a/include/gpufl/upload/upload_logs.cpp
+++ b/include/gpufl/upload/upload_logs.cpp
@@ -1,7 +1,7 @@
 // High-level structure (U1: file-unit upload - one POST per rotated file):
 //   1. resolve log_path as a v1.2 session-output root, with legacy prefix fallback
-//   2. discover .log / .log.gz files; sort by
-//      (session_id, channel, rotation_index DESC, active-file last)
+//   2. salvage .tmp leftovers, discover .log / .log.gz files; sort by
+//      (session_id, channel, rotation_index ASC, active-file last)
 //   3. read cursor file → uploaded files + completed sessions
 //   4. for each target session, for each of its files in order:
 //        - rotated file already in cursor: skip (crash-resume)
@@ -49,6 +49,7 @@
 #include "gpufl/core/debug_logger.hpp"
 #include "gpufl/core/host_info.hpp"
 #include "gpufl/core/json/json.hpp"
+#include "gpufl/core/logger/log_salvage.hpp"
 #include "gpufl/core/logger/logger.hpp"
 #include "gpufl/core/version.hpp"
 
@@ -291,10 +292,12 @@ std::vector<DiscoveredFile> discoverFiles(const PathParts& parts) {
         }
     }
 
-    // Sort: by (session_id, channel) lexicographic, then by upload
-    // order within a channel - oldest first. Rotation index N=max_files
-    // is the oldest; active (N=0) is newest. So within (sid, channel):
-    // descending rotation_index, with active (0) last.
+    // Sort: by (session_id, channel) lexicographic, then chronologically
+    // within a channel - oldest first, so dictionary_update lines are
+    // ingested before the rows that reference them. Windows are exported
+    // append-style: rotation index 1 is the OLDEST, higher indices are
+    // newer, and a bare active file (index 0, legacy/crash leftover) is
+    // the newest of all.
     std::sort(out.begin(), out.end(),
               [](const DiscoveredFile& a, const DiscoveredFile& b) {
                   if (a.session_id != b.session_id) return a.session_id < b.session_id;
@@ -302,7 +305,7 @@ std::vector<DiscoveredFile> discoverFiles(const PathParts& parts) {
                   const bool a_active = a.rotation_index == 0;
                   const bool b_active = b.rotation_index == 0;
                   if (a_active != b_active) return !a_active;  // active goes last
-                  return a.rotation_index > b.rotation_index;  // higher = older = first
+                  return a.rotation_index < b.rotation_index;  // lower = older = first
               });
     return out;
 }
@@ -1057,6 +1060,12 @@ UploadResult uploadLogs(const UploadOptions& opts) {
     }
 
     // ── Discover files + sessions ────────────────────────────────────
+    const auto salvaged = salvageSessionTempDirs(parts.directory);
+    if (salvaged.salvaged > 0 || salvaged.deferred > 0) {
+        GFL_LOG_DEBUG("[uploadLogs] salvaged ", salvaged.salvaged,
+                      " temp log file(s), deferred ", salvaged.deferred);
+    }
+
     auto files = discoverFiles(parts);
     if (files.empty()) {
         GFL_LOG_DEBUG("[uploadLogs] no session subdirs found in ",

--- a/python/gpufl/analyzer/analyzer.py
+++ b/python/gpufl/analyzer/analyzer.py
@@ -63,10 +63,18 @@ _STALL_NAMES: dict[int, str] = {
 
 
 class GpuFlightSession:
-    def __init__(self, log_dir: str, session_id: str = None, log_prefix: str = "gfl_block", max_stack_depth: int = 5):
+    def __init__(
+        self,
+        log_dir: str,
+        session_id: str = None,
+        log_prefix: str = "gfl_block",
+        max_stack_depth: int = 5,
+        load_all_rotated: bool = False,
+    ):
         self.log_dir = Path(log_dir)
         self.console = Console()
         self.max_stack_depth = max_stack_depth
+        self.load_all_rotated = load_all_rotated
         self.app_name = None
         self._requested_session = session_id
 
@@ -76,9 +84,9 @@ class GpuFlightSession:
         #    (<log_dir>/<session_id>/<channel>.log[.gz]). Resolve which dir
         #    actually holds this run's logs before loading.
         self._read_dir = self._resolve_read_dir(session_id)
-        device_df = self._load_log(self._resolve_log_path(log_prefix, "device"))
-        scope_df  = self._load_log(self._resolve_log_path(log_prefix, "scope"))
-        system_df = self._load_log(self._resolve_log_path(log_prefix, "system"))
+        device_df = self._load_logs(self._resolve_log_paths(log_prefix, "device"))
+        scope_df  = self._load_logs(self._resolve_log_paths(log_prefix, "scope"))
+        system_df = self._load_logs(self._resolve_log_paths(log_prefix, "system"))
 
         # 1.5 Resolve the target session and scope every raw frame to it. The
         # log files are append-only, so re-running into the same prefix leaves
@@ -301,13 +309,14 @@ class GpuFlightSession:
         except (OSError, FileNotFoundError):
             return False
 
-    def _resolve_log_path(self, log_prefix: str, channel: str) -> "Path | None":
-        """Find the best file for `channel` under the resolved read dir.
+    def _resolve_log_paths(self, log_prefix: str, channel: str) -> list[Path]:
+        """Find log file(s) for `channel` under the resolved read dir.
 
         Handles current (bare `<channel>.log[.gz]`) and legacy
         (`<prefix>.<channel>.log[.gz]`) names, active and rotated
-        (`...<channel>.<N>.log[.gz]`), compressed or not. Active wins over
-        rotated; among rotated the lowest index wins; uncompressed breaks ties.
+        (`...<channel>.<N>.log[.gz]`), compressed or not. By default this keeps
+        the historical light behavior and reads one best file. Pass
+        load_all_rotated=True to concatenate all windows chronologically.
         """
         base = log_prefix[:-4] if log_prefix.endswith(".log") else log_prefix
         ch = re.escape(channel)
@@ -320,21 +329,58 @@ class GpuFlightSession:
         except (OSError, FileNotFoundError):
             return None
 
-        best = None  # (rank_tuple, Path)
+        by_slot = {}  # logical slot -> (chronological_key, default_key, Path)
         for p in entries:
             if not p.is_file():
                 continue
             m = rx.match(p.name)
             if not m:
                 continue
+            try:
+                # Skip empty husks: when a held .log can't be deleted after
+                # compression it is truncated to 0 bytes instead, and must
+                # not shadow its .gz twin here.
+                if p.stat().st_size == 0:
+                    continue
+            except OSError:
+                continue
             idx = int(m.group(1)) if m.group(1) else -1
             compressed = 1 if m.group(2) else 0
-            # active (idx -1) before rotated; lowest rotated index next;
-            # uncompressed before compressed as a final tiebreak.
-            key = (0 if idx < 0 else 1, idx if idx >= 0 else 0, compressed)
-            if best is None or key < best[0]:
-                best = (key, p)
-        return best[1] if best else None
+            slot = idx
+            chronological_key = (
+                1 if idx < 0 or idx == 0 else 0,
+                idx if idx > 0 else 0,
+                compressed,
+            )
+            default_key = (
+                0 if idx < 0 else 1,
+                idx if idx >= 0 else 0,
+                compressed,
+            )
+            # For duplicate .log/.log.gz of the same logical slot, keep the
+            # uncompressed file first for legacy compatibility; empty husks
+            # were skipped above.
+            if slot not in by_slot or chronological_key < by_slot[slot][0]:
+                by_slot[slot] = (chronological_key, default_key, p)
+
+        ordered_items = sorted(by_slot.values(), key=lambda item: item[0])
+        ordered = [p for _, _, p in ordered_items]
+        if self.load_all_rotated:
+            return ordered
+
+        if len(ordered) > 1:
+            chosen = min(by_slot.values(), key=lambda item: item[1])[2]
+            self.console.print(
+                f"[yellow]Note:[/yellow] {len(ordered)} {channel} log windows "
+                f"found; reading only {chosen.name}. Pass "
+                f"load_all_rotated=True to merge all windows."
+            )
+            return [chosen]
+        return ordered[:1]
+
+    def _resolve_log_path(self, log_prefix: str, channel: str) -> "Path | None":
+        paths = self._resolve_log_paths(log_prefix, channel)
+        return paths[0] if paths else None
 
     def _load_log(self, path: Path | None):
         """Efficiently loads JSONL into Pandas"""
@@ -351,6 +397,13 @@ class GpuFlightSession:
                     except Exception:
                         pass
         return pd.DataFrame(data)
+
+    def _load_logs(self, paths: list[Path]):
+        frames = [self._load_log(p) for p in paths]
+        frames = [df for df in frames if not df.empty]
+        if not frames:
+            return pd.DataFrame()
+        return pd.concat(frames, ignore_index=True)
 
     # ── Batch format support ──────────────────────────────────────────────────
 

--- a/tests/python/test_analyzer.py
+++ b/tests/python/test_analyzer.py
@@ -1,5 +1,6 @@
 import sys
 import os
+import json
 from pathlib import Path
 import pytest
 
@@ -80,3 +81,62 @@ def test_session_loads_legacy_device_batch_without_clock(mock_log_dir_legacy_dev
     assert not session.device_metrics.empty
     assert "clock_sm" in session.device_metrics.columns
     assert session.device_metrics["clock_sm"].isna().all()
+
+
+def test_session_can_load_all_rotated_windows(tmp_path):
+    log_dir = tmp_path / "logs"
+    log_dir.mkdir()
+    prefix = "rotated"
+
+    first = [
+        {
+            "version": 1, "type": "job_start",
+            "session_id": "rotated-session", "app": "test", "pid": 1,
+            "ts_ns": 100, "host": {}, "devices": []
+        },
+        {
+            "version": 1, "type": "dictionary_update",
+            "session_id": "rotated-session",
+            "kernel_dict": {"1": "firstKernel", "2": "secondKernel"},
+            "scope_name_dict": {}, "function_dict": {}, "metric_dict": {}
+        },
+        {
+            "version": 1, "type": "kernel_event_batch",
+            "session_id": "rotated-session", "batch_id": 1,
+            "base_time_ns": 1000,
+            "columns": ["dt_ns", "kernel_id", "stream_id", "duration_ns",
+                        "corr_id", "dyn_shared", "num_regs", "has_details"],
+            "rows": [[0, 1, 0, 100, 11, 0, 16, 0]]
+        },
+    ]
+    second = [
+        {
+            "version": 1, "type": "kernel_event_batch",
+            "session_id": "rotated-session", "batch_id": 2,
+            "base_time_ns": 2000,
+            "columns": ["dt_ns", "kernel_id", "stream_id", "duration_ns",
+                        "corr_id", "dyn_shared", "num_regs", "has_details"],
+            "rows": [[0, 2, 0, 200, 22, 0, 32, 0]]
+        },
+        {
+            "type": "shutdown",
+            "session_id": "rotated-session", "app": "test", "pid": 1,
+            "ts_ns": 3000
+        },
+    ]
+
+    for name, events in [
+        (f"{prefix}.device.1.log", first),
+        (f"{prefix}.device.2.log", second),
+    ]:
+        with open(log_dir / name, "w") as f:
+            for ev in events:
+                f.write(json.dumps(ev) + "\n")
+
+    light = GpuFlightSession(log_dir, log_prefix=prefix)
+    assert len(light.kernels) == 1
+
+    full = GpuFlightSession(log_dir, log_prefix=prefix,
+                            load_all_rotated=True)
+    assert len(full.kernels) == 2
+    assert list(full.kernels["name"]) == ["firstKernel", "secondKernel"]

--- a/tests/upload/test_upload_logs.cpp
+++ b/tests/upload/test_upload_logs.cpp
@@ -351,7 +351,7 @@ TEST(UploadLogs, UploadsAllEventsAcrossChannelsAndRotation) {
 
     // job_start must arrive first (first line of the oldest file of the
     // first channel). The last file's last line is its shutdown copy -
-    // files go (channel asc, rotation desc, active last).
+    // files go (channel asc, rotation asc, active last).
     EXPECT_EQ(events.front().first, "job_start");
     EXPECT_EQ(events.back().first,  "shutdown");
 
@@ -950,6 +950,9 @@ TEST(UploadLogs, JobStartFirstShutdownLast) {
         R"({"type":"job_start","session_id":"s","ts_ns":1})",
         R"({"type":"kernel_event_batch","session_id":"s","batch_id":1,"rows":[]})",
     }, /*gzip=*/true);
+    writeLog(tmp / "s" / "device.2.log.gz", {
+        R"({"type":"device_metric_batch","session_id":"s","batch_id":2,"rows":[]})",
+    }, /*gzip=*/true);
     writeLog(tmp / "s" / "device.log", {
         R"({"type":"kernel_event_batch","session_id":"s","batch_id":2,"rows":[]})",
         R"({"type":"shutdown","session_id":"s","ts_ns":99})",
@@ -966,10 +969,13 @@ TEST(UploadLogs, JobStartFirstShutdownLast) {
     ASSERT_TRUE(result.success);
 
     const auto events = srv.allEvents();
-    ASSERT_EQ(events.size(), 4u);
+    ASSERT_EQ(events.size(), 5u);
     EXPECT_EQ(events.front().first, "job_start")
         << "job_start must be the first NDJSON line shipped - it heads "
         << "the oldest rotated file, which is POSTed first.";
+    EXPECT_EQ(events[2].first, "device_metric_batch")
+        << "rotation index 2 must be uploaded after index 1 and before "
+        << "the active file.";
     EXPECT_EQ(events.back().first, "shutdown")
         << "shutdown must be the last NDJSON line shipped - it tails "
         << "the active file, which is POSTed last.";
@@ -980,6 +986,44 @@ TEST(UploadLogs, JobStartFirstShutdownLast) {
 // ─────────────────────────────────────────────────────────────────────
 // File-unit upload - one POST per file regardless of line count.
 // ─────────────────────────────────────────────────────────────────────
+
+TEST(UploadLogs, SalvagesSessionTmpBeforeDiscovery) {
+    const fs::path tmp = fs::temp_directory_path() / "gpufl_upload_test_tmp_salvage";
+    fs::remove_all(tmp);
+    fs::create_directories(tmp / "s" / ".tmp");
+
+    writeLog(tmp / "s" / ".tmp" / "device.1.log.gz", {
+        R"({"type":"job_start","session_id":"s","ts_ns":1})",
+    }, /*gzip=*/true);
+    writeLog(tmp / "s" / ".tmp" / "device.log", {
+        R"({"type":"shutdown","session_id":"s","ts_ns":99})",
+    });
+
+    CaptureServer srv;
+    gpufl::UploadOptions opts;
+    opts.log_path        = tmp.string();
+    opts.backend_url     = srv.base_url();
+    opts.api_key         = "x";
+    opts.report_progress = false;
+
+    const auto result = gpufl::uploadLogs(opts);
+    ASSERT_TRUE(result.success) << "warnings: "
+        << (result.warnings.empty() ? "<none>" : result.warnings.front());
+
+    const auto events = srv.allEvents();
+    ASSERT_EQ(events.size(), 2u);
+    EXPECT_EQ(events.front().first, "job_start");
+    EXPECT_EQ(events.back().first, "shutdown");
+    EXPECT_TRUE(fs::exists(tmp / "s" / "device.1.log.gz"));
+    EXPECT_TRUE(fs::exists(tmp / "s" / "device.2.log.gz"))
+        << "active .tmp/device.log should be exported after the staged "
+        << "window with a monotonic index.";
+    EXPECT_FALSE(fs::exists(tmp / "s" / ".tmp"))
+        << "salvage should remove the session .tmp directory once no "
+        << "deferred data remains.";
+
+    fs::remove_all(tmp);
+}
 
 TEST(UploadLogs, ManyEventsShipInOneRequestPerFile) {
     // U1 regression guard: a file with far more lines than the old

--- a/tests/verify_pipeline.py
+++ b/tests/verify_pipeline.py
@@ -1,9 +1,44 @@
 import gpufl as gfl
 import gzip
 import os
+import re
 import time
 import tempfile
 import shutil
+
+
+def _read_channel_logs(session_dir, channel):
+    """Return (paths, lines) for active or rotated files in one log channel."""
+    active = {
+        f"{channel}.log": (10**9, 0),
+        f"{channel}.log.gz": (10**9, 1),
+    }
+    rotated_re = re.compile(rf"^{re.escape(channel)}\.(\d+)\.log(\.gz)?$")
+
+    matches = []
+    for entry in os.listdir(session_dir):
+        path = os.path.join(session_dir, entry)
+        if not os.path.isfile(path):
+            continue
+        if entry in active:
+            matches.append((active[entry], path))
+            continue
+        match = rotated_re.match(entry)
+        if match:
+            index = int(match.group(1))
+            compressed = 1 if match.group(2) else 0
+            matches.append(((index, compressed), path))
+
+    paths = [path for _, path in sorted(matches)]
+    lines = []
+    for path in paths:
+        if path.endswith(".gz"):
+            with gzip.open(path, 'rt') as f:
+                lines.extend(f.readlines())
+        else:
+            with open(path, 'r') as f:
+                lines.extend(f.readlines())
+    return paths, lines
 
 
 def test_pipeline():
@@ -73,23 +108,14 @@ def test_pipeline():
 
         categories = ["scope", "system"]
         for cat in categories:
-            log_path = os.path.join(session_dir, f"{cat}.log")
-            gz_path = log_path + ".gz"
-
-            if os.path.exists(gz_path):
-                with gzip.open(gz_path, 'rt') as f:
-                    lines = f.readlines()
-                found_at = gz_path
-            elif os.path.exists(log_path):
-                with open(log_path, 'r') as f:
-                    lines = f.readlines()
-                found_at = log_path
-            else:
-                print(f"FAILED: Expected {cat}.log or {cat}.log.gz in {session_dir}")
+            found_paths, lines = _read_channel_logs(session_dir, cat)
+            if not found_paths:
+                print(f"FAILED: Expected {cat} log files in {session_dir}")
                 keep = True
                 raise SystemExit(1)
 
-            print(f"   [OK] Found {cat} log: {os.path.basename(found_at)}")
+            found_names = [os.path.basename(path) for path in found_paths]
+            print(f"   [OK] Found {cat} log: {found_names}")
 
             has_init = any('"type":"job_start"' in line for line in lines)
             if not has_init:


### PR DESCRIPTION
## Description
Enhance [PcSampling](url) to have kernel events data.

Fix PC sampling, drain stability and log rotation salvage

- Make heavy PC-sampling kernel drain opt-in via GPUFL_PC_KERNEL_COLLECT=all
- Keep default PC/SASS collection on lightweight periodic GetData to avoid CUPTI stop/flush/start hangs
- Use original CUPTI function names for SASS source correlation and validate correlation inputs
- Tie Windows trace child process lifetime to the launcher with a Job Object
- Harden log rotation/compression salvage and remove clean .tmp session dirs
- Add rotated-log analyzer loading support and related tests

## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Documentation update

## Testing
## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas