### PR TITLE
chore(release): 1.2.0 — remove v1.1 deprecations, default+fix memory …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,33 +5,91 @@ inspired by [Keep a Changelog](https://keepachangelog.com/en/1.1.0/);
 versioning follows PEP 440 for the Python wheel and semver-style
 `MAJOR.MINOR.PATCH` for the C++ library.
 
-## [1.2.0rc1] - 2026-06-14
+## [1.2.0] - 2026-06-21
+
+Headline: **injection-mode profiling** — a native `gpufl` launcher that
+profiles any process (Windows included) with no code changes, plus
+multi-pass capture that runs several engines over one workload and merges
+the results.
 
 ### Added
 
-- **Bounded window profiling for `gpufl trace`.** New `--warmup`, `--window`,
-  `--window-timeout`, and `--after-window` flags time-box a capture of a
-  long-running target (e.g. an inference server) that never exits on its own.
-  The launcher runs the target for `warmup + window` wall-clock, then gracefully
-  stops it: POSIX SIGTERM → grace → SIGKILL; Windows signals an inherited
-  stop-event so the injected lib flushes + exits cleanly, falling back to
-  `TerminateProcess` after the grace. Durations accept `30s` / `500ms` / `5m` /
-  `1h` / a bare number of seconds.
-- **Composite passes (`+`).** `--passes Trace+PcSampling` runs the listed engines
-  together in one process (timeline + PC stalls in a single window) via
+- **`gpufl trace` — injection-mode launcher.** Profile any process by injecting
+  the gpufl library at launch (POSIX `LD_PRELOAD`, Windows-native) — no changes
+  to the target. See [docs/guides/trace-launcher.md](docs/guides/trace-launcher.md).
+- **Multi-pass profiling (`--passes`).** `--passes=Trace,PcSampling,SassMetrics`
+  runs each engine as its own isolated pass and tags them into one **analysis
+  group** (shown as a merged kernel/source view in the dashboard). `--passes=Deep`
+  runs the Deep engine (PcSampling + SassMetrics) in one pass, same as the
+  embedded engine; embedded Python targets can drive multi-pass too.
+  See [docs/guides/multi-pass-profiling.md](docs/guides/multi-pass-profiling.md).
+- **Composite passes (`+`).** `--passes=Trace+PcSampling` runs the listed engines
+  together in one process (timeline + PC stalls in one window) via
   `GPUFL_ENGINE_COMBO`; a comma still means one isolated pass each. `SassMetrics`
   and `Deep` are rejected inside a `+` group.
+- **Bounded-window profiling.** `--warmup` / `--window` / `--window-timeout` /
+  `--after-window` time-box a capture of a target that never exits on its own
+  (e.g. an inference server), then stop it gracefully (POSIX SIGTERM → grace →
+  SIGKILL; Windows stop-event → flush → `TerminateProcess` fallback). Durations
+  accept `30s` / `500ms` / `5m` / `1h` / a bare number of seconds.
+- **`gpufl monitor`.** Monitoring-only telemetry (GPU/host health, no CUPTI) as
+  a standalone command.
+- **`RangeProfilerKernelReplay` engine.** Kernel-owned hardware counters via
+  AutoRange + Kernel Replay.
+- **Windows support.** Native `gpufl trace` injection; NVAPI fallback for
+  GPU/memory utilization on WDDM (where NVML reports 0%); real kernel symbol
+  resolution in Deep mode; PC sampling under Windows injection.
+
+### Changed
+
+- **Lower per-kernel overhead** — stack symbolization, name demangling, and
+  metadata joins moved off the CUPTI callback path onto the collector thread;
+  the per-kernel critical section shrunk and several locks removed.
+- **PC sampling reports measured kernel timings** (no false "estimated" banner),
+  with standalone kernel-collect modes and a split SASS channel.
+- Environment-variable names centralized in `include/gpufl/core/env_vars.hpp`.
+- `enable_memory_tracking` now **defaults to on**. PyTorch's caching allocator
+  generates <1k events/session (negligible overhead); set it false for
+  alloc-heavy workloads (e.g. TensorFlow eager).
 
 ### Fixed
 
-- Synthetic shutdown markers are now written for ungracefully-stopped sessions
-  (window stop / SIGKILL / crash): the session's staged `.tmp` logs are published
-  before the completion-marker check, so the missing `shutdown` record is
-  synthesized instead of leaving the session incomplete.
+- Memory allocation tracking (`enable_memory_tracking`) now works in SASS / Deep
+  mode. CUPTI `MEMORY2` was gated behind kernel-activity collection — off by
+  default in SASS-safe mode — so `gpufl trace` (default Deep) recorded no
+  `cudaMalloc`/`cudaFree` events despite the flag being set. Allocation tracking
+  is now independent of kernel activity (gated only on `enable_memory_tracking`
+  plus the SASS-safety policy), so it collects in every engine.
+- Drop kernel activity with invalid zero CUPTI timestamps (they anchored to
+  system-boot time and sorted to the top of the kernel list).
+- Drop non-finite PM sample values (a priming-sample `NaN` produced `-nan(ind)`
+  that broke ingest); anchor PM samples to wall-clock time.
+- Synthesize a `shutdown` marker for ungracefully-stopped sessions (window stop
+  / SIGKILL / crash), written as an indexed window so the agent uploads it; the
+  launcher waits for the upload to finish instead of hard-killing the agent.
+- The no-CUDA Windows wheel links cleanly (CUPTI-only binding calls are guarded).
 
 ### Removed
 
 - The deprecated `gpufl trace --engine` flag (use `--passes`).
+- **`remote_upload`** — the Python kwarg, the C++ `InitOptions::remote_upload`
+  field, and the `GPUFL_REMOTE_UPLOAD` env var. The v1.1 backward-compat shim
+  (a Python `atexit` handler + the C++ shutdown auto-upload) is gone; passing it
+  now raises. Use `with gpufl.session(backend_url=..., api_key=...):` or call
+  `gpufl.upload_logs()` / `gpufl::uploadLogs()` after shutdown.
+- **`sampling_auto_start`** — the Python kwarg (renamed to
+  `continuous_system_sampling` in v1.1; C++ renamed then). The compatibility
+  shim is removed and the old name now raises `TypeError`.
+- **`InitOptions.backend_url` / `api_key`** — backend credentials no longer live
+  on `InitOptions` (the C++ fields and the Python `init()` kwargs are both gone;
+  `init()` now rejects them). Pass them to `gpufl.upload_logs()` /
+  `gpufl::uploadLogs()` or `gpufl.session(backend_url=..., api_key=...)`; the
+  version-discovery probe reads `GPUFL_BACKEND_URL` from the environment.
+
+### Build
+
+- The Windows wheel builds with Ninja + nvcc + MSVC `cl` (not the Visual Studio
+  CUDA toolset); per-version wheel generation fixed.
 
 ## [1.1.0] - 2026-06-03
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ project(gpufl_client
 # pre-release tokens (`rc1`, `a1`, `b1`, …) aren't valid in CMake's
 # `project(... VERSION ...)`, so we layer them on top here. Final releases
 # leave this empty.
-set(GPUFL_VERSION_SUFFIX "rc1")
+set(GPUFL_VERSION_SUFFIX "")
 
 # -----------------------
 # CUDA Architectures (CI Friendly)

--- a/README.md
+++ b/README.md
@@ -8,14 +8,17 @@ The goal is to make GPU profiling lighter and more continuous, closer to observa
 
 Built on CUPTI for NVIDIA GPUs and rocprofiler-sdk for AMD GPUs, GPUFlight is designed for always-on monitoring with low overhead in monitoring mode.
 
-## Project Status: 1.1.0
+## Project Status: 1.2.0
 
 GPUFlight is published to PyPI; the current release is
-`v1.1.0`. **Breaking changes vs 1.0.x** - `remote_upload` /
-`HttpLogSink` removed (upload moves to a post-shutdown step), and
-`sampling_auto_start` renamed to `continuous_system_sampling`. See
-[CHANGELOG.md](./CHANGELOG.md) for the full migration notes. Pin an
-exact version if you depend on it.
+`v1.2.0`. **New in 1.2.0** - injection-mode `gpufl trace` (profile any
+process, no code changes), multi-pass capture, and Windows support.
+**Breaking** - the v1.1 deprecation shims are removed: `remote_upload`
+(and `GPUFL_REMOTE_UPLOAD`), the old `sampling_auto_start` kwarg, and
+`backend_url`/`api_key` on `init()` now raise (creds move to
+`upload_logs()` / `session()`). See [CHANGELOG.md](./CHANGELOG.md) for
+the full migration notes.
+Pin an exact version if you depend on it.
 
 To keep the initial design coherent, **we are not currently accepting major feature Pull Requests.** However, we welcome:
 - Bug reports and local build issues.

--- a/daemon/launcher/cli_parse.cpp
+++ b/daemon/launcher/cli_parse.cpp
@@ -88,8 +88,8 @@ std::string validatePassToken(const std::string& token) {
                    "them in one process, e.g. Trace+PcSampling)";
         }
         if (composite && p == "Deep") {
-            return "Deep cannot be combined in a '+' group (it is a multi-pass "
-                   "preset); list it on its own";
+            return "Deep cannot be combined in a '+' group (it already runs "
+                   "PcSampling + SassMetrics together); give it its own pass";
         }
         if (composite && p == "SassMetrics") {
             return "SassMetrics cannot share a process (it deadlocks with kernel "
@@ -135,11 +135,12 @@ const char* traceHelp() {
         "                            Each comma is a separate pass (relaunch). Join\n"
         "                            engines with + to run them in ONE process, e.g.\n"
         "                            Trace+PcSampling (timeline + PC stalls, one run).\n"
-        "                            Default: Trace. Deep expands to isolated\n"
-        "                            Trace,PcSampling,SassMetrics passes and cannot\n"
-        "                            be combined with other passes. SassMetrics must\n"
-        "                            be its own pass (deadlocks if shared). Use gpufl\n"
-        "                            monitor for monitoring-only GPU/host telemetry.\n"
+        "                            Default: Trace. Deep runs PcSampling+SassMetrics\n"
+        "                            in one pass (same as the embedded Deep engine);\n"
+        "                            for timeline+stalls+SASS list passes explicitly,\n"
+        "                            e.g. Trace,PcSampling,SassMetrics. SassMetrics\n"
+        "                            must be its own pass (deadlocks if shared). Use\n"
+        "                            gpufl monitor for monitoring-only telemetry.\n"
         "                            PcSampling / PM / Range passes may need NVIDIA\n"
         "                            performance-counter access.\n"
         "    -q, --quiet             Suppress launcher chatter (errors still printed)\n"
@@ -271,7 +272,6 @@ TraceParseResult parseTraceArgs(const std::vector<std::string>& argv) {
             // be a single engine, or a '+'-joined group ("Trace+PcSampling")
             // that runs those engines together in one process (a composite).
             out.passes.clear();
-            bool saw_deep = false;
             size_t start = 0;
             while (true) {
                 const size_t comma = v.find(',', start);
@@ -281,7 +281,6 @@ TraceParseResult parseTraceArgs(const std::vector<std::string>& argv) {
                 if (!item.empty()) {
                     const std::string perr = validatePassToken(item);
                     if (!perr.empty()) return {std::nullopt, perr};
-                    saw_deep = saw_deep || item == "Deep";
                     out.passes.push_back(item);
                 }
                 if (comma == std::string::npos) break;
@@ -289,10 +288,6 @@ TraceParseResult parseTraceArgs(const std::vector<std::string>& argv) {
             }
             if (out.passes.empty()) {
                 return {std::nullopt, "--passes requires at least one engine"};
-            }
-            if (saw_deep && out.passes.size() != 1) {
-                return {std::nullopt,
-                        "--passes=Deep is a preset and cannot be combined with other passes"};
             }
         } else if (key == "--backend-url") {
             auto err = take_value(out.backend_url);
@@ -612,9 +607,6 @@ MonitorParseResult parseMonitorArgs(const std::vector<std::string>& argv) {
 
 std::vector<std::string> resolvePassPlan(const TraceArgs& args) {
     if (args.passes.empty()) return {"Trace"};
-    if (args.passes.size() == 1 && args.passes.front() == "Deep") {
-        return {"Trace", "PcSampling", "SassMetrics"};
-    }
     return args.passes;
 }
 

--- a/daemon/launcher/cli_parse.hpp
+++ b/daemon/launcher/cli_parse.hpp
@@ -14,9 +14,10 @@ struct TraceArgs {
     std::string name;                   // --name / -n; default: basename of cmd[0]
     std::string output_dir;             // --output / -o; default: ~/.gpufl/traces/{ts}_{sid}
     // --passes: explicit capture plan: a comma-separated list of engines, one
-    // isolated pass each (e.g. "Trace,PcSampling,SassMetrics"). "--passes=Deep"
-    // is a shorthand for the default deep plan. Empty here means "no explicit
-    // plan"; the launcher runs a single Trace pass.
+    // isolated pass each (e.g. "Trace,PcSampling,SassMetrics"). "Deep" is just
+    // the Deep engine (PcSampling + SassMetrics in one pass), like any other
+    // token. Empty here means "no explicit plan"; the launcher runs a single
+    // Trace pass.
     std::vector<std::string> passes;
     bool verbose = false;               // -v
     bool quiet = false;                 // -q
@@ -102,13 +103,11 @@ TraceParseResult parseTraceArgs(const std::vector<std::string>& argv);
 
 // Resolves the ordered capture plan (one isolated CUPTI engine per pass) from
 // parsed trace args. Precedence:
-//   1. --passes=Deep        -> the default deep plan
-//                             [Trace, PcSampling, SassMetrics];
-//   2. explicit --passes    -> the listed engines, one pass each;
-//   3. otherwise            -> a single Trace pass.
+//   1. explicit --passes    -> the listed engines, one pass each (Deep is the
+//                             Deep engine, not an expansion);
+//   2. otherwise            -> a single Trace pass.
 // A returned size() > 1 is a multi-pass run (the launcher assigns one
-// analysis_id and labels each pass). This is the single source of truth for
-// the default deep plan, shared by the Linux and Windows launchers.
+// analysis_id and labels each pass), shared by the Linux and Windows launchers.
 std::vector<std::string> resolvePassPlan(const TraceArgs& args);
 
 // Parses the args passed to `gpufl upload`. On success returns the

--- a/example/cuda/sass_divergence_demo.cu
+++ b/example/cuda/sass_divergence_demo.cu
@@ -150,7 +150,7 @@ int main() {
     opts.enable_debug_output = true;
     opts.continuous_system_sampling = true;
     opts.enable_stack_trace = true;
-    opts.profiling_engine = gpufl::ProfilingEngine::RangeProfilerKernelReplay;
+    opts.profiling_engine = gpufl::ProfilingEngine::Trace;
 
     if (!gpufl::init(opts)) {
         std::cerr << "Failed to initialize gpufl" << std::endl;

--- a/example/python/02_numba_cuda.py
+++ b/example/python/02_numba_cuda.py
@@ -49,8 +49,6 @@ def run_benchmark():
         system_sample_rate_ms=100,
         enable_debug_output=True,
         profiling_engine=gfl.ProfilingEngine.Deep,
-        backend_url=BACKEND_URL,
-        api_key=API_KEY,
     )
 
     try:

--- a/example/python/03_pytorch_benchmark.py
+++ b/example/python/03_pytorch_benchmark.py
@@ -45,8 +45,6 @@ def run_stress_test():
                # Blackwell driver builds; we've tested it here so
                # it's safe to enable for this benchmark.
                enable_cuda_graphs_tracking=True,
-               api_key=api_key,
-               backend_url=backend_url,
                profiling_engine=gpufl.ProfilingEngine.Deep)
 
     try:

--- a/include/gpufl/backends/nvidia/cupti_backend.cpp
+++ b/include/gpufl/backends/nvidia/cupti_backend.cpp
@@ -961,16 +961,18 @@ void CuptiBackend::start() {
 
     // MEMORY2 records capture cudaMalloc / cudaFree /
     // cudaMallocAsync / cudaFreeAsync / cudaMallocManaged with
-    // address, bytes, and memoryKind. **Default-off** in v1 (see
-    // InitOptions::enable_memory_tracking) because TF eager and
-    // similar workloads can produce a high volume; opt-in until we
-    // validate overhead in the field.
+    // address, bytes, and memoryKind. Gated on enable_memory_tracking
+    // (default-off in the base InitOptions; opt-in until we validate
+    // overhead) plus the SASS-safety gate AllowSassMemory2Activity().
+    // NOT tied to kernel/timeline activity - allocation tracking is an
+    // independent CUPTI activity, so it works in SASS / Deep mode too
+    // (where kernel activity is off by default).
     //
     // Soft-fail on enable: older CUPTI versions (CUDA 11) shipped
     // without MEMORY2 - they had MEMORY (deprecated) which has a
     // different record shape. We don't try to fall back; if MEMORY2
-    // isn't available we log and continue without F3 attribution.
-    if (timelineActivity && opts_.enable_memory_tracking && AllowSassMemory2Activity()) {
+    // isn't available we log and continue.
+    if (opts_.enable_memory_tracking && AllowSassMemory2Activity()) {
         const CUptiResult res_mem =
             cuptiActivityEnable(CUPTI_ACTIVITY_KIND_MEMORY2);
         if (res_mem != CUPTI_SUCCESS) {
@@ -1173,7 +1175,7 @@ void CuptiBackend::ReenableActivityAfterEngineStart_() {
     }
 
     // F3: matching post-engine re-enable for MEMORY2.
-    if (timelineActivity && opts_.enable_memory_tracking && AllowSassMemory2Activity()) {
+    if (opts_.enable_memory_tracking && AllowSassMemory2Activity()) {
         const CUptiResult mem_res =
             cuptiActivityEnable(CUPTI_ACTIVITY_KIND_MEMORY2);
         GFL_LOG_DEBUG(
@@ -1659,18 +1661,16 @@ void CuptiBackend::EmitCaptureCapabilities_() const {
                             : "PC sampling source correlation was enabled but emitted no source locator/function records.")
                       : "CUDA source-line correlation was not collected in this session.");
     const bool memoryRequestedAndAllowed =
-        kernelActivity && opts_.enable_memory_tracking && AllowSassMemory2Activity();
+        opts_.enable_memory_tracking && AllowSassMemory2Activity();
     AddCapability(evt, "memory_activity",
-                  kernelActivity && opts_.enable_memory_tracking,
+                  opts_.enable_memory_tracking,
                   memoryRequestedAndAllowed
                       ? (memoryHasData ? "collected" : "enabled_no_data")
-                      : (opts_.enable_memory_tracking
-                            ? (kernelActivity ? "skipped" : "not_requested")
-                            : "not_requested"),
+                      : (opts_.enable_memory_tracking ? "skipped" : "not_requested"),
                   memoryRequestedAndAllowed ? "cupti_memory" : "disabled",
                   memoryRequestedAndAllowed
                       ? (memoryHasData ? "" : "enabled_but_no_records")
-                      : (kernelActivity && opts_.enable_memory_tracking && !AllowSassMemory2Activity()
+                      : (opts_.enable_memory_tracking && !AllowSassMemory2Activity()
                             ? "sass_safe_mode_memory_activity_disabled" : ""),
                   memoryRequestedAndAllowed
                       ? (memoryHasData
@@ -2113,13 +2113,13 @@ void CUPTIAPI CuptiBackend::BufferCompleted(CUcontext context,
                             entry.name     = m->name   ? m->name   : "";
                             entry.domain   = m->domain ? m->domain : "";
                             entry.start_ts = m->timestamp;
-                            std::lock_guard<std::mutex> lk(g_nvtxMu);
+                            std::lock_guard lk(g_nvtxMu);
                             g_nvtxOpen[m->id] = std::move(entry);
                         } else if (isEnd) {
                             NvtxOpen entry;
                             bool found = false;
                             {
-                                std::lock_guard<std::mutex> lk(g_nvtxMu);
+                                std::lock_guard lk(g_nvtxMu);
                                 auto it = g_nvtxOpen.find(m->id);
                                 if (it != g_nvtxOpen.end()) {
                                     entry = std::move(it->second);

--- a/include/gpufl/backends/nvidia/engine/range_profiler_engine.cpp
+++ b/include/gpufl/backends/nvidia/engine/range_profiler_engine.cpp
@@ -128,7 +128,7 @@ void RangeProfilerEngine::onPerfScopeStart(const char* name) {
     if (mode_ != Mode::Scope) return;
     attempted_.store(true, std::memory_order_relaxed);
     GFL_LOG_DEBUG("[RangeProfilerEngine] onPerfScopeStart name=",
-                  (name ? name : "(null)"), " active=", perf_session_active_);
+                  name ? name : "(null)", " active=", perf_session_active_);
     if (!perf_session_active_) {
         if (!InitPerfworksSession_(true)) return;
     }

--- a/include/gpufl/backends/nvidia/profiling_plan.hpp
+++ b/include/gpufl/backends/nvidia/profiling_plan.hpp
@@ -11,7 +11,7 @@ namespace gpufl {
 
 struct ProfilingRequest {
     ProfilingEngine engine = ProfilingEngine::Monitor;
-    bool enable_memory_tracking = false;
+    bool enable_memory_tracking = true;
     bool enable_external_correlation = true;
     bool enable_synchronization = true;
     bool enable_cuda_graphs_tracking = false;
@@ -47,21 +47,21 @@ struct EnvOverrides {
 
     static EnvOverrides FromProcess() {
         EnvOverrides env;
-        env.sass_metrics_only = Enabled(gpufl::env::kSassMetricsOnly);
-        env.sass_force_safe_activity = Enabled(gpufl::env::kSassForceSafeActivity);
-        env.sass_allow_full_activity = Enabled(gpufl::env::kSassAllowFullActivity);
-        env.sass_allow_kernel_activity = Enabled(gpufl::env::kSassAllowKernelActivity);
-        env.sass_allow_marker_activity = Enabled(gpufl::env::kSassAllowMarkerActivity);
+        env.sass_metrics_only = Enabled(env::kSassMetricsOnly);
+        env.sass_force_safe_activity = Enabled(env::kSassForceSafeActivity);
+        env.sass_allow_full_activity = Enabled(env::kSassAllowFullActivity);
+        env.sass_allow_kernel_activity = Enabled(env::kSassAllowKernelActivity);
+        env.sass_allow_marker_activity = Enabled(env::kSassAllowMarkerActivity);
         env.sass_allow_mem_transfer_activity =
-            Enabled(gpufl::env::kSassAllowMemTransferActivity);
-        env.sass_allow_memory2_activity = Enabled(gpufl::env::kSassAllowMemory2Activity);
-        env.sass_allow_memory_activity = Enabled(gpufl::env::kSassAllowMemoryActivity);
-        env.sass_allow_sync_activity = Enabled(gpufl::env::kSassAllowSyncActivity);
-        env.sass_allow_graph_activity = Enabled(gpufl::env::kSassAllowGraphActivity);
+            Enabled(env::kSassAllowMemTransferActivity);
+        env.sass_allow_memory2_activity = Enabled(env::kSassAllowMemory2Activity);
+        env.sass_allow_memory_activity = Enabled(env::kSassAllowMemoryActivity);
+        env.sass_allow_sync_activity = Enabled(env::kSassAllowSyncActivity);
+        env.sass_allow_graph_activity = Enabled(env::kSassAllowGraphActivity);
         env.sass_allow_external_correlation =
-            Enabled(gpufl::env::kSassAllowExternalCorrelation);
-        env.disable_cubin_capture = Enabled(gpufl::env::kDisableCubinCapture);
-        env.sass_disable_cubin_capture = Enabled(gpufl::env::kSassDisableCubinCapture);
+            Enabled(env::kSassAllowExternalCorrelation);
+        env.disable_cubin_capture = Enabled(env::kDisableCubinCapture);
+        env.sass_disable_cubin_capture = Enabled(env::kSassDisableCubinCapture);
         return env;
     }
 };

--- a/include/gpufl/core/events.hpp
+++ b/include/gpufl/core/events.hpp
@@ -571,16 +571,16 @@ struct KernelPerfMetricEvent {
 };
 
 /**
- * NVTX range captured via CUPTI_ACTIVITY_KIND_MARKER. Sources include:
- *   - GFL_SCOPE (which auto-emits nvtxRangePushA/Pop as of the PyTorch
- *     integration work)
+ * NVTX-style named range, captured via CUPTI_ACTIVITY_KIND_MARKER (or
+ * gpufl's NVTX injection under `gpufl trace`). Sources include:
  *   - PyTorch's automatic NVTX annotations (via torch.cuda.nvtx or our
  *     gpufl.torch.TorchDispatchMode wrapping)
  *   - cuDNN / cuBLAS / NCCL / TensorRT which emit NVTX internally
  *   - User-emitted nvtxRangePush / nvtxMarkA calls
  *
- * Paired START/END records from CUPTI are merged in the client before
- * emitting; one NvtxMarkerEvent per completed range.
+ * gpufl's own scopes are NOT emitted here - they are recorded as
+ * scope_event only. Paired START/END records from CUPTI are merged in the
+ * client before emitting; one NvtxMarkerEvent per completed range.
  */
 struct NvtxMarkerEvent {
     int pid = 0;

--- a/include/gpufl/core/gpufl.cpp
+++ b/include/gpufl/core/gpufl.cpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <atomic>
 #include <cctype>
+#include <cstdio>
 #include <cstdlib>
 #include <filesystem>
 #include <fstream>
@@ -95,7 +96,7 @@ namespace detail {
 // around the caller's cleanup. `noinline` makes the intent explicit.
 __declspec(noinline) inline int SafeNvtxRangePushA(const char* name) {
     __try {
-        return ::nvtxRangePushA(name);
+        return nvtxRangePushA(name);
     } __except (EXCEPTION_EXECUTE_HANDLER) {
         // An AV here means NVTX's injection table has a null entry.
         // Mark NVTX unavailable so the rest of the session skips it.
@@ -276,28 +277,15 @@ bool init(const InitOptions& opts) {
     }
 
     {
-        std::string url  = g_opts.backend_url;
-        std::string key  = g_opts.api_key;
+        // Resolve api_path (InitOptions value or GPUFL_API_PATH) and normalize
+        // once - the version-discovery probe below appends to it. Backend
+        // creds live on UploadOptions now, not InitOptions; the probe reads
+        // GPUFL_BACKEND_URL straight from the environment.
         std::string apiPath = g_opts.api_path;
-        if (url.empty()) {
-            if (const char* e = std::getenv(gpufl::env::kBackendUrl)) url = e;
-            // Legacy name - accept for one release to ease migration.
-            else if (const char* e2 = std::getenv(gpufl::env::kRemoteConfig)) url = e2;
-        }
-        if (key.empty()) {
-            if (const char* e = std::getenv(gpufl::env::kApiKey)) key = e;
-        }
         if (apiPath.empty()) {
             if (const char* e = std::getenv(gpufl::env::kApiPath)) apiPath = e;
         }
-        // Normalize once - every downstream consumer (HttpLogSink wiring
-        // below, the version-discovery probe) just appends after this.
-        apiPath = normalizeApiPath(apiPath);
-        // Reflect env-var-resolved values back onto g_opts so downstream
-        // consumers see consistent values.
-        g_opts.backend_url  = url;
-        g_opts.api_key      = key;
-        g_opts.api_path     = apiPath;
+        g_opts.api_path = normalizeApiPath(apiPath);
     }
 
     DebugLogger::setEnabled(g_opts.enable_debug_output);
@@ -352,33 +340,17 @@ bool init(const InitOptions& opts) {
         return false;
     }
 
-    // `remote_upload` is a backward-compat shim in v1.1: live
-    // HttpLogSink streaming is gone, but to preserve the old "set
-    // one flag and forget" UX, gpufl::shutdown() (below) automatically
-    // invokes gpufl::uploadLogs() with the configured backend_url +
-    // api_key after the file sink is closed. We log a deprecation
-    // notice here at init time so users see they're on the legacy
-    // path. Removed in v1.2 - at which point callers must invoke
-    // uploadLogs() (or gpufl.session() in Python) explicitly.
-    if (g_opts.remote_upload) {
-        GFL_LOG_ERROR(
-            "[DEPRECATED] opts.remote_upload=true is a v1.1 backward-"
-            "compat shim. Live HTTP streaming was removed; "
-            "gpufl::shutdown() will auto-call gpufl::uploadLogs() at "
-            "the end of the session instead. This flag, and "
-            "backend_url / api_key on InitOptions, will be removed "
-            "entirely in v1.2 - switch to passing creds directly to "
-            "UploadOptions / gpufl::uploadLogs() in new code.");
-    }
-
     // Fire-and-forget version-discovery probe. Hits
     // <backend_url><api_path>/info/version with 2s timeouts to detect
     // client/backend version drift early and emit a clear warning.
     // Must NEVER block init - detached, bounded by httplib timeouts.
-    // Skipped when backend_url is empty (offline / file-only mode).
-    if (!g_opts.backend_url.empty()) {
-        std::thread([url = g_opts.backend_url,
-                     ap  = g_opts.api_path] {
+    // Reads GPUFL_BACKEND_URL from the environment (creds live on
+    // UploadOptions now); skipped when unset (offline / file-only mode).
+    std::string probeUrl;
+    if (const char* e = std::getenv(gpufl::env::kBackendUrl)) probeUrl = e;
+    else if (const char* e2 = std::getenv(gpufl::env::kRemoteConfig)) probeUrl = e2;
+    if (!probeUrl.empty()) {
+        std::thread([url = probeUrl, ap = g_opts.api_path] {
             probeBackendVersion(url, ap);
         }).detach();
     }
@@ -690,45 +662,6 @@ void shutdown() {
     rt->logger->close();
     GFL_LOG_DEBUG("Shutdown: logger->close() returned");
 
-    // remote_upload deprecation shim - auto-call uploadLogs() at the
-    // end of shutdown() so pure-C++ callers who set the legacy flag
-    // still get their data shipped. Matches the Python side's atexit
-    // handler. The file sink has been closed above, so all NDJSON
-    // events are guaranteed flushed to disk before uploadLogs reads
-    // them back. Removed in v1.2 along with the field. (See gpufl.hpp.)
-    if (g_opts.remote_upload && !g_opts.backend_url.empty() &&
-        !g_opts.api_key.empty() && !g_opts.log_path.empty()) {
-        GFL_LOG_DEBUG(
-            "[remote_upload shim] running uploadLogs() at shutdown - "
-            "log_path=", g_opts.log_path,
-            " backend_url=", g_opts.backend_url);
-        UploadOptions uopts;
-        uopts.log_path    = g_opts.log_path;
-        uopts.backend_url = g_opts.backend_url;
-        uopts.api_key     = g_opts.api_key;
-        uopts.api_path    = g_opts.api_path;
-        // Use defaults for the rest - timeouts, retries, etc. The
-        // upload runs synchronously here; in the legacy live-streaming
-        // model this work was amortized across the workload, so
-        // total shutdown wall time may now be noticeably longer
-        // (proportional to log volume). Acceptable trade-off - the
-        // alternative was silent data loss.
-        const auto r = uploadLogs(uopts);
-        if (r.success) {
-            GFL_LOG_DEBUG(
-                "[remote_upload shim] uploadLogs OK - ",
-                r.events_uploaded, " event(s), ",
-                r.bytes_uploaded, " bytes, ",
-                r.elapsed_ms, "ms");
-        } else {
-            GFL_LOG_ERROR(
-                "[remote_upload shim] uploadLogs FAILED - ",
-                r.warnings.size(), " warning(s); first: ",
-                r.warnings.empty() ? std::string("(none)") :
-                                     r.warnings.front());
-        }
-    }
-
     set_runtime(nullptr);
 
     GFL_LOG_DEBUG("Shutdown complete!");
@@ -810,26 +743,15 @@ void ScopedMonitor::init_(const ScopeMeta& meta) {
     // (GPUFL_ENGINE_COMBO) is active even with a Trace base - otherwise a
     // Trace+RangeProfiler combo would never trigger Range's perf scope. Harmless
     // no-op for engines that don't use perf scopes (PC / PM).
-    const char* comboEnv = std::getenv(gpufl::env::kEngineCombo);
+    const char* comboEnv = std::getenv(env::kEngineCombo);
     const bool comboActive = comboEnv && comboEnv[0] != '\0';
     if (g_opts.profiling_engine != ProfilingEngine::Monitor &&
         (g_opts.profiling_engine != ProfilingEngine::Trace || comboActive)) {
         Monitor::BeginPerfScope(name_.c_str());
     }
-
-    // Emit an NVTX range alongside the native scope_event. This makes the
-    // scope visible to Nsight Systems and captured uniformly via CUPTI's
-    // marker activity path (same pipeline that picks up PyTorch /
-    // cuDNN / NCCL framework ranges). No-op if NVTX isn't available.
-    GPUFL_NVTX_PUSH(name_.c_str());
 }
 
 ScopedMonitor::~ScopedMonitor() {
-    // Pop the NVTX range first - symmetric with the push in the
-    // constructor. Safe to call even if runtime() is gone; NVTX keeps
-    // its own internal range stack.
-    GPUFL_NVTX_POP();
-
     Runtime* rt = runtime();
     if (!rt || !rt->logger) {
         // Best-effort: if the runtime is already gone but we'd taken a
@@ -853,15 +775,19 @@ ScopedMonitor::~ScopedMonitor() {
     auto& stack = getThreadScopeStack();
     if (!stack.empty()) stack.pop_back();
     const int depth = static_cast<int>(stack.size());
+    const int64_t end_ns = detail::GetTimestampNs();
 
     ScopeBatchRow row;
-    row.ts_ns = detail::GetTimestampNs();
+    row.ts_ns = end_ns;
     row.scope_instance_id = scope_id_;
     row.name_id = Monitor::InternScopeName(name_);
     row.event_type = 1;  // end
     row.depth = depth;
     Monitor::PushScopeRow(row);
 
+    // Scopes are recorded via scope_event only - we no longer echo each
+    // scope as an NVTX marker. That echo duplicated scope_event (the SPA
+    // had to de-dupe it) and only the framework NVTX path remains useful.
     Monitor::EndProfilerScope(name_.c_str());
     const char* comboEnv = std::getenv(gpufl::env::kEngineCombo);
     const bool comboActive = comboEnv && comboEnv[0] != '\0';
@@ -877,7 +803,7 @@ ScopedMonitor::~ScopedMonitor() {
                 pe.session_id = rt->session_id;
                 pe.name = name_;
                 pe.start_ns = start_ns_;
-                pe.end_ns = detail::GetTimestampNs();
+                pe.end_ns = end_ns;
                 rt->logger->write(model::PerfMetricModel(pe));
 
                 GFL_LOG_DEBUG("Log Perf Metric Event");

--- a/include/gpufl/core/monitor.hpp
+++ b/include/gpufl/core/monitor.hpp
@@ -144,9 +144,8 @@ struct MonitorOptions {
     // CuptiBackend::start() - flag false means we never call
     // cuptiActivityEnable for the kind, so zero overhead.
     bool enable_synchronization = true;
-    // Gate for CUPTI_ACTIVITY_KIND_MEMORY2. Mirror of
-    // InitOptions::enable_memory_tracking. Default-off in v1.
-    bool enable_memory_tracking = false;
+    // Gate for CUPTI_ACTIVITY_KIND_MEMORY2.
+    bool enable_memory_tracking = true;
     // Gate for CUPTI_ACTIVITY_KIND_GRAPH_TRACE. Mirror of
     // InitOptions::enable_cuda_graphs_tracking. Default-off in v1.
     bool enable_cuda_graphs_tracking = false;

--- a/include/gpufl/gpufl.hpp
+++ b/include/gpufl/gpufl.hpp
@@ -38,14 +38,11 @@ struct InitOptions {
      *           you only care about telemetry during specific phases of
      *           your application (e.g. inside a training-step scope).
      *
-     * Renamed from `sampling_auto_start` in this release. The old name
-     * referred only to init-time auto-start and didn't capture the
-     * scope-bracketing behavior, which was silently broken when the
-     * flag was off. C++ callers must rename to `continuous_system_sampling`;
-     * the compiler will surface this as a "no member named
-     * 'sampling_auto_start'" error pointing at their call site. Python
-     * callers using the old kwarg name keep working for one release
-     * with a DeprecationWarning (see python/gpufl/__init__.py).
+     * Renamed from `sampling_auto_start` (the old name described only
+     * init-time auto-start and missed the scope-bracketing behavior). The
+     * old name is removed in v1.2: C++ hits a "no member named
+     * 'sampling_auto_start'" compile error, Python raises a `TypeError`
+     * pointing at `continuous_system_sampling`.
      */
     bool continuous_system_sampling = false;
     bool enable_debug_output = false;
@@ -74,15 +71,11 @@ struct InitOptions {
     bool enable_synchronization = true;
     // Enable CUPTI_ACTIVITY_KIND_MEMORY2 to capture cudaMalloc /
     // cudaFree / cudaMallocAsync / cudaMallocManaged / cudaMallocHost
-    // with timing, address, size, and kind. **Default-off** in v1
-    // because TensorFlow eager mode and similar can produce a high
-    // record rate, and we want a couple of internal sessions to
-    // validate overhead before flipping it on by default. PyTorch
-    // workloads with the caching allocator typically generate <1k
-    // events per session, so it's safe to enable manually for those
-    // (and that's why we surface the toggle prominently rather than
-    // burying it in a config file).
-    bool enable_memory_tracking = false;
+    // with timing, address, size, and kind. **Default-on**: PyTorch's
+    // caching allocator generates <1k events per session, so the
+    // overhead is negligible. Set false for alloc-heavy workloads
+    // (e.g. TensorFlow eager) where the record rate is high.
+    bool enable_memory_tracking = true;
     // Enable CUPTI_ACTIVITY_KIND_GRAPH_TRACE to capture per-launch
     // timing for cudaGraphLaunch calls. **Default-off** in v1 because
     // CUDA Graphs interact with PC Sampling on some Blackwell driver
@@ -130,31 +123,6 @@ struct InitOptions {
     std::string config_file = "";
 
     /**
-     * GPUFlight backend base URL - e.g. "https://api.gpuflight.com" or
-     * "http://localhost:8080". Host-only; do NOT include the API
-     * prefix (use {@link api_path} for that).
-     *
-     * Read by:
-     *   - the version-discovery probe at init time
-     *   - {@link gpufl::uploadLogs} when you call it post-shutdown
-     *     (stored on InitOptions so the deferred upload path can pick
-     *     it up without the caller having to re-supply it)
-     *
-     * Setting this alone does nothing - no HTTP runs during a session.
-     * Upload is a separate step (`gpufl::uploadLogs`, or the
-     * `gpufl.session()` Python context manager).
-     *
-     * **DEPRECATION NOTE (v1.2 removal)**: this field - together with
-     * {@link api_key} and {@link remote_upload} - is planned for
-     * removal in v1.2. Long-term, all backend creds will be passed
-     * directly to {@link gpufl::uploadLogs} (and the version probe
-     * will read `GPUFL_BACKEND_URL` directly). The fields stay
-     * functional in v1.1 to keep the migration painless; if you're
-     * starting fresh, prefer passing creds straight to `UploadOptions`.
-     */
-    std::string backend_url = "";
-
-    /**
      * Override for the URL path prefix the agent uses when calling
      * the backend. Empty (default) → the client uses the version it
      * was compiled against (currently `/api/v1`, see
@@ -173,49 +141,6 @@ struct InitOptions {
      */
     std::string api_path = "";
 
-    /**
-     * API key for log upload to the GPUFlight backend.
-     * Sent as `Authorization: Bearer <key>` on event POSTs.
-     *
-     * **DEPRECATION NOTE (v1.2 removal)**: planned for removal in v1.2
-     * together with {@link backend_url} and {@link remote_upload}.
-     * Long-term, pass creds directly to {@link gpufl::uploadLogs}.
-     */
-    std::string api_key = "";
-
-    /**
-     * **DEPRECATED - v1.1 backward-compat shim, removed in v1.2.**
-     *
-     * Previously attached an HttpLogSink that POSTed NDJSON events live
-     * during the session. That mechanism is gone in v1.1. To preserve
-     * the old "set one flag and forget" UX, this field now triggers an
-     * **automatic** call to {@link gpufl::uploadLogs} at the end of
-     * {@link gpufl::shutdown}, using {@link backend_url} +
-     * {@link api_key} from this InitOptions.
-     *
-     * Behavior with `remote_upload = true`:
-     *   - **At init()**: logs a deprecation message pointing at the
-     *     new API. No HTTP is opened.
-     *   - **At shutdown()**: after the file sink has flushed and
-     *     closed, `gpufl::uploadLogs(uopts)` is invoked synchronously
-     *     with creds copied from InitOptions. Failures are logged but
-     *     never thrown - the process exits cleanly either way.
-     *   - **In Python**: the wrapper emits a `DeprecationWarning` and
-     *     also schedules upload via `atexit`, so notebook / script
-     *     callers who never explicitly call shutdown() still get the
-     *     same delivery.
-     *
-     * Wall-time impact: the legacy live-streaming model amortized HTTP
-     * work across the session; the new shim does it all at shutdown.
-     * Expect shutdown to take seconds-to-minutes proportional to log
-     * volume. To avoid the wait or to control timing, drop the flag
-     * and call `gpufl::uploadLogs(uopts)` directly when convenient.
-     *
-     * In v1.2 this field - together with {@link backend_url} and
-     * {@link api_key} - is removed; creds move entirely onto
-     * `UploadOptions`. See `include/gpufl/upload/upload_logs.hpp`.
-     */
-    bool remote_upload = false;
 
     /**
      * Global kill switch. When false, {@link gpufl::init} returns false
@@ -299,7 +224,6 @@ inline InitOptions injection_mode_default_options() {
     opts.profiling_engine            = ProfilingEngine::Deep;
     opts.system_sample_rate_ms       = 100;
     opts.kernel_sample_rate_ms       = 1000;
-    opts.remote_upload               = false;
     return opts;
 }
 
@@ -337,7 +261,6 @@ inline InitOptions monitoring_mode_default_options() {
     opts.flush_logs_always           = false;
     opts.profiling_engine            = ProfilingEngine::Monitor;
     opts.system_sample_rate_ms       = 250;
-    opts.remote_upload               = false;
     return opts;
 }
 
@@ -409,9 +332,9 @@ class ScopedMonitor {
 
    private:
     // Shared ctor body - all constructors funnel through this so the
-    // begin-row push, NVTX push, and profiler-scope hooks live in one
-    // place. `meta` defaults to ScopeMeta{} (zeros) for the legacy
-    // overloads, so their wire output is byte-for-byte unchanged.
+    // begin-row push and profiler-scope hooks live in one place. `meta`
+    // defaults to ScopeMeta{} (zeros) for the legacy overloads, so their
+    // wire output is byte-for-byte unchanged.
     void init_(const ScopeMeta& meta);
 
     std::string name_;

--- a/include/gpufl/inject/inject_entry.cpp
+++ b/include/gpufl/inject/inject_entry.cpp
@@ -209,9 +209,8 @@ void shutdownAndSignal() {
         gpufl::shutdown();
         GFL_LOG_DEBUG("inject: gpufl::shutdown() returned");
 
-        // --upload: ship the just-written NDJSON to the backend. This is
-        // the forward path (gpufl::uploadLogs), not the deprecated
-        // opts.remote_upload shim. All network I/O happens here, after
+        // --upload: ship the just-written NDJSON to the backend via
+        // gpufl::uploadLogs. All network I/O happens here, after
         // shutdown() flushed the logs and the GPU workload is done, so it
         // can never affect the target's exit code or perf. Best-effort:
         // any failure is reported via gpufl's own debug log, never raised.

--- a/python/bindings.cpp
+++ b/python/bindings.cpp
@@ -106,20 +106,6 @@ PYBIND11_MODULE(_gpufl_client, m) {
         .def_readwrite("pm_sampling_metrics", &gpufl::InitOptions::pm_sampling_metrics)
         .def_readwrite("pm_sampling_scope_only", &gpufl::InitOptions::pm_sampling_scope_only)
         .def_readwrite("profiling_engine",      &gpufl::InitOptions::profiling_engine)
-        // Backend interactions - backend_url is the BASE URL of the
-        // GPUFlight backend. Upload is a separate post-shutdown step
-        // via gpufl.upload_logs() / gpufl.session(); nothing on
-        // InitOptions controls upload directly anymore.
-        // (The historical `config_name` / remote-config-fetch binding
-        // was removed along with the backend's ConfigController.)
-        .def_readwrite("backend_url",           &gpufl::InitOptions::backend_url)
-        .def_readwrite("api_key",               &gpufl::InitOptions::api_key)
-        // DEPRECATED in v1.1, planned removal v1.2 alongside
-        // backend_url + api_key. See InitOptions docstring in
-        // gpufl.hpp. Field is a no-op at the C++ level; the Python
-        // wrapper around init() turns remote_upload=True into an
-        // atexit-scheduled upload_logs() call for backward compat.
-        .def_readwrite("remote_upload",         &gpufl::InitOptions::remote_upload)
         // Global kill switch - when false, gpufl::init returns false
         // immediately and every downstream call is a no-op via the
         // null-runtime guards. The high-level Python wrapper
@@ -147,9 +133,6 @@ PYBIND11_MODULE(_gpufl_client, m) {
                      bool enable_source_collection,
                      gpufl::ProfilingEngine profiling_engine,
                      std::string config_file,
-                     std::string backend_url,
-                     std::string api_key,
-                     bool remote_upload,
                      bool enable_external_correlation,
                      bool enable_synchronization,
                      bool enable_memory_tracking,
@@ -174,9 +157,6 @@ PYBIND11_MODULE(_gpufl_client, m) {
         opts.flush_logs_always     = flush_logs_always;
         opts.profiling_engine      = profiling_engine;
         opts.config_file           = config_file;
-        opts.backend_url           = std::move(backend_url);
-        opts.api_key               = std::move(api_key);
-        opts.remote_upload         = remote_upload;
         opts.enable_external_correlation = enable_external_correlation;
         opts.enable_synchronization      = enable_synchronization;
         opts.enable_memory_tracking      = enable_memory_tracking;
@@ -199,12 +179,9 @@ PYBIND11_MODULE(_gpufl_client, m) {
        py::arg("enable_source_collection")    = true,
        py::arg("profiling_engine")            = gpufl::ProfilingEngine::Monitor,
        py::arg("config_file")                 = "",
-       py::arg("backend_url")                 = "",
-       py::arg("api_key")                     = "",
-       py::arg("remote_upload")               = false,
        py::arg("enable_external_correlation") = true,
        py::arg("enable_synchronization")      = true,
-       py::arg("enable_memory_tracking")      = false,
+       py::arg("enable_memory_tracking")      = true,
        py::arg("enable_cuda_graphs_tracking") = false,
        py::arg("pm_sampling_interval_us")     = 100,
        py::arg("pm_sampling_max_samples")     = 4096,

--- a/python/gpufl/__init__.py
+++ b/python/gpufl/__init__.py
@@ -245,9 +245,6 @@ except ImportError as e:
             self.pm_sampling_metrics = []
             self.pm_sampling_scope_only = True
             self.config_file = ""
-            self.backend_url = ""
-            self.api_key = ""
-            self.remote_upload = False  # DEPRECATED v1.1, removed v1.2
             self.enabled = True  # mirror C++ InitOptions::enabled
 
     class _CScope:
@@ -298,7 +295,7 @@ except Exception as e:
     print(f"[FATAL] Unexpected error importing _gpufl_client: {e}", file=sys.stderr)
     raise e
 
-__version__ = "1.2.0rc1"
+__version__ = "1.2.0"
 
 # ── Backend upload ────────────────────────────────────────────────────────────
 #
@@ -432,11 +429,11 @@ def _apply_eager_module_loading(profiling_engine):
     os.environ['CUDA_MODULE_LOADING'] = 'EAGER'
 
 
-# Wrap the C++ init to apply env-var fallbacks for backend_url and
-# api_key, and to reject removed kwargs with a clear TypeError.
+# Wrap the C++ init to apply multi-pass env tagging and to reject removed
+# kwargs (remote_upload / sampling_auto_start / backend_url / api_key).
 _original_init = init
 
-def init(*args, backend_url=None, api_key=None, remote_upload=None,
+def init(*args,
          enabled=True, analysis_id=None, pass_index=None, pass_count=None,
          **kwargs):
     """Initialize GPUFlight.
@@ -446,30 +443,14 @@ def init(*args, backend_url=None, api_key=None, remote_upload=None,
 
       1. InitOptions defaults (built-in).
       2. Local config file (config_file=...).
-      3. Env vars (GPUFL_BACKEND_URL / GPUFL_API_KEY /
-         GPUFL_REMOTE_UPLOAD / GPUFL_PROFILING_ENGINE / GPUFL_CONFIG_FILE).
+      3. Env vars (GPUFL_PROFILING_ENGINE / GPUFL_CONFIG_FILE).
       4. The kwargs you pass to this function.
 
+    Backend credentials are NOT init() arguments - pass them to
+    ``gpufl.upload_logs(backend_url=..., api_key=...)`` or
+    ``with gpufl.session(backend_url=..., api_key=...):`` instead.
+
     Args:
-        backend_url: Base URL of the GPUFlight backend
-            (e.g. "https://api.gpuflight.com"). Stored on InitOptions
-            so gpufl.upload_logs() / gpufl.session() can read it back
-            after shutdown without the caller having to re-supply it.
-            On its own it does nothing - upload is a separate step,
-            never live during the workload. **Planned removal v1.2** -
-            see DEPRECATION NOTE on InitOptions.backend_url in
-            include/gpufl/gpufl.hpp.
-        api_key: API key for log upload. Same purpose / lifecycle as
-            backend_url. **Planned removal v1.2.**
-        remote_upload: DEPRECATED (v1.1) - used to enable live HTTP
-            streaming via HttpLogSink. That mechanism is gone. Setting
-            True here still works for one release: emits a
-            DeprecationWarning and registers an atexit handler that
-            calls gpufl.upload_logs() at interpreter exit, preserving
-            the old "set one flag and forget" UX. Prefer
-            `with gpufl.session(backend_url=..., api_key=...):` (auto-
-            orchestrated) or call gpufl.upload_logs(...) explicitly
-            after shutdown. **Removed in v1.2.** Env: `GPUFL_REMOTE_UPLOAD=1`.
         enabled: When False, init becomes a no-op - no daemon spawn, no
             NVML probe, no log files, no atexit handler. Subsequent
             gpufl calls (Scope, shutdown, upload_logs, system_start/stop)
@@ -519,35 +500,34 @@ def init(*args, backend_url=None, api_key=None, remote_upload=None,
     # disabled-then-enabled tests / notebooks without restarting.
     _disabled = False
 
+    # Removed in v1.2: reject the old kwargs with a clear migration
+    # message instead of a cryptic "unexpected keyword argument" from
+    # the C++ binding.
+    if 'remote_upload' in kwargs:
+        raise TypeError(
+            "init(remote_upload=...) was removed in v1.2. Live HTTP "
+            "streaming is gone; upload happens after the session ends. "
+            "Use `with gpufl.session(backend_url=..., api_key=...):` or "
+            "call gpufl.upload_logs(...) after gpufl.shutdown().")
+    if 'sampling_auto_start' in kwargs:
+        raise TypeError(
+            "init(sampling_auto_start=...) was removed in v1.2; use "
+            "'continuous_system_sampling' instead (False = sample only "
+            "inside GFL_SCOPE / between systemStart/stop; True = sample "
+            "continuously from init to shutdown).")
+    if 'backend_url' in kwargs or 'api_key' in kwargs:
+        raise TypeError(
+            "init(backend_url=...) / init(api_key=...) were removed in v1.2 - "
+            "backend credentials live on the upload path now. Pass them to "
+            "gpufl.upload_logs(backend_url=..., api_key=...) or "
+            "`with gpufl.session(backend_url=..., api_key=...):` instead.")
+
     # EAGER module loading is OPT-IN (default: CUDA's normal LAZY). The
     # per-architecture SASS exclusion gate (GPUFL_SASS_EXCLUDE_ARCHS) is the
     # default guard for the CUPTI lazy-patching deadlock. Set
     # GPUFL_EAGER_MODULE_LOADING=1 to force EAGER for this run instead - must
     # happen before the training loop creates the CUDA context, hence here.
     _apply_eager_module_loading(kwargs.get('profiling_engine'))
-
-    # Backward-compat shim: `sampling_auto_start` was renamed to
-    # `continuous_system_sampling` because the old name only described
-    # init-time auto-start and missed the new scope-bracketing behavior
-    # (off → sample only inside GFL_SCOPE / between systemStart/stop).
-    # We accept the old kwarg for one release with a DeprecationWarning,
-    # forwarding it to the new name. Caller passing both is an error.
-    if 'sampling_auto_start' in kwargs:
-        if 'continuous_system_sampling' in kwargs:
-            raise TypeError(
-                "init() got both 'sampling_auto_start' (deprecated) and "
-                "'continuous_system_sampling' - pass only the new name.")
-        import warnings
-        warnings.warn(
-            "'sampling_auto_start' is deprecated; use "
-            "'continuous_system_sampling' instead. With the new name, "
-            "False enables scope-bracketed sampling (sample only inside "
-            "GFL_SCOPE or between systemStart/stop); True samples "
-            "continuously from init to shutdown. The kwarg will be "
-            "removed in a future release.",
-            DeprecationWarning,
-            stacklevel=2)
-        kwargs['continuous_system_sampling'] = kwargs.pop('sampling_auto_start')
 
     # ── Multi-pass analysis grouping ──────────
     # Let an embedded job self-tag as one pass of an analysis group without
@@ -566,98 +546,11 @@ def init(*args, backend_url=None, api_key=None, remote_upload=None,
         if pass_count is not None:
             os.environ['GPUFL_PASS_COUNT'] = str(int(pass_count))
 
-    # Resolve env-var fallbacks. Doing this in Python lets explicit
-    # kwargs win over env; the C++ layer also does env fallback for
-    # the pure-C++ code path, so either side resolving is sufficient.
-    if not backend_url:
-        backend_url = os.environ.get('GPUFL_BACKEND_URL')
-    if not api_key:
-        api_key = os.environ.get('GPUFL_API_KEY')
-    if remote_upload is None:
-        env_upload = os.environ.get('GPUFL_REMOTE_UPLOAD', '').strip().lower()
-        remote_upload = env_upload in ('1', 'true', 'yes', 'on')
-
-    # Forward backend creds to the underlying C++ init via the pybind11
-    # binding. These are needed by gpufl::uploadLogs() at shutdown - they
-    # live on InitOptions so the deferred-upload path can read them back
-    # without the caller having to re-supply them.
-    if backend_url and 'backend_url' not in kwargs:
-        kwargs['backend_url'] = backend_url
-    if api_key and 'api_key' not in kwargs:
-        kwargs['api_key'] = api_key
-
     # Remember where this session writes its logs so clean_logs() can
     # default to it later, and guard against wiping an active session.
     global _session_active, _last_log_path, _last_app_name
     _last_app_name = kwargs.get('app_name', args[0] if args else None)
     _last_log_path = kwargs.get('log_path', args[1] if len(args) > 1 else None)
-
-    # ── remote_upload deprecation shim ──────────────────────────────────
-    #
-    # The kwarg used to attach a live HttpLogSink that streamed every
-    # NDJSON event to the backend during the workload. That sink is
-    # gone. For backward compat we still accept the kwarg, but route
-    # it to the deferred path: register an `atexit` handler that calls
-    # upload_logs() at interpreter exit. Customer code keeps working
-    # unchanged.
-    #
-    # Why atexit (not "call upload_logs from the shutdown wrapper") -
-    # many existing customers don't call gpufl.shutdown() explicitly
-    # and rely on the interpreter exiting to flush everything. Hooking
-    # atexit preserves that pattern. For callers that DO call shutdown()
-    # explicitly, the atexit fires after shutdown() returns - still
-    # correct, just a small delay.
-    #
-    # Removed in v1.2. New code should use `gpufl.session()` or call
-    # `gpufl.upload_logs()` explicitly.
-    if remote_upload:
-        import warnings
-        warnings.warn(
-            "remote_upload=True is deprecated. Live HTTP streaming "
-            "was removed in v1.1 - upload now happens after the "
-            "session ends. For automated upload, use "
-            "`with gpufl.session(backend_url=..., api_key=...):`. "
-            "Your existing code keeps working - gpufl scheduled an "
-            "atexit handler that calls upload_logs() at interpreter "
-            "shutdown. The remote_upload kwarg, plus backend_url and "
-            "api_key on InitOptions, will be removed in v1.2.",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        # Forward to C++ so the C++ side also logs a deprecation
-        # warning (helps pure-C++ callers who hit this via the
-        # ergonomic env-var path).
-        kwargs['remote_upload'] = True
-
-        # Capture creds + log_path NOW. _last_log_path may be reassigned
-        # by a later init() call before the interpreter exits; closing
-        # over current values protects this session's atexit upload.
-        _deferred_url      = backend_url
-        _deferred_key      = api_key
-        _deferred_log_path = (kwargs.get('log_path')
-                              or (args[1] if len(args) > 1 else None)
-                              or _last_log_path)
-        _deferred_api_path = kwargs.get('api_path', '')
-
-        def _atexit_upload():
-            if not _deferred_log_path or not _deferred_url or not _deferred_key:
-                return
-            try:
-                upload_logs(
-                    log_path=_deferred_log_path,
-                    backend_url=_deferred_url,
-                    api_key=_deferred_key,
-                    api_path=_deferred_api_path,
-                )
-            except Exception as e:
-                # atexit handlers must not raise - Python prints a
-                # traceback otherwise, which is confusing for users
-                # who didn't know upload was happening. Log + swallow.
-                print(f"[gpufl] atexit upload_logs failed: {e}",
-                      file=sys.stderr)
-
-        import atexit
-        atexit.register(_atexit_upload)
 
     result = _original_init(*args, **kwargs)
     if result:
@@ -829,11 +722,13 @@ def session(*args, **kwargs):
     """
     # Capture credentials for the post-shutdown upload BEFORE init()
     # mutates kwargs (it pops some of them while resolving env fallbacks).
-    upload_backend_url = (kwargs.get('backend_url')
+    # Pop (not get) the upload creds: they belong to the upload step, and
+    # init() rejects backend_url / api_key / api_path now.
+    upload_backend_url = (kwargs.pop('backend_url', None)
                           or os.environ.get('GPUFL_BACKEND_URL', ''))
-    upload_api_key    = (kwargs.get('api_key')
+    upload_api_key    = (kwargs.pop('api_key', None)
                           or os.environ.get('GPUFL_API_KEY', ''))
-    upload_api_path   = kwargs.get('api_path', '')
+    upload_api_path   = kwargs.pop('api_path', '')
 
     result = init(*args, **kwargs)
     try:

--- a/tests/launcher/test_cli_parse.cpp
+++ b/tests/launcher/test_cli_parse.cpp
@@ -258,7 +258,7 @@ TEST(CliParseTrace, PassesTrimsWhitespace) {
     EXPECT_EQ(r.args->passes[1], "SassMetrics");
 }
 
-TEST(CliParseTrace, PassesDeepPresetParsed) {
+TEST(CliParseTrace, PassesDeepParsedAsEngine) {
     auto r = parseTraceArgs(argsFor({"--passes=Deep", "--", "./bin"}));
     ASSERT_TRUE(r.args.has_value()) << r.error;
     ASSERT_EQ(r.args->passes.size(), 1u);
@@ -283,10 +283,12 @@ TEST(CliParseTrace, PassesEmptyRejected) {
     EXPECT_NE(r.error.find("--passes requires"), std::string::npos);
 }
 
-TEST(CliParseTrace, DeepPresetCannotBeCombined) {
+TEST(CliParseTrace, DeepCanBeAPassAlongsideOthers) {
     auto r = parseTraceArgs(argsFor({"--passes=Trace,Deep", "--", "./bin"}));
-    EXPECT_FALSE(r.args.has_value());
-    EXPECT_NE(r.error.find("cannot be combined"), std::string::npos);
+    ASSERT_TRUE(r.args.has_value()) << r.error;
+    ASSERT_EQ(r.args->passes.size(), 2u);
+    EXPECT_EQ(r.args->passes[0], "Trace");
+    EXPECT_EQ(r.args->passes[1], "Deep");
 }
 
 // ── gpufl trace --passes composite ('+') groups ─────────────────────────────
@@ -348,14 +350,12 @@ TEST(ResolvePassPlan, ExplicitPassesWin) {
     EXPECT_EQ(plan[1], "SassMetrics");
 }
 
-TEST(ResolvePassPlan, DeepExpandsToDefaultPlan) {
+TEST(ResolvePassPlan, DeepResolvesToSinglePass) {
     TraceArgs a;
     a.passes = {"Deep"};
     const auto plan = resolvePassPlan(a);
-    ASSERT_EQ(plan.size(), 3u);
-    EXPECT_EQ(plan[0], "Trace");
-    EXPECT_EQ(plan[1], "PcSampling");
-    EXPECT_EQ(plan[2], "SassMetrics");
+    ASSERT_EQ(plan.size(), 1u);
+    EXPECT_EQ(plan[0], "Deep");
 }
 
 TEST(ResolvePassPlan, SingleExplicitPassIsOnePass) {

--- a/tests/python/test_continuous_system_sampling.py
+++ b/tests/python/test_continuous_system_sampling.py
@@ -162,31 +162,28 @@ def test_continuous_false_with_scope_samples_during_scope(tmp_path):
     )
 
 
-def test_sampling_auto_start_kwarg_deprecation_warning(tmp_path):
-    """Old kwarg `sampling_auto_start` still works for one release, with
-    a DeprecationWarning. Removed in the next major.
-    """
-    app = f"test_deprecated_kwarg_{int(time.time_ns())}"
+def test_sampling_auto_start_kwarg_removed(tmp_path):
+    """The old `sampling_auto_start` kwarg was removed in v1.2 - passing it
+    raises a TypeError pointing at the new name (no silent shim)."""
+    app = f"test_removed_kwarg_{int(time.time_ns())}"
     log_prefix = str(tmp_path / app)
-    with pytest.warns(DeprecationWarning, match="continuous_system_sampling"):
-        ok = gpufl.init(
-            app_name=app,
-            log_path=log_prefix,
-            sampling_auto_start=False,  # deprecated name
-            system_sample_rate_ms=SAMPLE_INTERVAL_MS,
-        )
-    if ok:
-        gpufl.shutdown()
-
-
-def test_sampling_auto_start_and_new_name_together_raises(tmp_path):
-    """Passing both old and new kwargs is an error - not a silent winner."""
-    app = f"test_dup_kwarg_{int(time.time_ns())}"
-    log_prefix = str(tmp_path / app)
-    with pytest.raises(TypeError, match="pass only the new name"):
+    with pytest.raises(TypeError, match="continuous_system_sampling"):
         gpufl.init(
             app_name=app,
             log_path=log_prefix,
-            sampling_auto_start=True,
-            continuous_system_sampling=True,
+            sampling_auto_start=False,  # removed in v1.2
+            system_sample_rate_ms=SAMPLE_INTERVAL_MS,
+        )
+
+
+def test_remote_upload_kwarg_removed(tmp_path):
+    """`remote_upload` was removed in v1.2 - passing it raises a TypeError
+    directing the caller to gpufl.session() / gpufl.upload_logs()."""
+    app = f"test_removed_remote_upload_{int(time.time_ns())}"
+    log_prefix = str(tmp_path / app)
+    with pytest.raises(TypeError, match="remote_upload"):
+        gpufl.init(
+            app_name=app,
+            log_path=log_prefix,
+            remote_upload=True,  # removed in v1.2
         )


### PR DESCRIPTION
…tracking, --passes=Deep = engine, drop scope NVTX echo

## Description
Finalize the 1.2.0 client release — release prep, v1.1 deprecation removals, and several behaviour fixes.
Release prep
- Rewrite the [1.2.0] CHANGELOG to cover the real headline work (injection-mode `gpufl trace`, multi-pass `--passes`, `gpufl monitor`, RangeProfilerKernelReplay, Windows support, lower per-kernel overhead).
- Bump version: GPUFL_VERSION_SUFFIX "" + __version__ 1.2.0.
Remove v1.1 deprecation shims (all promised for v1.2); each now raises a clear TypeError pointing at the replacement:
- remote_upload — InitOptions field, Python kwarg, atexit/shutdown auto upload shim, and GPUFL_REMOTE_UPLOAD. Use gpufl.session(...) or gpufl.upload_logs() after shutdown.
- sampling_auto_start — use continuous_system_sampling.
- backend_url / api_key on InitOptions — credentials live on the upload path now (upload_logs() / session() / UploadOptions); the version discovery probe reads GPUFL_BACKEND_URL from the environment, and session() pops the creds before forwarding to init().
Updated the two Python examples and the deprecation tests to match.
Memory tracking
- Decouple CUPTI MEMORY2 from kernel-activity collection. It was gated on collectsKernelEvents() (off in SASS/Deep), so enable_memory_tracking silently recorded nothing under `gpufl trace` (default Deep). Now gated only on enable_memory_tracking + the SASS-safety policy, so allocations collect in every engine. Verified with deep_deadlock_repro: Deep run 0 -> 1 memory batch under stress, no deadlock.
- enable_memory_tracking now defaults to ON (PyTorch's caching allocator is <1k events/session; set false for alloc-heavy TF-eager workloads).
gpufl trace
- `--passes=Deep` now runs the Deep engine in one pass (same as the embedded engine) instead of expanding to Trace, PcSampling, SassMetrics.
  For the full timeline+stalls+SASS profile, list the passes explicitly.
  Deep can now be a comma-separated pass alongside others; it stays out of `+` composite groups (one-process deadlock guard).
NVTX
- Stop emitting gpufl scopes as NVTX markers. The CUPTI nvtxRangePush echo failed rc=-2 (injection not initialized), and the native NVTX_MARKER echo only duplicated scope_event (the SPA had to de-dupe it). Scopes are now recorded via scope_event alone; the NVTX lane carries framework NVTX only.

## Type of Change
- [x] Bug fix
- [x] New feature
- [x] Documentation update

## Testing
## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas