### PR TITLE
fix: drop non-finite PM sample values (priming-sample NaN broke ingest)

### DIFF
--- a/include/gpufl/backends/nvidia/engine/pm_sampling_engine.cpp
+++ b/include/gpufl/backends/nvidia/engine/pm_sampling_engine.cpp
@@ -7,6 +7,7 @@
 #endif
 
 #include <algorithm>
+#include <cmath>
 #include <cstdint>
 
 #include "gpufl/backends/nvidia/cupti_utils.hpp"
@@ -402,6 +403,12 @@ void PmSamplingEngine::DecodeAndEmit_() {
         const uint64_t mid = sampleInfo.startTimestamp +
             ((sampleInfo.endTimestamp - sampleInfo.startTimestamp) / 2ull);
         for (size_t metric = 0; metric < metrics_.size(); ++metric) {
+            // The first sample of a PM-sampling window is a priming sample whose
+            // counters haven't accumulated yet, so EvaluateToGpuValues returns a
+            // non-finite value (NaN) — paired with a garbage timestamp. Drop it at
+            // the source: a NaN serializes as "-nan(ind)" (MSVC), which is invalid
+            // JSON and makes the agent reject the ENTIRE batch.
+            if (!std::isfinite(values[metric])) continue;
             PmSampleInput row;
             row.sample_index = static_cast<uint32_t>(sample);
             row.ts_ns = static_cast<int64_t>(mid);

--- a/include/gpufl/core/model/batch_models.cpp
+++ b/include/gpufl/core/model/batch_models.cpp
@@ -1,5 +1,6 @@
 #include "gpufl/core/model/batch_models.hpp"
 
+#include <cmath>
 #include <sstream>
 
 #include "gpufl/core/host_info.hpp"
@@ -233,6 +234,12 @@ std::string PmSampleBatchModel::buildJson() const {
 
     bool first = true;
     for (const auto& r : rows) {
+        // A non-finite value serializes as "-nan(ind)" / "inf" (platform-
+        // specific) — invalid JSON that makes the agent reject the whole batch.
+        // The PM engine already filters these at the source; this is a
+        // belt-and-suspenders guard. ('value' is the only float column here;
+        // PC/SASS metric_value is an integer.)
+        if (!std::isfinite(r.value)) continue;
         if (!first) oss << ',';
         first = false;
         oss << '[' << r.sample_index << ',' << (r.ts_ns - base) << ','


### PR DESCRIPTION
## Description
The first sample of each PM-sampling window is a priming sample whose counters haven't accumulated yet: cuptiProfilerHostEvaluateToGpuValues returns NaN for it (paired with a garbage timestamp). Serialized via ostream <<, a NaN prints as the platform token "-nan(ind)" (MSVC) — not a valid JSON number — so the agent rejected the ENTIRE pm_sample_batch line ("Skipping malformed line: ... expected digit to follow minus sign"), dropping every sample in the batch.
- pm_sampling_engine: skip non-finite metric values at the source, so the priming sample (and its garbage timestamp) never enters the buffer and  base_time_ns is computed from valid samples.
- batch_models (PmSampleBatchModel): belt-and-suspenders guard that never serializes a non-finite value. PM 'value' is the only float column;  PC/SASS metric_value is an integer.

## Type of Change
- [x] Bug fix
- [x] New feature
- [ ] Documentation update

## Testing
## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas