### PR TITLE
fix(trace): scope --upload to a per-run folder, not the shared --outp…

### DIFF
--- a/daemon/launcher/trace_command_common.cpp
+++ b/daemon/launcher/trace_command_common.cpp
@@ -87,6 +87,21 @@ std::string makeAnalysisId() {
     return buf;
 }
 
+// Filesystem-safe slug for a run-folder name: keep [A-Za-z0-9-_.], turn anything else into '-',
+// trim leading/trailing dashes, cap length. Empty input falls back to "session".
+std::string slugForPath(const std::string& in) {
+    auto safe = [](const char c) {
+        return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') ||
+               (c >= '0' && c <= '9') || c == '-' || c == '_' || c == '.';
+    };
+    std::string out;
+    for (const char c : in) out.push_back(safe(c) ? c : '-');
+    while (!out.empty() && out.front() == '-') out.erase(out.begin());
+    while (!out.empty() && out.back() == '-') out.pop_back();
+    if (out.size() > 48) out.resize(48);
+    return out.empty() ? std::string("session") : out;
+}
+
 int64_t nowNs() {
     return std::chrono::duration_cast<std::chrono::nanoseconds>(
             std::chrono::system_clock::now().time_since_epoch()).count();
@@ -485,9 +500,18 @@ int runTraceCommon(const TraceArgs& args, const TracePlatform& platform) {
     const std::string analysis_id = multipass ? makeAnalysisId() : std::string();
     const std::string dir_tag = multipass ? analysis_id : makeSessionId();
 
+    const std::string app_name = args.name.empty()
+                               ? platform.defaultAppName(args.command.front())
+                               : args.name;
+
+    // Each `gpufl trace` run gets its OWN folder so the upload agent picks up ONLY this run's
+    // session(s), not old sessions left over in a reused --output dir. The default output dir is
+    // already per-run (defaultOutputDir(dir_tag)); an explicit --output is a dir the user reuses
+    // across runs, so nest this run under a readable, unique "run-<name>-<id>" folder inside it.
+    const std::string run_folder = "run-" + slugForPath(app_name) + "-" + dir_tag.substr(0, 8);
     const fs::path output_dir = args.output_dir.empty()
                               ? platform.defaultOutputDir(dir_tag)
-                              : fs::path(args.output_dir);
+                              : fs::path(args.output_dir) / run_folder;
 
     std::error_code ec;
     fs::create_directories(output_dir, ec);
@@ -498,10 +522,6 @@ int runTraceCommon(const TraceArgs& args, const TracePlatform& platform) {
     }
     const fs::path agent_output_dir = fs::weakly_canonical(output_dir, ec);
     const fs::path upload_dir = ec ? output_dir : agent_output_dir;
-
-    const std::string app_name = args.name.empty()
-                               ? platform.defaultAppName(args.command.front())
-                               : args.name;
 
     std::string error;
     if (!platform.prepareInjectionEnv(inject_lib, error)) {


### PR DESCRIPTION
…ut dir

With an explicit --output reused across runs, every run's session lands as a sibling <output>/<session-id>/ folder. The upload agent watches the whole --output directory and uploads + POSTs session-complete for EVERY session it finds, so a single `gpufl trace --upload` re-submitted ~21 old sessions from prior runs, not just the current one. 
The default output dir was already per-run (defaultOutputDir(dir_tag)); only an explicit --output was shared and flat. Nest each run under a readable, unique "run-<name>-<short-id>" folder inside the explicit --output and point the agent there, so old runs sit in sibling folders the agent never scans. The name comes from --name (filesystem-slugged); the short id is sliced from the run's dir_tag (analysis-id for multipass, a fresh session id otherwise). The "[gpufl] capturing -> ..." line already prints the
resolved folder. Adds slugForPath().

## Description
## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

## Testing
## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas