### PR TITLE
feat: PC-sampling kernel-collect modes + bulletproof log rotation + s…

### DIFF
--- a/include/gpufl/backends/nvidia/cupti_backend.cpp
+++ b/include/gpufl/backends/nvidia/cupti_backend.cpp
@@ -816,19 +816,14 @@ CUptiResult (*CuptiBackend::get_value())(CUpti_ActivityKind) {
 
 void CuptiBackend::start() {
     if (!initialized_) return;
-    // SASS / PC sampling don't get trustworthy kernel timing: SASS safe mode keeps
-    // kernel-activity OFF (it deadlocks), so its launches would be flushed as
-    // synthetic kernels whose "duration" is just the host-dispatch interval -
-    // meaningless. Suppress that synthetic fallback so these sessions show no
-    // misleading kernel rows. PC additionally enables CONCURRENT_KERNEL in its engine
-    // (pc_sampling_engine.cpp), so if REAL kernel records flow on this GPU they are
-    // joined + emitted normally - suppress only drops the un-joined orphans, never
-    // real rows. So PC shows real kernels when coexistence works, nothing when it
-    // doesn't - never fake. KERNEL_LAUNCH_META still flows for the per-scope
-    // Execution Signature, so a multi-pass merge is unaffected.
+    // SASS safe mode keeps kernel-activity OFF (it deadlocks), so orphan launch
+    // metas would become synthetic kernels with host-dispatch timing only. Keep
+    // suppressing that path for SASS. PC sampling intentionally leaves the
+    // synthetic drain enabled so callback-derived kernel rows can be emitted
+    // when kernel activity is unavailable; drainSyntheticKernels filters
+    // non-kernel memcpy/memset API metas before emitting rows.
     SetSuppressOrphanSyntheticKernels(
-        opts_.profiling_engine == ProfilingEngine::SassMetrics ||
-        opts_.profiling_engine == ProfilingEngine::PcSampling);
+        opts_.profiling_engine == ProfilingEngine::SassMetrics);
     kernel_activity_seen_.store(0, std::memory_order_relaxed);
     kernel_activity_emitted_.store(0, std::memory_order_relaxed);
     kernel_activity_throttled_.store(0, std::memory_order_relaxed);
@@ -1313,7 +1308,6 @@ void CuptiBackend::EmitCaptureCapabilities_() const {
     const EngineRequestSet requests =
         BuildEngineRequestSet(opts_.profiling_engine, combo_);
     const bool kernelActivity = collectsKernelEvents();
-    const bool syntheticKernels = !kernelActivity && (requests.sass || requests.pc);
     const bool cubinRequested = requests.needsCubin();
     const bool cubinCapture = NeedsCubinCapture();
     // Capability emission happens after final engine shutdown so the report can
@@ -1345,6 +1339,19 @@ void CuptiBackend::EmitCaptureCapabilities_() const {
     const uint64_t functionRows =
         function_record_seen_.load(std::memory_order_relaxed);
     const bool kernelHasData = kernelRows > 0;
+    // Kernels are "synthetic" (launch-callback duration estimates) ONLY when a
+    // sampling engine ran but emitted no real CUPTI activity records. PcSampling
+    // enables CONCURRENT_KERNEL out-of-band in its engine (pc_sampling_engine
+    // start(), bypassing collectsKernelEvents()), so real activity records with
+    // MEASURED durations flow even though collectsKernelEvents() — the handler-
+    // enable gate — returns false for PC. So decide by what actually flowed
+    // (kernelRows), not by engine type: when real records were emitted, the
+    // kernel_events/names/details capabilities report "collected" with measured
+    // timing, not a stale "estimated from launch callbacks" fallback.
+    // (Detecting a purely-synthetic session when kernelRows==0 would need a
+    // synthetic-emitted counter wired from monitor.cpp — a follow-up.)
+    const bool syntheticKernels =
+        !kernelActivity && (requests.sass || requests.pc) && kernelRows == 0;
     const bool memoryHasData = memoryRows > 0;
     const bool memTransferHasData = memTransferRows > 0;
     const bool syncHasData = syncRows > 0;

--- a/include/gpufl/backends/nvidia/cupti_backend.cpp
+++ b/include/gpufl/backends/nvidia/cupti_backend.cpp
@@ -1338,20 +1338,31 @@ void CuptiBackend::EmitCaptureCapabilities_() const {
         source_locator_seen_.load(std::memory_order_relaxed);
     const uint64_t functionRows =
         function_record_seen_.load(std::memory_order_relaxed);
-    const bool kernelHasData = kernelRows > 0;
-    // Kernels are "synthetic" (launch-callback duration estimates) ONLY when a
-    // sampling engine ran but emitted no real CUPTI activity records. PcSampling
-    // enables CONCURRENT_KERNEL out-of-band in its engine (pc_sampling_engine
-    // start(), bypassing collectsKernelEvents()), so real activity records with
-    // MEASURED durations flow even though collectsKernelEvents() — the handler-
-    // enable gate — returns false for PC. So decide by what actually flowed
-    // (kernelRows), not by engine type: when real records were emitted, the
-    // kernel_events/names/details capabilities report "collected" with measured
-    // timing, not a stale "estimated from launch callbacks" fallback.
-    // (Detecting a purely-synthetic session when kernelRows==0 would need a
-    // synthetic-emitted counter wired from monitor.cpp — a follow-up.)
+    // Real CUPTI kernel activity records emitted this session. PcSampling enables
+    // CONCURRENT_KERNEL out-of-band in its engine (bypassing collectsKernelEvents(),
+    // the handler-enable gate that returns false for PC), so real records with
+    // MEASURED durations flow — and increment this — even for PC sessions.
+    const bool realKernelRows = kernelRows > 0;
+    // Synthetic kernel rows are launch-callback duration ESTIMATES that
+    // drainSyntheticKernels emits for launches with no matching real activity
+    // record (host-dispatch timing, not measured). They appear when: kernel
+    // launches were seen, NO real activity records were collected, and the
+    // synthetic drain wasn't suppressed — suppression is on only for pure
+    // SASS-metrics mode (kernel activity intentionally off → no kernel rows at
+    // all). The live case is NON-ADMIN PC: PC arms but Stop/GetData are
+    // privilege-blocked, so zero real records flow and the kernel rows come from
+    // launch callbacks. kernel_launch_callback_seen_ is an atomic set on every
+    // launch callback, so reading it here is both safe AND populated —
+    // capabilities emit BEFORE the collector's end-of-session synthetic drain, so
+    // a post-drain emit count would read zero at this point.
     const bool syntheticKernels =
-        !kernelActivity && (requests.sass || requests.pc) && kernelRows == 0;
+        !realKernelRows &&
+        (requests.sass || requests.pc) &&
+        opts_.profiling_engine != ProfilingEngine::SassMetrics &&
+        kernel_launch_callback_seen_.load(std::memory_order_acquire);
+    // "Has kernel data" = any kernel rows, real OR synthetic. The status then
+    // splits collected (measured) vs fallback (estimated) on syntheticKernels.
+    const bool kernelHasData = realKernelRows || syntheticKernels;
     const bool memoryHasData = memoryRows > 0;
     const bool memTransferHasData = memTransferRows > 0;
     const bool syncHasData = syncRows > 0;
@@ -1384,10 +1395,9 @@ void CuptiBackend::EmitCaptureCapabilities_() const {
                             : "not_requested"),
                   metricsOnly
                       ? "sass_metrics_only"
-                      : (kernelActivity
-                            ? (syntheticKernels ? "launch_callbacks_synthetic"
-                                                : "cupti_activity")
-                            : "disabled"),
+                      : (syntheticKernels ? "launch_callbacks_synthetic"
+                         : ((realKernelRows || kernelActivity) ? "cupti_activity"
+                                                               : "disabled")),
                   kernelHasData
                       ? (syntheticKernels
                             ? (requests.pc ? "cupti_kernel_activity_conflicts_with_pc_sampling"
@@ -1416,10 +1426,9 @@ void CuptiBackend::EmitCaptureCapabilities_() const {
                             : "not_requested"),
                   metricsOnly
                       ? "sass_metrics_only"
-                      : (kernelActivity
-                            ? (syntheticKernels ? "callback_symbol_probe"
-                                                : "cupti_activity_name")
-                            : "disabled"),
+                      : (syntheticKernels ? "callback_symbol_probe"
+                         : ((realKernelRows || kernelActivity) ? "cupti_activity_name"
+                                                               : "disabled")),
                   kernelHasData
                       ? (syntheticKernels ? "symbol_name_may_be_unavailable" : "")
                       : (kernelActivity
@@ -1443,10 +1452,9 @@ void CuptiBackend::EmitCaptureCapabilities_() const {
                             : "not_requested"),
                   metricsOnly
                       ? "sass_metrics_only"
-                      : (kernelActivity
-                            ? (syntheticKernels ? "launch_callback_params"
-                                                : "cupti_activity_details")
-                            : "disabled"),
+                      : (syntheticKernels ? "launch_callback_params"
+                         : ((realKernelRows || kernelActivity) ? "cupti_activity_details"
+                                                               : "disabled")),
                   kernelHasData
                       ? (syntheticKernels ? "activity_details_unavailable" : "")
                       : (kernelActivity

--- a/include/gpufl/backends/nvidia/engine/pc_sampling_engine.cpp
+++ b/include/gpufl/backends/nvidia/engine/pc_sampling_engine.cpp
@@ -73,8 +73,12 @@ BuildPcSamplingConfig(const uint32_t samplingPeriod,
         CUpti_PCSamplingConfigurationInfo info = {};
         info.attributeType =
             CUPTI_PC_SAMPLING_CONFIGURATION_ATTR_TYPE_SCRATCH_BUFFER_SIZE;
+        // Host-resident staging between HW buffer and GetData. CUPTI sizing:
+        // ~1 MB per ~5,500 PCs with all stall reasons, so 32 MB covers
+        // ~175k distinct PCs per drain window - generous at our 1 s collect
+        // cadence (the old 256 MB was wildly oversized per context).
         info.attributeData.scratchBufferSizeData.scratchBufferSize =
-            256 * 1024 * 1024;
+            32 * 1024 * 1024;
         addConfig(info);
     }
     {

--- a/include/gpufl/core/dictionary_manager.cpp
+++ b/include/gpufl/core/dictionary_manager.cpp
@@ -46,13 +46,15 @@ struct DictLine final : IJsonSerializable {
     Channel channel() const override { return Channel::All; }
 };
 
-/// Disassembly and source content go to Device channel only.
-/// These are large payloads that don't need to be tripled across all logs.
-struct DeviceLine final : IJsonSerializable {
+/// Disassembly and source content go to the dedicated Sass channel
+/// (sass.log): these artifact payloads dwarf the event stream (60+ MB of
+/// SASS listings vs ~17 MB of kernels in a torch run) and bloated
+/// device.log past upload caps when they shared it.
+struct SassLine final : IJsonSerializable {
     std::string json;
-    explicit DeviceLine(std::string j) : json(std::move(j)) {}
+    explicit SassLine(std::string j) : json(std::move(j)) {}
     std::string buildJson() const override { return json; }
-    Channel channel() const override { return Channel::Device; }
+    Channel channel() const override { return Channel::Sass; }
 };
 
 void appendDict(std::ostringstream& oss, const char* key,
@@ -166,7 +168,7 @@ void DictionaryManager::flushSourceContent(Logger& logger,
             oss << '"' << model::jsonEscape(ln) << '"';
         }
         oss << "]}";
-        logger.write(DeviceLine{oss.str()});
+        logger.write(SassLine{oss.str()});
     }
 }
 
@@ -475,11 +477,11 @@ void DictionaryManager::flushDisassembly(Logger& logger,
                 oss << '}';
             }
             oss << "]}";
-            logger.write(DeviceLine{oss.str()});
+            logger.write(SassLine{oss.str()});
         }
 
         // For AMD code objects with DWARF debug info, emit source file content
-        // and a profile_sample_batch that maps pc_offset → source_file:line.
+        // and a profile_sample_batch that maps pc_offset -> source_file:line.
         // This enables the same source-correlated ISA view as NVIDIA/CUPTI.
         if (isAmd) {
             // Collect unique source files and intern them

--- a/include/gpufl/core/itanium_demangle.cpp
+++ b/include/gpufl/core/itanium_demangle.cpp
@@ -135,10 +135,12 @@ private:
     // <name> ::= <nested_name>
     //          | <unscoped_name>
     //          | <unscoped_template_name> <template_args>
+    //          | <local_name>
     //          | <substitution>
     std::string parseName() {
         char c = peek();
         if (c == 'N') return parseNestedName();
+        if (c == 'Z') return parseLocalName();
         if (c == 'S') {
             // Substitution at the start of a name - rare for CUDA
             // kernels; substitution refers back to a previously seen
@@ -240,14 +242,50 @@ private:
     }
 
     // <unqualified_name> ::= <source_name>
-    //                      | <operator_name>      (not handled - falls back)
+    //                      | <operator_name>      (subset - operator())
     //                      | <ctor_dtor_name>     (not handled - falls back)
     std::string parseUnqualifiedName() {
+        std::string op = parseOperatorName();
+        if (!op.empty()) return op;
+
         // For our scope: always a source_name (length-prefixed).
         // Anonymous-namespace markers like "_GLOBAL__N_…" are still
         // length-prefixed identifiers, so they fall through here too.
         if (peek() < '0' || peek() > '9') throw ParseError();
         return parseSourceName();
+    }
+
+    std::string parseOperatorName() {
+        if (p_ + 1 >= end_) return {};
+        if (p_[0] == 'c' && p_[1] == 'l') {
+            p_ += 2;
+            return "operator()";
+        }
+        return {};
+    }
+
+    std::string parseLocalName() {
+        if (!consume('Z')) throw ParseError();
+
+        const std::string context = parseEncoding();
+        if (!consume('E')) throw ParseError();
+
+        std::string entity;
+        if (peek() == 'U' && p_ + 1 < end_ && p_[1] == 'l') {
+            entity = parseClosureType();
+        } else {
+            entity = parseName();
+        }
+
+        // Discriminators do not help frontend matching, so consume and drop.
+        if (peek() == '_') {
+            ++p_;
+            while (!eof() && peek() >= '0' && peek() <= '9') ++p_;
+        }
+
+        if (context.empty()) return entity;
+        if (entity.empty()) return context;
+        return context + "::" + entity;
     }
 
     // <source_name> ::= <positive length number> <identifier>
@@ -433,11 +471,23 @@ private:
             return n;
         }
 
+        if (c == 'Z') {
+            std::string n = parseLocalName();
+            subs_.push_back(n);
+            return n;
+        }
+
         if (c >= '0' && c <= '9') {
             // Source name as a class type, e.g. "5MyClass", optionally
             // abi-tagged.
             std::string n = parseSourceName();
             skipAbiTags();
+            subs_.push_back(n);
+            return n;
+        }
+
+        if (c == 'U' && p_ + 1 < end_ && p_[1] == 'l') {
+            std::string n = parseClosureType();
             subs_.push_back(n);
             return n;
         }
@@ -451,6 +501,30 @@ private:
 
         // Anything else we don't recognize - bail out.
         throw ParseError();
+    }
+
+    std::string parseClosureType() {
+        if (!consume('U')) throw ParseError();
+        if (!consume('l')) throw ParseError();
+
+        std::vector<std::string> params;
+        while (!eof() && peek() != 'E') {
+            params.push_back(parseType());
+        }
+        if (!consume('E')) throw ParseError();
+
+        // Closure ordinal: absent digits means the first closure. The
+        // frontend only needs a stable readable surface, so we drop it.
+        while (!eof() && peek() >= '0' && peek() <= '9') ++p_;
+        if (!consume('_')) throw ParseError();
+
+        std::string out = "lambda(";
+        for (size_t i = 0; i < params.size(); ++i) {
+            if (i) out += ", ";
+            out += params[i];
+        }
+        out += ")";
+        return out;
     }
 
     // Map a single-character builtin code to its display name. Returns

--- a/include/gpufl/core/logger/file_log_sink.cpp
+++ b/include/gpufl/core/logger/file_log_sink.cpp
@@ -189,6 +189,7 @@ FileLogSink::FileLogSink(const Logger::Options& opt) {
     chanDevice_ = std::make_unique<FileChannel>("device", opt);
     chanScope_  = std::make_unique<FileChannel>("scope",  opt);
     chanSystem_ = std::make_unique<FileChannel>("system", opt);
+    chanSass_   = std::make_unique<FileChannel>("sass",   opt);
     LogRotationOptions r{};
     r.base_path = opt.base_path;
     r.session_id = opt.session_id;
@@ -200,16 +201,19 @@ FileLogSink::~FileLogSink() { close(); }
 bool FileLogSink::anyChannelOpen() const {
     return (chanDevice_ && chanDevice_->isOpen()) ||
            (chanScope_  && chanScope_->isOpen())  ||
-           (chanSystem_ && chanSystem_->isOpen());
+           (chanSystem_ && chanSystem_->isOpen()) ||
+           (chanSass_   && chanSass_->isOpen());
 }
 
 void FileLogSink::close() {
     if (chanDevice_) chanDevice_->close();
     if (chanScope_)  chanScope_->close();
     if (chanSystem_) chanSystem_->close();
+    if (chanSass_)   chanSass_->close();
     chanDevice_.reset();
     chanScope_.reset();
     chanSystem_.reset();
+    chanSass_.reset();
     // Every channel has exported and dropped its active file - the
     // shared session temp dir can go now (loud on failure, swept by the
     // launcher's salvage pass otherwise).
@@ -240,6 +244,7 @@ FileLogSink::FileChannel* FileLogSink::resolveChannel(Channel ch) const {
         case Channel::Device: return chanDevice_.get();
         case Channel::Scope:  return chanScope_.get();
         case Channel::System: return chanSystem_.get();
+        case Channel::Sass:   return chanSass_.get();
         default:              return nullptr;
     }
 }
@@ -249,6 +254,12 @@ void FileLogSink::write(Channel ch, std::string_view json) {
         if (chanDevice_) chanDevice_->write(json);
         if (chanScope_)  chanScope_->write(json);
         if (chanSystem_) chanSystem_->write(json);
+        // Sass is part of the fan-out so each sass.log is self-ordered:
+        // dictionary_update lines land in the file BEFORE the
+        // source_file_content/cubin_disassembly lines that reference their
+        // IDs - live tailers (agent) read channels independently and have
+        // no cross-file ordering.
+        if (chanSass_) chanSass_->write(json);
     } else {
         if (FileChannel* channel = resolveChannel(ch)) {
             channel->write(json);

--- a/include/gpufl/core/logger/file_log_sink.hpp
+++ b/include/gpufl/core/logger/file_log_sink.hpp
@@ -88,6 +88,7 @@ class FileLogSink final : public ILogSink {
     std::unique_ptr<FileChannel> chanDevice_;
     std::unique_ptr<FileChannel> chanScope_;
     std::unique_ptr<FileChannel> chanSystem_;
+    std::unique_ptr<FileChannel> chanSass_;
     // The shared session `.tmp` dir, removed once in close() after every
     // channel has finalized (its own actives would block earlier removal).
     std::string temp_dir_;

--- a/include/gpufl/core/model/serializable.hpp
+++ b/include/gpufl/core/model/serializable.hpp
@@ -4,7 +4,10 @@
 
 namespace gpufl {
 
-enum class Channel { Device, Scope, System, All };
+// Sass = bulky artifacts (SASS disassembly listings, source file content)
+// in their own sass.log so they can't bloat the device event stream past
+// upload caps. All = device+scope+system lifecycle fan-out (NOT sass).
+enum class Channel { Device, Scope, System, Sass, All };
 
 struct IJsonSerializable {
     virtual std::string buildJson() const = 0;

--- a/include/gpufl/core/monitor.cpp
+++ b/include/gpufl/core/monitor.cpp
@@ -411,6 +411,16 @@ void SetSuppressOrphanSyntheticKernels(bool suppress) {
     g_suppressOrphanSyntheticKernels = suppress;
 }
 
+static bool isSyntheticNonKernelLaunchName(const char* name) {
+    if (!name || name[0] == '\0') return false;
+    auto startsWith = [&](const char* prefix) {
+        return std::strncmp(name, prefix, std::strlen(prefix)) == 0;
+    };
+    return startsWith("cudaMemcpy") || startsWith("cuMemcpy") ||
+           startsWith("cudaMemset") || startsWith("cuMemset") ||
+           startsWith("mem_transfer");
+}
+
 static void drainSyntheticKernels(Runtime* rt) {
     if (g_launchMetaByCorr.empty()) return;
     if (g_suppressOrphanSyntheticKernels) {
@@ -439,6 +449,12 @@ static void drainSyntheticKernels(Runtime* rt) {
 
     for (size_t i = 0; i < orderedCorr.size(); ++i) {
         const uint64_t corr = orderedCorr[i];
+        if (isSyntheticNonKernelLaunchName(g_launchMetaByCorr[corr].name)) {
+            GFL_LOG_DEBUG("[drainSyntheticKernels] skip non-kernel synthetic "
+                          "meta corr=", corr,
+                          " name=", g_launchMetaByCorr[corr].name);
+            continue;
+        }
         // Copy the stored meta: it already carries name, device_id, scope,
         // stack, has_details, grid/block/dyn_shared and the precomputed
         // simplified occupancy. We only override the synthetic-specific fields.

--- a/python/bindings.cpp
+++ b/python/bindings.cpp
@@ -324,14 +324,31 @@ PYBIND11_MODULE(_gpufl_client, m) {
     //
     // We expose with a leading underscore to signal "internal API
     // for the gpufl.torch package, not a stable user-facing surface."
+    // push/popExternalCorrelation are thin CUPTI wrappers defined only in the
+    // NVIDIA backend (cupti_backend.cpp), which CMake compiles only when the
+    // CUDA toolkit + CUPTI are present. On a CPU-only / no-CUPTI wheel the
+    // symbols don't exist; the binding must still be callable (gpufl.torch
+    // imports it) but is a no-op since there's no GPU backend to correlate
+    // against. Guard the calls rather than the m.def so the Python surface
+    // stays identical across builds. (Linux .so tolerates the undefined symbol
+    // at link time; a Windows .pyd does not — LNK2001 — so this guard is what
+    // keeps the no-CUDA Windows wheel linking.)
     m.def("_push_external_corr_id",
           [](uint32_t kind, uint64_t id) {
+#if GPUFL_HAS_CUPTI
               gpufl::pushExternalCorrelation(kind, id);
+#else
+              (void)kind; (void)id;
+#endif
           },
           py::arg("kind"), py::arg("id"));
     m.def("_pop_external_corr_id",
           [](uint32_t kind) {
+#if GPUFL_HAS_CUPTI
               gpufl::popExternalCorrelation(kind);
+#else
+              (void)kind;
+#endif
           },
           py::arg("kind"));
 

--- a/python/gpufl/__init__.py
+++ b/python/gpufl/__init__.py
@@ -1066,8 +1066,8 @@ def clean_logs(log_path=None, log_prefix=None, *, dry_run=False):
     import warnings
 
     # Each session subdir's channel files match this pattern.
-    # device.log / device.log.gz / device.5.log / device.5.log.gz / etc.
-    channel_re = re.compile(r"^(?:device|scope|system)(?:\.\d+)?\.log(?:\.gz)?$")
+    # device.log / device.log.gz / device.5.log / sass.1.log.gz / etc.
+    channel_re = re.compile(r"^(?:device|scope|system|sass)(?:\.\d+)?\.log(?:\.gz)?$")
 
     matched = []
     if os.path.isdir(log_path):

--- a/python/gpufl/analyzer/analyzer.py
+++ b/python/gpufl/analyzer/analyzer.py
@@ -87,6 +87,13 @@ class GpuFlightSession:
         device_df = self._load_logs(self._resolve_log_paths(log_prefix, "device"))
         scope_df  = self._load_logs(self._resolve_log_paths(log_prefix, "scope"))
         system_df = self._load_logs(self._resolve_log_paths(log_prefix, "system"))
+        # SASS artifacts (cubin_disassembly / source_file_content) moved to
+        # their own sass.log channel; fold them back into the device frame so
+        # type-based consumers keep working on old AND new sessions alike.
+        sass_df = self._load_logs(self._resolve_log_paths(log_prefix, "sass"))
+        if not sass_df.empty:
+            device_df = pd.concat([device_df, sass_df], ignore_index=True) \
+                if not device_df.empty else sass_df
 
         # 1.5 Resolve the target session and scope every raw frame to it. The
         # log files are append-only, so re-running into the same prefix leaves
@@ -303,7 +310,7 @@ class GpuFlightSession:
 
     @staticmethod
     def _dir_has_any_channel(d: Path) -> bool:
-        rx = re.compile(r"^(?:.+\.)?(?:device|scope|system)(?:\.\d+)?\.log(?:\.gz)?$")
+        rx = re.compile(r"^(?:.+\.)?(?:device|scope|system|sass)(?:\.\d+)?\.log(?:\.gz)?$")
         try:
             return any(rx.match(p.name) for p in d.iterdir() if p.is_file())
         except (OSError, FileNotFoundError):

--- a/tests/core/test_itanium_demangle.cpp
+++ b/tests/core/test_itanium_demangle.cpp
@@ -122,6 +122,31 @@ TEST(ItaniumDemangle, AtenVectorizedElementwiseKernel_RealCapture) {
            "namespace-shortcut bug) - got: " << out;
 }
 
+// Additional real CUDA kernel regression: local ATen lambda closure.
+
+TEST(ItaniumDemangle, AtenReduceKernelWithLambdaClosure_RealCapture) {
+    // Captured from a PyTorch PC sampling/SASS run. The template args include
+    // a local lambda closure type (`UlffE_`) inside sum_functor::operator().
+    // Without local-name + closure parsing this fell back to the raw mangled
+    // symbol and showed up unreadable in Source/SASS.
+    const char* mangled =
+        "_ZN2at6native13reduce_kernelILi128ELi4ENS0_8ReduceOpIfNS0_14func_wrapper_t"
+        "IfZNS0_11sum_functorIfffEclERNS_14TensorIteratorEEUlffE_EEjfLi4ELi4EEEEEvT1_";
+    auto out = DemangleItaniumName(mangled);
+
+    EXPECT_NE(out, mangled) << "must not fall back to the raw mangled name";
+    EXPECT_NE(out.find("at::native::reduce_kernel"), std::string::npos)
+        << "missing reducer prefix - got: " << out;
+    EXPECT_NE(out.find("ReduceOp"), std::string::npos)
+        << "missing ReduceOp template arg - got: " << out;
+    EXPECT_NE(out.find("sum_functor"), std::string::npos)
+        << "missing functor context - got: " << out;
+    EXPECT_NE(out.find("operator()"), std::string::npos)
+        << "missing local operator() context - got: " << out;
+    EXPECT_NE(out.find("lambda(float, float)"), std::string::npos)
+        << "missing lambda closure signature - got: " << out;
+}
+
 // ── Failure modes - must always return a non-empty displayable string ─
 
 TEST(ItaniumDemangle, MalformedReturnsOriginal) {


### PR DESCRIPTION
…ass channel split
- rotation: temp-dir actives, export-only (gzip -> stage -> truncate -> publish at first
  free index); never rename/delete the active, copy+truncate fallback, .tmp swept
  on close + launcher salvage. Fixes the held-file 81MB-single-file failures.
- logging: cubin_disassembly + source_file_content -> dedicated sass.log channel
  (device.log 81MB->~17MB class); All fan-out includes sass for self-ordering.
- pcsampling: GPUFL_PC_KERNEL_COLLECT=all|none drain modes; scratch buffer 256→32MB;
  pc_offset emission; profiler-init pre-context; arm before first kernel.
- python analyzer/clean_logs: read+sweep sass channel; uploader chronological sort.
## Description
## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Documentation update

## Testing
## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas