### PR TITLE
Fix pc sampling issue

### DIFF
--- a/daemon/launcher/trace_command_common.cpp
+++ b/daemon/launcher/trace_command_common.cpp
@@ -10,6 +10,7 @@
 #include <ctime>
 #include <filesystem>
 #include <fstream>
+#include <future>
 #include <iomanip>
 #include <random>
 #include <sstream>
@@ -20,10 +21,12 @@
 
 #include "agent_launcher.hpp"
 #include "gpufl/core/env_vars.hpp"
+#include "gpufl/core/debug_logger.hpp"
 #include "gpufl/core/json/json.hpp"
 #include "gpufl/core/logger/file_compressor.hpp"
 #include "gpufl/core/logger/log_salvage.hpp"
 #include "gpufl/inject/inject_entry.hpp"
+#include "gpufl/upload/upload_logs.hpp"
 
 namespace gpufl::launcher {
 namespace {
@@ -165,6 +168,13 @@ struct SessionLifecycleInfo {
     std::string app = "unknown";
     int64_t job_start_ts_ns = 0;
 };
+
+bool isSessionDirectory(const fs::directory_entry& entry) {
+    std::error_code ec;
+    if (!entry.is_directory(ec)) return false;
+    const std::string name = entry.path().filename().string();
+    return !name.empty() && name.front() != '.';
+}
 
 struct SyntheticShutdownContext {
     int exit_code = 0;
@@ -365,11 +375,10 @@ int ensureTraceCompletionMarkers(const fs::path& output_dir,
     int synthesized = 0;
     for (const auto& session_entry : fs::directory_iterator(output_dir, ec)) {
         if (ec) break;
-        if (!session_entry.is_directory(ec)) continue;
+        if (!isSessionDirectory(session_entry)) continue;
 
         const fs::path session_dir = session_entry.path();
         const std::string session_id = session_dir.filename().string();
-        if (session_id.empty() || session_id.front() == '.') continue;
 
         std::vector<fs::path> system_logs;
         std::vector<fs::path> fallback_logs;
@@ -400,6 +409,44 @@ int ensureTraceCompletionMarkers(const fs::path& output_dir,
         }
     }
     return synthesized;
+}
+
+// Out-of-process upload-complete signal. After the agent has drained and exited
+// cleanly, POST /events/session-complete for each session under output_dir so the
+// backend finalizes on its fast path (upload_complete_at) instead of waiting out
+// the grace/settle window. The agent sends this too, but from inside a process
+// racing its own shutdown — that POST is often interrupted before it lands; this
+// launcher-side signal is the reliable one. Best-effort: a failure just means the
+// backend's grace path finalizes a little slower.
+void signalSessionsComplete(const fs::path& output_dir,
+                            const BackendConfig& config,
+                            const bool quiet) {
+    if (config.backend_url.empty() || config.api_key.empty()) return;
+
+    std::error_code ec;
+    if (output_dir.empty() || !fs::exists(output_dir, ec)) return;
+
+    // Fire off requests in parallel. Bound total time via per-POST httplib timeouts
+    // (currently ~6s) to ensure a black-holed backend can't stall trace exit.
+    std::vector<std::future<std::pair<std::string, bool>>> futures;
+    for (const auto& entry : fs::directory_iterator(output_dir, ec)) {
+        if (ec) break;
+        if (!isSessionDirectory(entry)) continue;
+
+        const std::string session_id = entry.path().filename().string();
+        futures.push_back(std::async(std::launch::async, [config, session_id]() {
+            return std::make_pair(session_id, postSessionComplete(config, session_id));
+        }));
+    }
+
+    for (auto& f : futures) {
+        const auto res = f.get();
+        if (res.second) {
+            GFL_LOG_DEBUG("signalled upload-complete for session ", res.first);
+        } else if (!quiet) {
+            GFL_LOG_ERROR("failed to signal upload-complete for session ", res.first);
+        }
+    }
 }
 
 /// Remove with a short backoff (100/200/400 ms) - a freshly written or
@@ -522,6 +569,8 @@ int runTraceCommon(const TraceArgs& args, const TracePlatform& platform) {
     }
     const fs::path agent_output_dir = fs::weakly_canonical(output_dir, ec);
     const fs::path upload_dir = ec ? output_dir : agent_output_dir;
+
+    DebugLogger::setEnabled(args.verbose);
 
     std::string error;
     if (!platform.prepareInjectionEnv(inject_lib, error)) {
@@ -703,9 +752,8 @@ int runTraceCommon(const TraceArgs& args, const TracePlatform& platform) {
         shutdown_context.window_stopped = run.window_stopped;
         const int synthesized = ensureTraceCompletionMarkers(
                 output_dir, pass_start_ns, shutdown_context);
-        if (!args.quiet && synthesized > 0) {
-            std::fprintf(stderr, "[gpufl] wrote %d synthetic shutdown marker(s)\n",
-                         synthesized);
+        if (synthesized > 0) {
+            GFL_LOG_DEBUG("wrote ", synthesized, " synthetic shutdown marker(s)");
         }
     }
 
@@ -718,26 +766,29 @@ int runTraceCommon(const TraceArgs& args, const TracePlatform& platform) {
         // --agent-drain-ms as a safety cap - instead of a fixed sleep that used to
         // hard-kill the agent mid-upload and drop its late windows.
         const int cap = args.agent_drain_ms;
-        if (!args.quiet) {
-            std::fprintf(stderr, "[gpufl] waiting up to %.1fs for agent to finish uploading\n",
-                         cap / 1000.0);
-        }
+        GFL_LOG_DEBUG("waiting up to ", cap / 1000.0, "s for agent to finish uploading");
         if (agent.waitForExit(cap)) {
-            if (!args.quiet) std::fprintf(stderr, "[gpufl] agent finished uploading\n");
+            GFL_LOG_DEBUG("agent finished uploading");
+            // Clean drain: every window was 202-accepted, so no more chunks are
+            // coming. Signal upload-complete from here (outside the agent's racing
+            // shutdown) so the backend finalizes on its fast path.
+            gpufl::BackendConfig config;
+            config.backend_url = resolveOption(args.backend_url, env::kBackendUrl);
+            config.api_key = resolveOption(args.api_key, env::kApiKey);
+            config.api_path = args.api_version.empty() ? "" : "/api/" + args.api_version;
+            signalSessionsComplete(output_dir, config, args.quiet);
         } else {
             if (!args.quiet) {
-                std::fprintf(stderr,
-                             "[gpufl] agent still running after %.1fs cap - stopping "
-                             "(late windows may need a post-hoc `gpufl upload`)\n",
-                             cap / 1000.0);
+                GFL_LOG_ERROR("agent still running after ", cap / 1000.0,
+                              "s cap - stopping (late windows may need a post-hoc `gpufl upload`) ");
             }
             agent.stop();
         }
     }
 
     const int repaired_logs = repairUncompressedLogs(output_dir);
-    if (!args.quiet && repaired_logs > 0) {
-        std::fprintf(stderr, "[gpufl] compressed %d log file(s)\n", repaired_logs);
+    if (repaired_logs > 0) {
+        GFL_LOG_DEBUG("compressed ", repaired_logs, " log file(s)");
     }
 
     return overall_rc;

--- a/include/gpufl/backends/nvidia/cupti_backend.cpp
+++ b/include/gpufl/backends/nvidia/cupti_backend.cpp
@@ -857,7 +857,7 @@ void CuptiBackend::start() {
     external_correlation_seen_.store(0, std::memory_order_relaxed);
     source_locator_seen_.store(0, std::memory_order_relaxed);
     function_record_seen_.store(0, std::memory_order_relaxed);
-    kernel_launch_callback_seen_.store(false, std::memory_order_relaxed);
+    kernel_launch_callback_count_.store(0, std::memory_order_relaxed);
     capture_capabilities_emitted_.store(false, std::memory_order_relaxed);
 
     // Reset the BufferCompleted companion maps for a clean per-session slate
@@ -1362,30 +1362,30 @@ void CuptiBackend::EmitCaptureCapabilities_() const {
         source_locator_seen_.load(std::memory_order_relaxed);
     const uint64_t functionRows =
         function_record_seen_.load(std::memory_order_relaxed);
-    // Real CUPTI kernel activity records emitted this session. PcSampling enables
-    // CONCURRENT_KERNEL out-of-band in its engine (bypassing collectsKernelEvents(),
-    // the handler-enable gate that returns false for PC), so real records with
-    // MEASURED durations flow — and increment this — even for PC sessions.
+    // Real CUPTI kernel-activity records emitted this session (MEASURED GPU
+    // durations). PcSampling enables CONCURRENT_KERNEL out-of-band in its engine
+    // (bypassing collectsKernelEvents()), so SOME real records can flow even for
+    // PC sessions — e.g. when the GPUFL_PC_KERNEL_COLLECT=all heavy drain's
+    // Stop→flush→restart cycle succeeds for a handful of launches.
+    const uint64_t launchCount =
+        kernel_launch_callback_count_.load(std::memory_order_acquire);
     const bool realKernelRows = kernelRows > 0;
-    // Synthetic kernel rows are launch-callback duration ESTIMATES that
-    // drainSyntheticKernels emits for launches with no matching real activity
-    // record (host-dispatch timing, not measured). They appear when: kernel
-    // launches were seen, NO real activity records were collected, and the
-    // synthetic drain wasn't suppressed — suppression is on only for pure
-    // SASS-metrics mode (kernel activity intentionally off → no kernel rows at
-    // all). The live case is NON-ADMIN PC: PC arms but Stop/GetData are
-    // privilege-blocked, so zero real records flow and the kernel rows come from
-    // launch callbacks. kernel_launch_callback_seen_ is an atomic set on every
-    // launch callback, so reading it here is both safe AND populated —
-    // capabilities emit BEFORE the collector's end-of-session synthetic drain, so
-    // a post-drain emit count would read zero at this point.
+    // The rest of the launches get SYNTHETIC rows — launch-callback duration
+    // ESTIMATES (host dispatch gaps, not measured) from drainSyntheticKernels.
+    // Report "synthetic" when they're the MAJORITY (fewer than half the launches
+    // got a real record): a binary "no real record at all" test under-reported —
+    // when the PC heavy drain captured a handful of real records it flipped the
+    // whole session to "collected" while the timeline was still ~90% host-gap
+    // estimates. launchCount and kernelRows are both populated DURING the run, so
+    // this is correct whether capabilities emit before or after the end-of-session
+    // synthetic drain. (Pure SASS-metrics mode keeps no kernel rows at all.)
     const bool syntheticKernels =
-        !realKernelRows &&
         (requests.sass || requests.pc) &&
         opts_.profiling_engine != ProfilingEngine::SassMetrics &&
-        kernel_launch_callback_seen_.load(std::memory_order_acquire);
+        launchCount > 0 &&
+        kernelRows * 2 < launchCount;
     // "Has kernel data" = any kernel rows, real OR synthetic. The status then
-    // splits collected (measured) vs fallback (estimated) on syntheticKernels.
+    // splits collected (measured) vs fallback (mostly estimated) on syntheticKernels.
     const bool kernelHasData = realKernelRows || syntheticKernels;
     const bool memoryHasData = memoryRows > 0;
     const bool memTransferHasData = memTransferRows > 0;
@@ -1772,7 +1772,7 @@ void CuptiBackend::StartActivityFlushThreadIfNeeded_() {
                 break;
             }
             if (!active_.load(std::memory_order_relaxed)) continue;
-            if (!kernel_launch_callback_seen_.load(std::memory_order_acquire)) {
+            if (kernel_launch_callback_count_.load(std::memory_order_acquire) == 0) {
                 continue;
             }
             LogCuptiIfUnexpected(

--- a/include/gpufl/backends/nvidia/cupti_backend.cpp
+++ b/include/gpufl/backends/nvidia/cupti_backend.cpp
@@ -842,6 +842,10 @@ void CuptiBackend::start() {
     // non-kernel memcpy/memset API metas before emitting rows.
     SetSuppressOrphanSyntheticKernels(
         opts_.profiling_engine == ProfilingEngine::SassMetrics);
+    // Windows-injection PC sampling loses its final flush to the process-exit
+    // teardown, so emit synthetic kernel rows during the run rather than only at
+    // shutdown (the same reason SASS disassembly runs mid-run for this mode).
+    SetDrainSyntheticKernelsMidRun(IsWindowsInjectedPcSampling());
     kernel_activity_seen_.store(0, std::memory_order_relaxed);
     kernel_activity_emitted_.store(0, std::memory_order_relaxed);
     kernel_activity_throttled_.store(0, std::memory_order_relaxed);

--- a/include/gpufl/backends/nvidia/cupti_backend.cpp
+++ b/include/gpufl/backends/nvidia/cupti_backend.cpp
@@ -337,6 +337,24 @@ inline void PreloadMatchingPerfWorks() {}
 #endif
 }  // namespace
 
+bool CuptiBackend::IsWindowsInjectedPcSampling() const {
+    // Single-engine PC sampling under Windows DLL injection. The cubin worker
+    // keys captured cubins for disassembly + PC source correlation; doing that
+    // with cuptiGetCubinCrc() takes CUPTI's internal global lock, which while
+    // PC sampling is armed under Windows injection disengages the GPU PC sampler
+    // -> zero samples (proven root cause). So the worker uses zlib crc32 here
+    // and disassembles during the run (PC samples join the disassembly by
+    // function name, not by CRC, so the CRC choice is immaterial).
+#if defined(_WIN32)
+    const char* injected = std::getenv(env::kInject);
+    const bool win_inject = injected && std::strcmp(injected, "1") == 0;
+#else
+    const bool win_inject = false;
+#endif
+    return win_inject && combo_.empty() &&
+           opts_.profiling_engine == ProfilingEngine::PcSampling;
+}
+
 bool CuptiBackend::ShouldEnableNvtxMarkerActivityBeforeEngine_() const {
     if (!collectsKernelEvents()) return false;
     if (!IsSassProfilerMode()) return true;

--- a/include/gpufl/backends/nvidia/cupti_backend.hpp
+++ b/include/gpufl/backends/nvidia/cupti_backend.hpp
@@ -138,6 +138,15 @@ class CuptiBackend : public IMonitorBackend {
     // all, so it doesn't reach this method.)
     bool NeedsCubinCapture() const { return resolved_plan_.needs_cubin_capture; }
 
+    /** True for single-engine PC sampling running under Windows DLL injection.
+     *  In that mode the cubin worker must NOT call cuptiGetCubinCrc() (it takes
+     *  CUPTI's internal global lock, which disengages the armed GPU PC sampler —
+     *  the proven root cause of zero-sample PC sampling on Windows); it uses
+     *  zlib crc32 instead and disassembles during the run rather than at the
+     *  fragile process-exit teardown. Defined out-of-line (needs the
+     *  Windows-injection probe). */
+    bool IsWindowsInjectedPcSampling() const;
+
     void RegisterHandler(const std::shared_ptr<ICuptiHandler>& handler);
 
     bool IsActive() const { return active_.load(); }

--- a/include/gpufl/backends/nvidia/cupti_backend.hpp
+++ b/include/gpufl/backends/nvidia/cupti_backend.hpp
@@ -40,6 +40,7 @@ class CuptiBackend : public IMonitorBackend {
 
     void initialize(const MonitorOptions& opts) override;
     void shutdown() override;
+    void emitCapabilities() override { EmitCaptureCapabilities_(); }
 
     static CUptiResult (*get_value())(CUpti_ActivityKind);
 
@@ -110,7 +111,7 @@ class CuptiBackend : public IMonitorBackend {
     void StartActivityFlushThreadIfNeeded_();
     void StopActivityFlushThread_();
     void NoteKernelLaunchForCleanupFlush() {
-        kernel_launch_callback_seen_.store(true, std::memory_order_release);
+        kernel_launch_callback_count_.fetch_add(1, std::memory_order_release);
         last_cleanup_flush_ns_.store(0, std::memory_order_release);
     }
     // Per-launch engine tick from the launch API_ENTER callback (app
@@ -305,7 +306,9 @@ class CuptiBackend : public IMonitorBackend {
     std::atomic<uint64_t> external_correlation_seen_{0};
     std::atomic<uint64_t> source_locator_seen_{0};
     std::atomic<uint64_t> function_record_seen_{0};
-    std::atomic<bool> kernel_launch_callback_seen_{false};
+    // Count (not just a flag) of kernel launch callbacks seen this session - the
+    // denominator for the real-vs-synthetic kernel ratio in EmitCaptureCapabilities_.
+    std::atomic<uint64_t> kernel_launch_callback_count_{0};
     std::atomic<int64_t> last_cleanup_flush_ns_{0};
     std::atomic<bool> activity_flush_thread_running_{false};
     std::thread activity_flush_thread_;

--- a/include/gpufl/backends/nvidia/engine/pc_sampling_engine.cpp
+++ b/include/gpufl/backends/nvidia/engine/pc_sampling_engine.cpp
@@ -782,11 +782,15 @@ void PcSamplingEngine::CollectPcSamplingData_() {
                       " droppedSamples=", droppedSamples,
                       " nonUsrKernelsTotalSamples=", nonUsrSamples);
 
+        // CUPTI leaves CUpti_PCSamplingData::totalSamples at 0 in armed-GetData
+        // (KERNEL_SERIALIZED, no Stop) mode, so sum the real per-PC counts.
+        uint64_t samplesThisCollect = 0;
         for (size_t i = 0; i < numPcs; ++i) {
             const CUpti_PCSamplingPCData& pc =
                 pc_sampling_buffers_->data->pPcData[i];
             if (pc.stallReasonCount > 0 && pc.stallReason) {
                 for (uint32_t j = 0; j < pc.stallReasonCount; ++j) {
+                    samplesThisCollect += pc.stallReason[j].samples;
                     if (pc.stallReason[j].samples > 0) {
                         ActivityRecord out{};
                         out.type = TraceType::PC_SAMPLE;
@@ -871,7 +875,13 @@ void PcSamplingEngine::CollectPcSamplingData_() {
             }
         }
 
-        if (!hasMore) break;
+        GFL_LOG_DEBUG("[PC Sampling] collect produced ", samplesThisCollect,
+                      " samples across ", numPcs, " PCs");
+        // Drain fully: GetData returns up to collectNumPcs records per call and
+        // reports remainingNumPcs still buffered. Loop until the buffer is empty;
+        // stop if a call makes no progress (guards against an infinite loop).
+        const size_t remainingNow = pc_sampling_buffers_->data->remainingNumPcs;
+        if (!hasMore && (remainingNow == 0 || numPcs == 0)) break;
     }
 
     // Copies, not field refs - see the packed-field note above.

--- a/include/gpufl/backends/nvidia/engine/pc_sampling_engine.cpp
+++ b/include/gpufl/backends/nvidia/engine/pc_sampling_engine.cpp
@@ -263,6 +263,12 @@ void PcSamplingEngine::stop() {
     // the correct order (before flush) - ensures cuptiActivityFlushAll
     // delivers real kernel activity records with correct GPU durations.
     StopCycleThread_();   // join BEFORE the lock - the cycle takes it too
+    // Windows-injection process exit: cudart already tore the context down (its
+    // atexit runs before ours), so cuptiPCSamplingStop/Disable below crash
+    // (0xC0000005) against the dying driver. The cycle thread is joined above
+    // and the OS reclaims the sampler at process exit, so skip the fragile CUPTI
+    // release - by here the run's data is already flushed + closed.
+    if (detail::isProcessExitTeardown()) return;
     std::lock_guard lk(sampling_lifecycle_mu_);
     if (pc_sampling_method_ == Method::SamplingAPI &&
         sampling_api_ready_.load() && ctx_.cuda_ctx) {
@@ -279,6 +285,10 @@ void PcSamplingEngine::stop() {
 }
 
 void PcSamplingEngine::drainData() {
+    // Once process-exit teardown begins, cudart is destroying the CUDA context;
+    // stop issuing CUPTI data-retrieval calls (GetData/Stop) so the cycle thread
+    // can't fault against the dying driver while shutdown flushes + joins it.
+    if (detail::isProcessExitTeardown()) return;
     // Periodic collection on the engine's cycle thread (deferring all of it to
     // session stop loses the session to process-exit teardown). Two paths by
     // kernel_collect_: light = armed GetData (no Stop; KERNEL_SERIALIZED still
@@ -348,6 +358,10 @@ void PcSamplingEngine::DrainKernelsAndCollect_() {
 
 void PcSamplingEngine::shutdown() {
     StopCycleThread_();   // join BEFORE the lock - the cycle takes it too
+    // Windows-injection process exit: skip the fragile cuptiPCSamplingDisable
+    // (crashes against the context cudart already destroyed). Threads are joined
+    // above; the OS reclaims CUPTI state at exit. See stop() for the full note.
+    if (gpufl::detail::isProcessExitTeardown()) return;
     std::lock_guard lk(sampling_lifecycle_mu_);
     // Collect a still-active SamplingAPI session before teardown.
     if (sampling_api_started_.load() &&

--- a/include/gpufl/backends/nvidia/resource_handler.cpp
+++ b/include/gpufl/backends/nvidia/resource_handler.cpp
@@ -84,7 +84,7 @@ void ResourceHandler::handle(CUpti_CallbackDomain domain, CUpti_CallbackId cbid,
         // cubin_disassembly bloat seen with PyTorch under None.
         if (!backend_->NeedsCubinCapture()) return;
 
-        auto *modData = static_cast<CUpti_ModuleResourceData *>(
+        const auto *modData = static_cast<CUpti_ModuleResourceData *>(
             resourceData->resourceDescriptor);
         if (modData && modData->pCubin && modData->cubinSize > 0) {
             const void *cubinPtr = modData->pCubin;
@@ -104,12 +104,12 @@ void ResourceHandler::handle(CUpti_CallbackDomain domain, CUpti_CallbackId cbid,
                 backend_->seen_cubin_ptrs_.insert(cubinPtr);
             }
 
-            // Copy the cubin bytes here (safe - no CUPTI calls).
-            // cuptiGetCubinCrc() must NOT be called from this callback:
-            // SASS holds CUPTI-internal locks during cubin patching (even
-            // with enableLazyPatching=0, modules loaded after
-            // cuptiSassMetricsEnable() are still patched lazily). Calling
-            // cuptiGetCubinCrc() here deadlocks. Defer to the worker thread.
+            // Copy the cubin bytes here (safe - no CUPTI calls) and hand off
+            // to the worker thread. cuptiGetCubinCrc() must NOT run from this
+            // callback: SASS holds CUPTI-internal locks during cubin patching
+            // (modules loaded after cuptiSassMetricsEnable() are patched lazily
+            // even with enableLazyPatching=0), so calling it here deadlocks.
+            // The worker computes the CRC off the callback.
             GFL_LOG_DEBUG("Queuing Cubin for CRC at ", cubinPtr,
                           " Size: ", cubinSize);
             std::vector bytes(
@@ -135,55 +135,61 @@ void ResourceHandler::workerLoop() {
             data = std::move(pending_.front());
             pending_.pop();
         }
+        processCubin(std::move(data));
+    }
+}
 
-        // Compute the cubin CRC.  We prefer cuptiGetCubinCrc() because it
-        // returns the exact CRC that CUPTI uses in PC sampling records
-        // (CUpti_PCSamplingPCData::cubinCrc) and activity records.
-        //
-        // cuptiGetCubinCrc() acquires CUPTI's internal global lock, which
-        // can deadlock when called from a CUPTI callback while
-        // cuptiSassMetricsEnable() is patching modules.  However, this
-        // worker thread runs OUTSIDE the callback, so the deadlock does
-        // not apply here.  Fall back to zlib crc32 only if CUPTI fails.
-        GFL_LOG_DEBUG("Computing CRC for cubin copy, size=", data.size());
-        uint64_t cubinCrc = 0;
-        {
-            CUpti_GetCubinCrcParams crcParams = {CUpti_GetCubinCrcParamsSize};
-            crcParams.cubin = data.data();
-            crcParams.cubinSize = data.size();
-            if (cuptiGetCubinCrc(&crcParams) == CUPTI_SUCCESS) {
-                cubinCrc = crcParams.cubinCrc;
-            } else {
-                // Fallback: zlib crc32 (may not match CUPTI's CRC on all
-                // driver versions, but better than nothing).
-                GFL_LOG_DEBUG("cuptiGetCubinCrc failed, falling back to zlib crc32");
-                cubinCrc = crc32(0, data.data(), static_cast<uInt>(data.size()));
-            }
+void ResourceHandler::processCubin(std::vector<uint8_t> data) {
+    // Windows-injection PC sampling can't call cuptiGetCubinCrc at all: it takes
+    // CUPTI's internal global lock, which disengages the armed HW sampler (zero
+    // samples). It uses zlib crc32 instead - harmless because PC samples join
+    // disassembly by FUNCTION NAME, not by cubin CRC (the CRC is only the
+    // cubin_disassembly message's group key). Every other path keeps
+    // cuptiGetCubinCrc, the exact CRC CUPTI puts in its records.
+    const bool inject = backend_->IsWindowsInjectedPcSampling();
+    GFL_LOG_DEBUG("Computing CRC for cubin copy, size=", data.size());
+    uint64_t cubinCrc = 0;
+    if (inject) {
+        cubinCrc = crc32(0, data.data(), static_cast<uInt>(data.size()));
+    } else {
+        CUpti_GetCubinCrcParams crcParams = {CUpti_GetCubinCrcParamsSize};
+        crcParams.cubin = data.data();
+        crcParams.cubinSize = data.size();
+        if (cuptiGetCubinCrc(&crcParams) == CUPTI_SUCCESS) {
+            cubinCrc = crcParams.cubinCrc;
+        } else {
+            GFL_LOG_DEBUG("cuptiGetCubinCrc failed, falling back to zlib crc32");
+            cubinCrc = crc32(0, data.data(), static_cast<uInt>(data.size()));
         }
+    }
 
-        bool isNew = false;
-        const uint8_t *enqueuePtr = nullptr;
-        size_t enqueueSize = 0;
-        {
-            GFL_LOG_DEBUG("Lock here");
-            std::lock_guard lk(backend_->cubin_mu_);
-            GFL_LOG_DEBUG("Lock acquired");
-            if (backend_->cubin_by_crc_.find(cubinCrc) ==
-                backend_->cubin_by_crc_.end()) {
-                auto &[map_data, map_crc] = backend_->cubin_by_crc_[cubinCrc];
+    bool isNew = false;
+    const uint8_t *enqueuePtr = nullptr;
+    size_t enqueueSize = 0;
+    {
+        std::lock_guard lk(backend_->cubin_mu_);
+        if (backend_->cubin_by_crc_.find(cubinCrc) ==
+            backend_->cubin_by_crc_.end()) {
+            auto &[map_data, map_crc] = backend_->cubin_by_crc_[cubinCrc];
 
-                map_crc = cubinCrc;
-                map_data = std::move(data); // Now successfully moves the outer bytes into the map
+            map_crc = cubinCrc;
+            map_data = std::move(data);
 
-                enqueuePtr = map_data.data();
-                enqueueSize = map_data.size(); // Will now be > 0
-                isNew = true;
-            }
+            enqueuePtr = map_data.data();
+            enqueueSize = map_data.size();
+            isNew = true;
         }
-        if (isNew) {
-            Monitor::EnqueueCubinForDisassembly(cubinCrc, enqueuePtr,
-                                                enqueueSize);
-            GFL_LOG_DEBUG("Finished EnqueueCubinForDisassembly!");
+    }
+    if (isNew) {
+        Monitor::EnqueueCubinForDisassembly(cubinCrc, enqueuePtr, enqueueSize);
+        GFL_LOG_DEBUG("Finished EnqueueCubinForDisassembly!");
+        if (inject) {
+            // Disassemble + emit NOW, on this worker thread during the run -
+            // NOT at shutdown. nvdisasm during the Windows-injection process-
+            // exit teardown intermittently hangs (proven); here the GPU is
+            // live and stable. nvdisasm is a subprocess (no CUPTI), so the
+            // armed sampler is unaffected.
+            Monitor::FlushDisassemblyNow();
         }
     }
 }

--- a/include/gpufl/backends/nvidia/resource_handler.hpp
+++ b/include/gpufl/backends/nvidia/resource_handler.hpp
@@ -27,6 +27,12 @@ class ResourceHandler : public ICuptiHandler {
 
    private:
     void workerLoop();
+    // Compute the cubin CRC (cuptiGetCubinCrc normally; zlib crc32 under
+    // Windows-injection PC sampling, where the CUPTI call would disengage the
+    // sampler), store it in the backend's cubin map, and enqueue it for
+    // disassembly. Under injection it also disassembles immediately so nvdisasm
+    // runs during the live run, not during the fragile process-exit teardown.
+    void processCubin(std::vector<uint8_t> data);
 
     CuptiBackend* backend_;
 

--- a/include/gpufl/core/dictionary_manager.cpp
+++ b/include/gpufl/core/dictionary_manager.cpp
@@ -1,6 +1,7 @@
 #include "gpufl/core/dictionary_manager.hpp"
 
 #include "gpufl/core/env_vars.hpp"
+#include "gpufl/core/stack_trace.hpp"  // DemangleFunctionKey
 
 #include <chrono>
 #include <cstdio>
@@ -280,17 +281,17 @@ void DictionaryManager::flushDisassembly(Logger& logger,
             const char* cudaPath = std::getenv(gpufl::env::kCudaPath);
             if (cudaPath && cudaPath[0]) {
                 std::snprintf(cmd, sizeof(cmd),
-                              "\"\"%s\\bin\\nvdisasm.exe\" --print-code \"%s\"\"",
+                              "\"\"%s\\bin\\nvdisasm.exe\" -g \"%s\"\"",
                               cudaPath, tmpPathStr.c_str());
             } else {
                 std::snprintf(cmd, sizeof(cmd),
-                              "\"nvdisasm.exe --print-code \"%s\"\"",
+                              "\"nvdisasm.exe -g \"%s\"\"",
                               tmpPathStr.c_str());
             }
             pipe = _popen(cmd, "r");
 #else
             std::vector<std::string> args = {
-                "/usr/local/cuda/bin/nvdisasm", "--print-code", tmpPathStr};
+                "/usr/local/cuda/bin/nvdisasm", "-g", tmpPathStr};
             std::vector<char*> argv;
             argv.reserve(args.size() + 1);
             for (auto& a : args) argv.push_back(a.data());
@@ -399,14 +400,17 @@ void DictionaryManager::flushDisassembly(Logger& logger,
                 funcEntries[currentFunc].push_back(
                     {pc, std::move(ins), currentSourceFile, currentSourceLine});
             } else {
-                // NVIDIA nvdisasm format:
-                // Function: "_Z11vectorScalePiii:"
-                // Instruction: "/*XXXX*/   INSTR ;"
+                // NVIDIA nvdisasm -g format:
+                // Function:     "_Z11vectorScalePiii:"
+                // Line marker:  //## File "<path>", line <N>
+                // Instruction:  "/*XXXX*/   INSTR ;"
                 if (!std::isspace(static_cast<unsigned char>(raw[0])) && raw[0] != '.' &&
                     raw.back() == ':') {
                     currentFunc = raw.substr(0, raw.size() - 1);
                     if (!funcEntries.count(currentFunc))
                         funcEntries[currentFunc] = {};
+                    currentSourceFile.clear();  // new function - reset line tracking
+                    currentSourceLine = 0;
                     continue;
                 }
 
@@ -414,6 +418,36 @@ void DictionaryManager::flushDisassembly(Logger& logger,
                 const size_t start = raw.find_first_not_of(" \t");
                 if (start == std::string::npos) continue;
                 const std::string s = raw.substr(start);
+
+                // Source-line annotation from -g (applies to the instructions
+                // that follow, until the next marker): //## File "path", line N
+                if (s.rfind("//## File", 0) == 0) {
+                    const size_t q1 = s.find('"');
+                    const size_t q2 = (q1 == std::string::npos)
+                                          ? std::string::npos : s.find('"', q1 + 1);
+                    const size_t lpos = s.find(", line ");
+                    if (q1 != std::string::npos && q2 != std::string::npos &&
+                        lpos != std::string::npos && q2 > q1) {
+                        // nvdisasm escapes backslashes in the quoted path.
+                        const std::string esc = s.substr(q1 + 1, q2 - q1 - 1);
+                        std::string path;
+                        path.reserve(esc.size());
+                        for (size_t k = 0; k < esc.size(); ++k) {
+                            if (esc[k] == '\\' && k + 1 < esc.size() && esc[k + 1] == '\\') {
+                                path += '\\';
+                                ++k;
+                            } else {
+                                path += esc[k];
+                            }
+                        }
+                        currentSourceFile = path;
+                        try {
+                            currentSourceLine = static_cast<uint32_t>(
+                                std::stoul(s.substr(lpos + 7)));
+                        } catch (...) { currentSourceLine = 0; }
+                    }
+                    continue;
+                }
 
                 if (s.rfind("/*", 0) != 0) continue;
                 const size_t end = s.find("*/");
@@ -427,7 +461,12 @@ void DictionaryManager::flushDisassembly(Logger& logger,
                 std::string ins = s.substr(insStart);
                 if (!ins.empty() && ins.back() == ';') ins.pop_back();
                 while (!ins.empty() && ins.back() == ' ') ins.pop_back();
-                funcEntries[currentFunc].push_back({pc, std::move(ins), {}, 0});
+                // -g emits non-code sections (.debug_line/.nv.info) whose
+                // "/*pc*/ .word/.dword/.string ..." lines mimic instructions.
+                // Real SASS opcodes never start with '.', so drop directives.
+                if (ins.empty() || ins[0] == '.') continue;
+                funcEntries[currentFunc].push_back(
+                    {pc, std::move(ins), currentSourceFile, currentSourceLine});
             }
         }
         GFL_LOG_DEBUG("[flushDisassembly] parsed ", funcEntries.size(),
@@ -480,10 +519,21 @@ void DictionaryManager::flushDisassembly(Logger& logger,
             logger.write(SassLine{oss.str()});
         }
 
-        // For AMD code objects with DWARF debug info, emit source file content
-        // and a profile_sample_batch that maps pc_offset -> source_file:line.
-        // This enables the same source-correlated ISA view as NVIDIA/CUPTI.
-        if (isAmd) {
+        // Emit source file content + a pc_offset -> source_file:line map
+        // (sample_kind=isa_source_map) whenever the disassembly carries line
+        // info: AMD via llvm-objdump -l, NVIDIA via nvdisasm -g (cubin built
+        // with -lineinfo). This is what gives the source-correlated ISA view its
+        // line mapping - and on Windows-injection PC sampling it's the ONLY
+        // source of it, since cuptiGetSassToSourceCorrelation can't run while
+        // the sampler is armed.
+        bool anySourceLine = false;
+        for (const auto& [funcName, entries] : funcEntries) {
+            for (const auto& e : entries) {
+                if (!e.source_file.empty() && e.source_line > 0) { anySourceLine = true; break; }
+            }
+            if (anySourceLine) break;
+        }
+        if (isAmd || anySourceLine) {
             // Collect unique source files and intern them
             std::unordered_map<std::string, uint32_t> sourceFileIds;
             for (const auto& [funcName, entries] : funcEntries) {
@@ -528,7 +578,12 @@ void DictionaryManager::flushDisassembly(Logger& logger,
                             bestCount = cnt;
                         }
                     }
-                    internFunction(funcName + "@" + primarySourceFile);
+                    // Demangle the name so it merges with the PC-sample function
+                    // entry (which is demangled), and carry the mangled symbol so
+                    // the funcKey/disassembly join still keys off md5(symbol).
+                    internFunction(
+                        core::DemangleFunctionKey(funcName + "@" + primarySourceFile),
+                        funcName);
                 }
 
                 // Flush dictionary + source content NOW so IDs appear
@@ -575,8 +630,9 @@ void DictionaryManager::flushDisassembly(Logger& logger,
                             bestCount = cnt;
                         }
                     }
-                    const std::string funcKey = funcName + "@" + primarySourceFile;
-                    const uint32_t functionId = internFunction(funcKey);
+                    const std::string funcKey =
+                        core::DemangleFunctionKey(funcName + "@" + primarySourceFile);
+                    const uint32_t functionId = internFunction(funcKey, funcName);
 
                     // Build profile_sample_batch JSON
                     std::ostringstream poss;

--- a/include/gpufl/core/gpufl.cpp
+++ b/include/gpufl/core/gpufl.cpp
@@ -18,6 +18,7 @@
 #include "gpufl/backends/host_collector.hpp"
 #include "gpufl/core/backend_factory.hpp"
 #include "gpufl/core/common.hpp"
+#include "gpufl/core/teardown_flag.hpp"  // detail::isProcessExitTeardown
 #include "gpufl/core/config_file_loader.hpp"
 #include "gpufl/core/debug_logger.hpp"
 #include "gpufl/core/events.hpp"
@@ -634,10 +635,23 @@ void shutdown() {
     // process exit races with late CUDA initialization. Joining it first keeps
     // backend shutdown from overlapping with telemetry collection.
     rt->sampler.shutdown();
-    GFL_LOG_DEBUG("Shutdown: sampler stopped -> Monitor::Shutdown()");
 
-    Monitor::Shutdown();
-    GFL_LOG_DEBUG("Shutdown: Monitor::Shutdown() returned -> finalize logs");
+    // Windows-injection process exit: the CUPTI release (cuptiPCSamplingStop/
+    // Disable) can hang or crash against the context the driver is tearing down.
+    // So drain + flush every batch, emit capabilities + the shutdown marker, and
+    // CLOSE the log BEFORE that release - a teardown failure then costs no data.
+    // Embedded/normal exits keep the clean order (Monitor::Shutdown releases
+    // CUPTI first so its activity flush can deliver the final kernels).
+    const bool processExit = detail::isProcessExitTeardown();
+
+    if (processExit) {
+        GFL_LOG_DEBUG("Shutdown: process-exit -> DrainAndFinalizeForExit()");
+        Monitor::DrainAndFinalizeForExit();
+    } else {
+        GFL_LOG_DEBUG("Shutdown: sampler stopped -> Monitor::Shutdown()");
+        Monitor::Shutdown();
+    }
+    GFL_LOG_DEBUG("Shutdown: monitor drained -> finalize logs");
 
     if (g_opts.continuous_system_sampling && rt->collector) {
         SystemStopEvent e;
@@ -661,6 +675,15 @@ void shutdown() {
     GFL_LOG_DEBUG("Shutdown: writing events done -> logger->close()");
     rt->logger->close();
     GFL_LOG_DEBUG("Shutdown: logger->close() returned");
+
+    // Logs are durable now. Release the CUPTI backend LAST so that if
+    // cuptiPCSamplingStop/Disable hangs or crashes against the dying context,
+    // the run's data is already saved.
+    if (processExit) {
+        GFL_LOG_DEBUG("Shutdown: process-exit -> ReleaseBackendForExit()");
+        Monitor::ReleaseBackendForExit();
+        GFL_LOG_DEBUG("Shutdown: ReleaseBackendForExit() returned");
+    }
 
     set_runtime(nullptr);
 

--- a/include/gpufl/core/monitor.cpp
+++ b/include/gpufl/core/monitor.cpp
@@ -1015,6 +1015,18 @@ void Monitor::EnqueueCubinForDisassembly(uint64_t crc, const uint8_t* data,
     g_dictManager.enqueueDisassembly(crc, data, size);
 }
 
+void Monitor::FlushDisassemblyNow() {
+    // Disassemble + emit any enqueued cubins immediately, off the normal
+    // shutdown flush. Used by the cubin worker under Windows-injection PC
+    // sampling so nvdisasm runs during the live run rather than during the
+    // process-exit teardown (where it intermittently hangs). flushDisassembly
+    // swaps the pending list under its lock, then runs nvdisasm outside it, so
+    // this is safe to call concurrently with the collector's own flushes.
+    if (Runtime* rt = runtime(); rt && rt->logger) {
+        g_dictManager.flushDisassembly(*rt->logger, rt->session_id);
+    }
+}
+
 void Monitor::PushActivityRecord(const ActivityRecord& rec) {
     g_monitorBuffer.Push(rec);
 }

--- a/include/gpufl/core/monitor.cpp
+++ b/include/gpufl/core/monitor.cpp
@@ -718,6 +718,42 @@ void Monitor::Shutdown() {
     g_state.adapter.reset();
 }
 
+void Monitor::DrainAndFinalizeForExit() {
+    if (!g_state.initialized.exchange(false)) return;
+
+    // The backend's PC sampling cycle thread stops issuing CUPTI reads as soon
+    // as process-exit teardown is flagged (PcSamplingEngine::drainData), so it
+    // sits idle here and can't fault mid-flush. We deliberately do NOT join it
+    // yet - the join (and the fragile CUPTI release) is deferred to
+    // ReleaseBackendForExit, which runs AFTER the logger is closed, so a stuck
+    // join can't cost the run's data. The collector stop below is a flag + join;
+    // the drain/flush/capabilities read already-captured state.
+    g_state.collectorRunning.store(false);
+    if (g_state.collectorThread.joinable()) g_state.collectorThread.join();
+
+    while (RecordProcessor::processNext()) {}
+    if (Runtime* rt = runtime(); rt && rt->logger) {
+        drainSyntheticKernels(rt);
+        g_state.metadata.emitSignatures(rt);
+        g_state.batches.flushAll(*rt->logger, rt->session_id, BatchManager::FlushMode::Full);
+    }
+
+    // Emit capabilities while the engine state is intact and the logger is
+    // still open - ReleaseBackendForExit runs after the logger closes.
+    if (g_state.adapter) {
+        if (IMonitorBackend* b = g_state.adapter->backend()) b->emitCapabilities();
+    }
+}
+
+void Monitor::ReleaseBackendForExit() {
+    if (g_state.adapter) {
+        g_state.adapter->stop();
+        g_state.adapter->shutdown();
+    }
+    g_monitorBuffer.resetDroppedCount();
+    g_state.adapter.reset();
+}
+
 void Monitor::Start() { if (g_state.adapter) g_state.adapter->start(); }
 void Monitor::Stop() { if (g_state.adapter) g_state.adapter->stop(); }
 

--- a/include/gpufl/core/monitor.cpp
+++ b/include/gpufl/core/monitor.cpp
@@ -33,383 +33,262 @@
 
 namespace gpufl {
 
+// Global ring buffer (as declared in monitor.hpp)
 RingBuffer<ActivityRecord, kMonitorBufferSize> g_monitorBuffer;
 
-static std::unique_ptr<IMonitorAdapter> g_adapter;
-static std::atomic g_initialized{false};
-static std::thread g_collectorThread;
-static std::atomic g_collectorRunning{false};
+namespace {
+
+/**
+ * @brief Encapsulates all batching and dictionary flushing logic.
+ */
+class BatchManager {
+public:
+    void reset() {
+        dictManager.reset();
+        kernelBatch.clear();
+        memcpyBatch.clear();
+        scopeBatch.clear();
+        profileBatch.clear();
+        pmSampleBatch.clear();
+        syncBatch.clear();
+        memAllocBatch.clear();
+        pendingDetails.clear();
+
+        kernelBatchId = 0;
+        memcpyBatchId = 0;
+        scopeBatchId = 0;
+        profileBatchId = 0;
+        pmSampleBatchId = 0;
+        syncBatchId = 0;
+        memAllocBatchId = 0;
+
+        nextScopeInstanceId.store(1);
+        activeScopeNameId.store(0);
+    }
+
+    enum class FlushMode { Fast, Full };
+
+    void flushAll(Logger& logger, const std::string& session_id, FlushMode mode = FlushMode::Fast) {
+        // Dictionary MUST be written before any batch that references its IDs.
+        dictManager.flushDictionary(logger, session_id);
+        if (mode == FlushMode::Full) {
+            dictManager.flushSourceContent(logger, session_id);
+            dictManager.flushDisassembly(logger, session_id);
+        }
+
+        if (!kernelBatch.empty()) {
+            dictManager.flushDictionary(logger, session_id);
+            logger.write(model::KernelEventBatchModel(kernelBatch, session_id, ++kernelBatchId));
+            kernelBatch.clear();
+            for (const auto& d : pendingDetails) {
+                logger.write(model::KernelDetailModel(d));
+            }
+            pendingDetails.clear();
+        }
+
+        if (!memcpyBatch.empty()) {
+            dictManager.flushDictionary(logger, session_id);
+            logger.write(model::MemcpyEventBatchModel(memcpyBatch, session_id, ++memcpyBatchId));
+            memcpyBatch.clear();
+        }
+
+        if (!syncBatch.empty()) {
+            dictManager.flushDictionary(logger, session_id);
+            logger.write(model::SynchronizationEventBatchModel(syncBatch, session_id, ++syncBatchId));
+            syncBatch.clear();
+        }
+
+        if (!memAllocBatch.empty()) {
+            logger.write(model::MemoryAllocEventBatchModel(memAllocBatch, session_id, ++memAllocBatchId));
+            memAllocBatch.clear();
+        }
+
+        {
+            std::lock_guard lk(scopeBatchMu);
+            if (!scopeBatch.empty() || !profileBatch.empty() || !pmSampleBatch.empty()) {
+                dictManager.flushDictionary(logger, session_id);
+            }
+            if (!scopeBatch.empty()) {
+                logger.write(model::ScopeEventBatchModel(scopeBatch, session_id, ++scopeBatchId));
+                scopeBatch.clear();
+            }
+            if (!profileBatch.empty()) {
+                logger.write(model::ProfileSampleBatchModel(profileBatch, session_id, ++profileBatchId));
+                profileBatch.clear();
+            }
+            if (!pmSampleBatch.empty()) {
+                logger.write(model::PmSampleBatchModel(pmSampleBatch, session_id, ++pmSampleBatchId));
+                pmSampleBatch.clear();
+            }
+        }
+    }
+
+    DictionaryManager dictManager;
+    
+    BatchBuffer<KernelBatchRow> kernelBatch;
+    BatchBuffer<MemcpyBatchRow> memcpyBatch;
+    uint64_t kernelBatchId = 0;
+    uint64_t memcpyBatchId = 0;
+    std::vector<KernelDetailRow> pendingDetails;
+
+    BatchBuffer<ScopeBatchRow> scopeBatch;
+    BatchBuffer<ProfileSampleBatchRow> profileBatch;
+    BatchBuffer<PmSampleBatchRow> pmSampleBatch;
+    uint64_t scopeBatchId = 0;
+    uint64_t profileBatchId = 0;
+    uint64_t pmSampleBatchId = 0;
+    std::mutex scopeBatchMu;
+    std::atomic<uint64_t> nextScopeInstanceId{1};
+    std::atomic<uint32_t> activeScopeNameId{0};
+
+    BatchBuffer<SynchronizationEventBatchRow> syncBatch;
+    BatchBuffer<MemoryAllocEventBatchRow> memAllocBatch;
+    uint64_t syncBatchId = 0;
+    uint64_t memAllocBatchId = 0;
+};
+
+/**
+ * @brief Manages metadata joins, demangling, and execution signatures.
+ */
+class MetadataManager {
+public:
+    void reset() {
+        kernelNameDemangleCache.clear();
+        functionKeyDemangleCache.clear();
+        launchMetaByCorr.clear();
+        emittedKernelCorrIds.clear();
+        syncStackByCorr.clear();
+        execSignatureByScope.clear();
+    }
+
+    const std::string& demangleKernelName(const char* raw) {
+        static const std::string kFallback = "kernel_launch";
+        if (!raw || raw[0] == '\0') return kFallback;
+        auto it = kernelNameDemangleCache.find(raw);
+        if (it != kernelNameDemangleCache.end()) return it->second;
+        auto [ins, _] = kernelNameDemangleCache.emplace(raw, gpufl::core::DemangleName(raw));
+        return ins->second;
+    }
+
+    const std::string& demangleFunctionKey(const std::string& key) {
+        auto it = functionKeyDemangleCache.find(key);
+        if (it != functionKeyDemangleCache.end()) return it->second;
+        auto [ins, _] = functionKeyDemangleCache.emplace(key, gpufl::core::DemangleFunctionKey(key));
+        return ins->second;
+    }
+
+    void accumulateSignature(const ActivityRecord& rec) {
+        if (!rec.has_details) return;
+        std::string key = rec.name;
+        key += '\x1f';
+        key += std::to_string(rec.grid_x);  key += ',';
+        key += std::to_string(rec.grid_y);  key += ',';
+        key += std::to_string(rec.grid_z);  key += '\x1f';
+        key += std::to_string(rec.block_x); key += ',';
+        key += std::to_string(rec.block_y); key += ',';
+        key += std::to_string(rec.block_z); key += '\x1f';
+        key += std::to_string(rec.dyn_shared);
+        const std::string scope = (rec.user_scope[0] != '\0') ? rec.user_scope : std::string();
+        ++execSignatureByScope[scope][key];
+    }
+
+    void emitSignatures(Runtime* rt) {
+        if (execSignatureByScope.empty() || !(rt && rt->logger)) return;
+        const int64_t ts = detail::GetTimestampNs();
+        for (const auto& [scope, kernels] : execSignatureByScope) {
+            std::string buf;
+            uint64_t launch_count = 0;
+            for (const auto& [k, cnt] : kernels) {
+                buf += k; buf += '='; buf += std::to_string(cnt); buf += ';';
+                launch_count += cnt;
+            }
+            ExecutionSignatureEvent ev;
+            ev.session_id = rt->session_id;
+            ev.ts_ns = ts;
+            ev.scope_name = scope;
+            ev.signature = Fnv1a64(buf);
+            ev.launch_count = launch_count;
+            ev.distinct_kernels = static_cast<uint32_t>(kernels.size());
+            rt->logger->write(model::ExecutionSignatureModel(ev));
+        }
+        execSignatureByScope.clear();
+    }
+
+    void joinLaunchMeta(ActivityRecord& rec) {
+        auto it = launchMetaByCorr.find(rec.corr_id);
+        if (it == launchMetaByCorr.end()) return;
+        const ActivityRecord& m = it->second;
+        rec.scope_depth = m.scope_depth;
+        rec.stack_id = m.stack_id;
+        std::memcpy(rec.user_scope, m.user_scope, sizeof(rec.user_scope));
+        rec.api_start_ns = m.api_start_ns;
+        rec.api_exit_ns = m.api_exit_ns;
+        rec.const_bytes = m.const_bytes;
+        launchMetaByCorr.erase(it);
+    }
+
+private:
+    static uint64_t Fnv1a64(const std::string& s) {
+        uint64_t h = 1469598103934665603ULL;
+        for (const unsigned char c : s) {
+            h ^= c; h *= 1099511628211ULL;
+        }
+        return h;
+    }
+
+public:
+    std::unordered_map<std::string, std::string> kernelNameDemangleCache;
+    std::unordered_map<std::string, std::string> functionKeyDemangleCache;
+    std::unordered_map<uint64_t, ActivityRecord> launchMetaByCorr;
+    std::unordered_set<uint64_t> emittedKernelCorrIds;
+    std::unordered_map<uint64_t, size_t> syncStackByCorr;
+    std::map<std::string, std::map<std::string, uint64_t>> execSignatureByScope;
+};
+
+struct MonitorState {
+    std::unique_ptr<IMonitorAdapter> adapter;
+    std::atomic<bool> initialized{false};
+    std::thread collectorThread;
+    std::atomic<bool> collectorRunning{false};
+    
+    BatchManager batches;
+    MetadataManager metadata;
+
+    bool suppressOrphanSyntheticKernels = false;
+    bool drainSyntheticMidRun = false;
+
+    struct ScopeWindow {
+        int64_t start_ns = 0, end_ns = 0;
+        uint64_t instance_id = 0;
+        uint32_t name_id = 0;
+        int depth = 0;
+    };
+    struct OpenScopeWindow {
+        int64_t start_ns = 0;
+        uint32_t name_id = 0;
+        int depth = 0;
+    };
+    std::unordered_map<uint64_t, OpenScopeWindow> openScopeWindows;
+    std::vector<ScopeWindow> completedScopeWindows;
+
+    uint32_t resolveScopeId(int64_t ts_ns) {
+        uint32_t best_id = 0;
+        int best_depth = -1;
+        int64_t best_start = 0;
+        for (auto it = completedScopeWindows.rbegin(); it != completedScopeWindows.rend(); ++it) {
+            if (ts_ns < it->start_ns || ts_ns > it->end_ns) continue;
+            if (it->depth > best_depth || (it->depth == best_depth && it->start_ns >= best_start)) {
+                best_id = it->name_id; best_depth = it->depth; best_start = it->start_ns;
+            }
+        }
+        return best_id;
+    }
+};
+
+static MonitorState g_state;
 static thread_local std::stack<void*> g_rangeStack;
 
-// Batch state - kernel/memcpy accessed only from CollectorLoop thread;
-// scope/profile may be pushed from any thread (guarded by their own mutex)
-static DictionaryManager      g_dictManager;
-static BatchBuffer<KernelBatchRow>  g_kernelBatch;
-static BatchBuffer<MemcpyBatchRow>  g_memcpyBatch;
-static uint64_t g_kernelBatchId = 0;
-static uint64_t g_memcpyBatchId = 0;
-
-// Worker-local kernel-name demangle cache (Step 4a). Demangling moved off the
-// CUPTI callback/activity threads to here. collectorProcessNext runs only on
-// the collector thread (and on the main thread AFTER the collector is joined
-// at shutdown), never concurrently - so no lock is needed (the old
-// callback-side cache used demangle_mu_).
-static std::unordered_map<std::string, std::string> g_kernelNameDemangleCache;
-static const std::string& DemangleKernelNameCached(const char* raw) {
-    static const std::string kFallback = "kernel_launch";
-    if (!raw || raw[0] == '\0') return kFallback;
-    auto it = g_kernelNameDemangleCache.find(raw);
-    if (it != g_kernelNameDemangleCache.end()) return it->second;
-    auto [ins, _] =
-        g_kernelNameDemangleCache.emplace(raw, gpufl::core::DemangleName(raw));
-    return ins->second;
-}
-
-// Collector-thread cache for demangling the "name@source" function keys that
-// PC sampling interns. The PC_SAMPLE branch in collectorProcessNext runs only
-// on the collector thread (and on the main thread after the collector joins at
-// shutdown) - the same single-consumer contract as g_kernelNameDemangleCache,
-// so no lock. CUPTI hands PC/SASS function names MANGLED; demangling here gives
-// every engine ONE canonical kernel identity (matching Trace's already-
-// demangled kernel_dict) that the backend multi-pass merge can join on. NOTE:
-// SASS interns on the USER thread (PushProfileSamples) and uses its OWN burst-
-// local cache so this map stays single-threaded - do not share it from there.
-static std::unordered_map<std::string, std::string> g_functionKeyDemangleCache;
-static const std::string& DemangleFunctionKeyCached(const std::string& key) {
-    auto it = g_functionKeyDemangleCache.find(key);
-    if (it != g_functionKeyDemangleCache.end()) return it->second;
-    auto [ins, _] = g_functionKeyDemangleCache.emplace(
-        key, gpufl::core::DemangleFunctionKey(key));
-    return ins->second;
-}
-// Deferred kernel detail rows - written after the kernel batch so the
-// backend's UPDATE (match by corr_id) always finds the INSERT first.
-static std::vector<KernelDetailRow> g_pendingDetails;
-
-// Tracks the most recently begun scope name ID.
-// Updated by PushScopeRow (user thread) when a scope begin row is pushed.
-static std::atomic<uint32_t> g_activeScopeNameId{0};
-
-struct ScopeWindow {
-    int64_t  start_ns = 0;
-    int64_t  end_ns   = 0;
-    uint64_t instance_id = 0;
-    uint32_t name_id = 0;
-    int      depth = 0;
-};
-
-struct OpenScopeWindow {
-    int64_t  start_ns = 0;
-    uint32_t name_id = 0;
-    int      depth = 0;
-};
-
-static std::unordered_map<uint64_t, OpenScopeWindow> g_openScopeWindows;
-static std::vector<ScopeWindow> g_completedScopeWindows;
-
-static uint32_t ResolveScopeNameIdForTimestampLocked(const int64_t ts_ns) {
-    uint32_t best_id = 0;
-    int best_depth = -1;
-    int64_t best_start = 0;
-
-    for (auto it = g_completedScopeWindows.rbegin();
-         it != g_completedScopeWindows.rend(); ++it) {
-        if (ts_ns < it->start_ns || ts_ns > it->end_ns) continue;
-        if (it->depth > best_depth ||
-            (it->depth == best_depth && it->start_ns >= best_start)) {
-            best_id = it->name_id;
-            best_depth = it->depth;
-            best_start = it->start_ns;
-        }
-    }
-    return best_id;
-}
-
-static BatchBuffer<ScopeBatchRow>         g_scopeBatch;
-static BatchBuffer<ProfileSampleBatchRow> g_profileBatch;
-static BatchBuffer<PmSampleBatchRow>      g_pmSampleBatch;
-static uint64_t g_scopeBatchId    = 0;
-static uint64_t g_profileBatchId  = 0;
-static uint64_t g_pmSampleBatchId = 0;
-static std::mutex g_scopeBatchMu;
-static std::atomic<uint64_t> g_nextScopeInstanceId{1};
-
-// Per-event sync + memory-alloc emissions used to ship as full
-// envelope JSON each time. Now batched + dictionary-encoded
-// (sync's stack_trace interns into function_dict). Both buffers
-// are written only from the CollectorLoop thread, same threading
-// model as g_kernelBatch / g_memcpyBatch.
-static BatchBuffer<SynchronizationEventBatchRow> g_syncBatch;
-static BatchBuffer<MemoryAllocEventBatchRow>     g_memAllocBatch;
-static uint64_t g_syncBatchId     = 0;
-static uint64_t g_memAllocBatchId = 0;
-
-enum class FlushBatchesMode {
-    Fast,
-    Full,
-};
-
-static void flushBatches(Logger& logger, const std::string& session_id,
-                         FlushBatchesMode mode = FlushBatchesMode::Fast) {
-    // Dictionary MUST be written before any batch that references its
-    // name_id / kernel_id / function_id / metric_id entries, otherwise
-    // readers see rows that reference undefined dictionary IDs.
-    //
-    // We call flushDictionary at the top for any full-mode source content
-    // and disassembly (which also reference dict IDs), and again immediately
-    // before each batch emission. This closes a race where the app thread
-    // could intern a new scope name AFTER the initial flushDictionary call
-    // but BEFORE the batch flush - the
-    // new name would be pushed into g_scopeBatch but remain dirty in
-    // the dict, producing an ordering bug where scope_event_batch
-    // references name_ids 2-5 before their dict_update is emitted.
-    g_dictManager.flushDictionary(logger, session_id);
-    if (mode == FlushBatchesMode::Full) {
-        g_dictManager.flushSourceContent(logger, session_id);
-        g_dictManager.flushDisassembly(logger, session_id);
-    }
-    if (!g_kernelBatch.empty()) {
-        g_dictManager.flushDictionary(logger, session_id);
-        logger.write(model::KernelEventBatchModel(
-            g_kernelBatch, session_id, ++g_kernelBatchId));
-        g_kernelBatch.clear();
-        // Write deferred details AFTER their batch so the backend UPDATE
-        // always finds the INSERT row that was just written.
-        for (const auto& d : g_pendingDetails) {
-            logger.write(model::KernelDetailModel(d));
-        }
-        g_pendingDetails.clear();
-    }
-    if (!g_memcpyBatch.empty()) {
-        g_dictManager.flushDictionary(logger, session_id);
-        logger.write(model::MemcpyEventBatchModel(
-            g_memcpyBatch, session_id, ++g_memcpyBatchId));
-        g_memcpyBatch.clear();
-    }
-    if (!g_syncBatch.empty()) {
-        // Sync rows reference function_dict entries via function_id;
-        // dict MUST flush first or backend resolution falls back to
-        // "function#<id>" placeholders.
-        g_dictManager.flushDictionary(logger, session_id);
-        logger.write(model::SynchronizationEventBatchModel(
-            g_syncBatch, session_id, ++g_syncBatchId));
-        g_syncBatch.clear();
-    }
-    if (!g_memAllocBatch.empty()) {
-        // Pure-numeric rows - no dictionary references.
-        logger.write(model::MemoryAllocEventBatchModel(
-            g_memAllocBatch, session_id, ++g_memAllocBatchId));
-        g_memAllocBatch.clear();
-    }
-    {
-        // Hold g_scopeBatchMu across BOTH the dict flush and the batch
-        // write. This blocks app threads in PushScopeRow until we're
-        // done. Since app threads always intern a name BEFORE pushing
-        // the corresponding row (see ScopedMonitor ctor in gpufl.cpp),
-        // any dirty dict entry at the moment we take this lock is
-        // guaranteed to correspond either to a row already in
-        // g_scopeBatch or to a row that won't be pushed until after we
-        // release. Flushing dict here emits exactly the names the
-        // outgoing batch references.
-        std::lock_guard lk(g_scopeBatchMu);
-        if (!g_scopeBatch.empty() || !g_profileBatch.empty() ||
-            !g_pmSampleBatch.empty()) {
-            g_dictManager.flushDictionary(logger, session_id);
-        }
-        if (!g_scopeBatch.empty()) {
-            logger.write(model::ScopeEventBatchModel(
-                g_scopeBatch, session_id, ++g_scopeBatchId));
-            g_scopeBatch.clear();
-        }
-        if (!g_profileBatch.empty()) {
-            logger.write(model::ProfileSampleBatchModel(
-                g_profileBatch, session_id, ++g_profileBatchId));
-            g_profileBatch.clear();
-        }
-        if (!g_pmSampleBatch.empty()) {
-            logger.write(model::PmSampleBatchModel(
-                g_pmSampleBatch, session_id, ++g_pmSampleBatchId));
-            g_pmSampleBatch.clear();
-        }
-    }
-}
-
-// Worker-local launch-meta join map (Step 4b-2). The corr->meta join that ran
-// under CuptiBackend::meta_mu_ on the CUPTI callback + BufferCompleted threads
-// now happens here, on the single collector thread, so NO lock is needed (same
-// threading model as g_kernelNameDemangleCache: written only by the collector,
-// and by the main thread AFTER the collector is joined at shutdown - never
-// concurrently). Keyed by CUPTI correlationId. Populated by KERNEL_LAUNCH_META
-// records (API_ENTER), api_exit_ns patched by KERNEL_API_EXIT records
-// (API_EXIT), consumed + erased when the matching KERNEL / MEMCPY / MEMSET
-// activity record is processed. Entries still present at shutdown are launches
-// CUPTI never delivered an activity record for; drainSyntheticKernels() flushes
-// them as synthetic kernels (replacing CuptiBackend::FlushPendingKernels).
-// Stores the whole KERNEL_LAUNCH_META ActivityRecord - it already carries every
-// field the join and the synthetic-kernel path need, so no parallel struct.
-static std::unordered_map<uint64_t, ActivityRecord> g_launchMetaByCorr;
-static std::unordered_set<uint64_t> g_emittedKernelCorrIds;
-
-// ── Execution Signature (P2 multi-pass determinism guard) ──────────────────
-// Per-scope multiset of (mangled kernel name + launch dims) -> launch count,
-// built from the KERNEL_LAUNCH_META records below (which fire in EVERY engine
-// mode, so every isolated pass - even SASS, where kernel-activity is off - has
-// the full launch inventory). Collector-thread-only: accumulated as launch
-// metas are consumed from the ring and emitted at session end after the
-// collector joins - same single-consumer contract as g_launchMetaByCorr, no
-// lock. std::map keeps keys sorted so the hash is order-independent (the
-// MULTISET property: benign async launch reordering must not change it). Scope
-// key = full user_scope path ("" = global); perf-scope reconciliation is the
-// deferred P2 backend scope work.
-static std::map<std::string, std::map<std::string, uint64_t>>
-    g_execSignatureByScope;
-
-// FNV-1a 64-bit over the canonical multiset encoding.
-static uint64_t Fnv1a64(const std::string& s) {
-    uint64_t h = 1469598103934665603ULL;
-    for (const unsigned char c : s) {
-        h ^= c;
-        h *= 1099511628211ULL;
-    }
-    return h;
-}
-
-// Accumulate one kernel launch into its scope's signature multiset. `rec` is a
-// KERNEL_LAUNCH_META carrying final launch dims (has_details). The key uses the
-// MANGLED name - byte-identical across passes, so no demangle is needed for the
-// cross-pass comparison. \x1f separates fields (never appears in names/dims).
-static void accumulateExecSignature(const ActivityRecord& rec) {
-    std::string key = rec.name;
-    key += '\x1f';
-    key += std::to_string(rec.grid_x);  key += ',';
-    key += std::to_string(rec.grid_y);  key += ',';
-    key += std::to_string(rec.grid_z);  key += '\x1f';
-    key += std::to_string(rec.block_x); key += ',';
-    key += std::to_string(rec.block_y); key += ',';
-    key += std::to_string(rec.block_z); key += '\x1f';
-    key += std::to_string(rec.dyn_shared);
-    const std::string scope =
-        (rec.user_scope[0] != '\0') ? rec.user_scope : std::string();
-    ++g_execSignatureByScope[scope][key];
-}
-
-// Worker-local sync-stack join map (Step 4c). The corr->stack join that ran
-// under CuptiBackend::sync_meta_mu_ in BufferCompleted now happens here on the
-// single collector thread, lock-free. Populated by SYNC_META records (sync
-// API_ENTER), consumed + erased when the matching SYNCHRONIZATION activity
-// record is processed. Only the stack_id is carried/joined - the old SyncMeta
-// also held an api_enter_ns that nothing downstream ever read, so it's dropped.
-// No synthetic drain: sync activity records are 1:1 with the API call, and
-// orphans (e.g. sub-100ns syncs filtered in BufferCompleted) are simply dropped,
-// same as before; the map is reset per session in Monitor::Initialize.
-static std::unordered_map<uint64_t, size_t> g_syncStackByCorr;
-
-// Join launch-callback metadata (scope path, stack id, API timestamps, const-
-// bank size) from the worker-local meta map onto an activity record, then erase
-// the entry. The activity record supplies everything else (kernel timing / dims
-// / occupancy from CUpti_ActivityKernel11; bytes / kind for mem ops). Best-
-// effort: if no meta arrived for this corr the record is left untouched - same
-// as the old meta_mu_ join missing (e.g. the API_ENTER push lost to ring
-// backpressure, or an activity record that arrived before its launch callback).
-static void joinLaunchMeta(ActivityRecord& rec) {
-    auto it = g_launchMetaByCorr.find(rec.corr_id);
-    if (it == g_launchMetaByCorr.end()) return;
-    const ActivityRecord& m = it->second;
-    rec.scope_depth  = m.scope_depth;
-    rec.stack_id     = m.stack_id;
-    std::memcpy(rec.user_scope, m.user_scope, sizeof(rec.user_scope));
-    rec.api_start_ns = m.api_start_ns;
-    rec.api_exit_ns  = m.api_exit_ns;
-    rec.const_bytes  = m.const_bytes;
-    g_launchMetaByCorr.erase(it);
-}
-
-// Emit one fully-joined KERNEL record: intern the (demangled) name, push the
-// kernel batch row, and - when detailed - the deferred detail row; flush if the
-// batch filled. Extracted from collectorProcessNext's KERNEL branch (Step 4b-2)
-// so drainSyntheticKernels can reuse the exact same emission path. `rec` must
-// already carry the joined scope/stack metadata and resolved `stack_trace`.
-static void emitKernelRecord(const ActivityRecord& rec,
-                             const std::string& stack_trace, Runtime* rt) {
-    // Demangle on the collector thread (Step 4a) - rec.name holds the RAW
-    // mangled name pushed by the CUPTI callback/activity path.
-    const uint32_t kernel_id =
-        g_dictManager.internKernel(DemangleKernelNameCached(rec.name).c_str());
-
-    KernelBatchRow row;
-    row.start_ns    = rec.cpu_start_ns;
-    row.kernel_id   = kernel_id;
-    row.stream_id   = static_cast<uint32_t>(rec.stream);
-    row.duration_ns = rec.duration_ns;
-    row.corr_id     = rec.corr_id;
-    row.dyn_shared  = rec.dyn_shared;
-    row.num_regs    = rec.num_regs;
-    row.has_details = rec.has_details ? 1 : 0;
-    // Pre-stamped by KernelLaunchHandler; both fields are 0 when no framework
-    // was tracking this launch.
-    row.external_kind = rec.external_kind;
-    row.external_id   = rec.external_id;
-    g_kernelBatch.push(row);
-
-    if (rec.has_details) {
-        KernelDetailRow detail;
-        detail.corr_id    = rec.corr_id;
-        detail.session_id = rt->session_id;
-        detail.pid        = detail::GetPid();
-        detail.app        = rt->app_name;
-        detail.grid_x = rec.grid_x; detail.grid_y = rec.grid_y;
-        detail.grid_z = rec.grid_z;
-        detail.block_x = rec.block_x; detail.block_y = rec.block_y;
-        detail.block_z = rec.block_z;
-        detail.static_shared         = rec.static_shared;
-        detail.local_bytes           = rec.local_bytes;
-        detail.const_bytes           = rec.const_bytes;
-        detail.occupancy             = rec.occupancy;
-        detail.reg_occupancy         = rec.reg_occupancy;
-        detail.smem_occupancy        = rec.smem_occupancy;
-        detail.warp_occupancy        = rec.warp_occupancy;
-        detail.block_occupancy       = rec.block_occupancy;
-        std::memcpy(detail.limiting_resource, rec.limiting_resource,
-                    sizeof(detail.limiting_resource));
-        detail.max_active_blocks      = rec.max_active_blocks;
-        detail.local_mem_total        = rec.local_mem_total;
-        detail.local_mem_per_thread   = rec.local_mem_per_thread;
-        detail.cache_config_requested = rec.cache_config_requested;
-        detail.cache_config_executed  = rec.cache_config_executed;
-        detail.shared_mem_executed    = rec.shared_mem_executed;
-        detail.user_scope  = rec.user_scope;
-        detail.stack_trace = stack_trace;
-        // Defer: written after the kernel batch by flushBatches().
-        g_pendingDetails.push_back(std::move(detail));
-    }
-
-    if (g_kernelBatch.needsFlush()) {
-        flushBatches(*rt->logger, rt->session_id);
-    }
-}
-
-// Flush launch metas that never got a CUPTI activity record as synthetic
-// kernels (Step 4b-2 - replaces CuptiBackend::FlushPendingKernels). Runs on the
-// collector thread AFTER the ring is fully drained, so g_launchMetaByCorr holds
-// exactly the orphaned launches (every kernel with an activity record has
-// already joined + erased its entry). Common in PC Sampling / SASS safe modes,
-// where CONCURRENT_KERNEL activity is off and launch callbacks are the only
-// kernel source; empty (no-op) in normal Trace/Deep mode.
-//
-// CUPTI gave us no GPU timestamps for these, so duration is approximated as the
-// gap to the next launch's dispatch (kernels run sequentially on the default
-// stream of single-stream workloads) - or `flushNs` for the last one. The
-// simplified occupancy was precomputed on the launch callback (it has the
-// nvidia-only SM properties this core TU must not reach for); we just carry it.
-// Idempotent: clears the map, so the second call from Monitor::Shutdown's
-// post-join drain is a no-op.
-// Set by the active backend at start() - see SetSuppressOrphanSyntheticKernels
-// in monitor.hpp. Engines where kernel-activity is intentionally off (SASS safe
-// mode) set this so we don't emit misleading synthetic kernel rows.
-static bool g_suppressOrphanSyntheticKernels = false;
-void SetSuppressOrphanSyntheticKernels(bool suppress) {
-    g_suppressOrphanSyntheticKernels = suppress;
-}
+// --- Helper Functions ---
 
 static bool isSyntheticNonKernelLaunchName(const char* name) {
     if (!name || name[0] == '\0') return false;
@@ -421,538 +300,426 @@ static bool isSyntheticNonKernelLaunchName(const char* name) {
            startsWith("mem_transfer");
 }
 
-static void drainSyntheticKernels(Runtime* rt) {
-    if (g_launchMetaByCorr.empty()) return;
-    if (g_suppressOrphanSyntheticKernels) {
-        // SASS safe mode: kernel-activity is OFF (it deadlocks), so EVERY launch is
-        // orphaned here. A synthetic row's only "duration" would be the host-dispatch
-        // interval between consecutive launches - meaningless as GPU time - so drop
-        // them rather than emit misleading kernel rows. The Execution Signature was
-        // already accumulated from these metas during processing, so merge is unaffected.
-        g_launchMetaByCorr.clear();
+static void emitKernelRecord(const ActivityRecord& rec, const std::string& stack_trace, Runtime* rt) {
+    const uint32_t kernel_id = g_state.batches.dictManager.internKernel(
+        g_state.metadata.demangleKernelName(rec.name).c_str());
+
+    KernelBatchRow row;
+    row.start_ns = rec.cpu_start_ns;
+    row.kernel_id = kernel_id;
+    row.stream_id = static_cast<uint32_t>(rec.stream);
+    row.duration_ns = rec.duration_ns;
+    row.corr_id = rec.corr_id;
+    row.dyn_shared = rec.dyn_shared;
+    row.num_regs = rec.num_regs;
+    row.has_details = rec.has_details ? 1 : 0;
+    row.external_kind = rec.external_kind;
+    row.external_id = rec.external_id;
+    g_state.batches.kernelBatch.push(row);
+
+    if (rec.has_details) {
+        KernelDetailRow detail;
+        detail.corr_id = rec.corr_id;
+        detail.session_id = rt->session_id;
+        detail.pid = detail::GetPid();
+        detail.app = rt->app_name;
+        detail.grid_x = rec.grid_x; detail.grid_y = rec.grid_y; detail.grid_z = rec.grid_z;
+        detail.block_x = rec.block_x; detail.block_y = rec.block_y; detail.block_z = rec.block_z;
+        detail.static_shared = rec.static_shared;
+        detail.local_bytes = rec.local_bytes;
+        detail.const_bytes = rec.const_bytes;
+        detail.occupancy = rec.occupancy;
+        detail.reg_occupancy = rec.reg_occupancy;
+        detail.smem_occupancy = rec.smem_occupancy;
+        detail.warp_occupancy = rec.warp_occupancy;
+        detail.block_occupancy = rec.block_occupancy;
+        std::memcpy(detail.limiting_resource, rec.limiting_resource, sizeof(detail.limiting_resource));
+        detail.max_active_blocks = rec.max_active_blocks;
+        detail.local_mem_total = rec.local_mem_total;
+        detail.local_mem_per_thread = rec.local_mem_per_thread;
+        detail.cache_config_requested = rec.cache_config_requested;
+        detail.cache_config_executed = rec.cache_config_executed;
+        detail.shared_mem_executed = rec.shared_mem_executed;
+        detail.user_scope = rec.user_scope;
+        detail.stack_trace = stack_trace;
+        g_state.batches.pendingDetails.push_back(std::move(detail));
+    }
+
+    if (g_state.batches.kernelBatch.needsFlush()) {
+        g_state.batches.flushAll(*rt->logger, rt->session_id);
+    }
+}
+
+static void drainSyntheticKernels(Runtime* rt, int64_t maxApiStartNs = INT64_MAX) {
+    auto& metaMap = g_state.metadata.launchMetaByCorr;
+    if (metaMap.empty()) return;
+    if (g_state.suppressOrphanSyntheticKernels) {
+        if (maxApiStartNs == INT64_MAX) metaMap.clear();
         return;
     }
     if (!(rt && rt->logger)) return;
+    
     const int64_t flushNs = detail::GetTimestampNs();
-
     std::vector<uint64_t> orderedCorr;
-    orderedCorr.reserve(g_launchMetaByCorr.size());
-    for (const auto& [corr, _] : g_launchMetaByCorr) orderedCorr.push_back(corr);
-    std::sort(orderedCorr.begin(), orderedCorr.end(),
-              [&](uint64_t a, uint64_t b) {
-                  return g_launchMetaByCorr[a].api_start_ns <
-                         g_launchMetaByCorr[b].api_start_ns;
-              });
+    orderedCorr.reserve(metaMap.size());
+    for (const auto& [corr, _] : metaMap) orderedCorr.push_back(corr);
+    std::sort(orderedCorr.begin(), orderedCorr.end(), [&](uint64_t a, uint64_t b) {
+        return metaMap[a].api_start_ns < metaMap[b].api_start_ns;
+    });
 
-    GFL_LOG_DEBUG("[drainSyntheticKernels] draining ", orderedCorr.size(),
-                  " synthetic kernel(s) at flushNs=", flushNs);
-
+    std::vector<uint64_t> drained;
     for (size_t i = 0; i < orderedCorr.size(); ++i) {
         const uint64_t corr = orderedCorr[i];
-        if (isSyntheticNonKernelLaunchName(g_launchMetaByCorr[corr].name)) {
-            GFL_LOG_DEBUG("[drainSyntheticKernels] skip non-kernel synthetic "
-                          "meta corr=", corr,
-                          " name=", g_launchMetaByCorr[corr].name);
-            continue;
-        }
-        // Copy the stored meta: it already carries name, device_id, scope,
-        // stack, has_details, grid/block/dyn_shared and the precomputed
-        // simplified occupancy. We only override the synthetic-specific fields.
-        ActivityRecord out = g_launchMetaByCorr[corr];
+        const ActivityRecord& meta = metaMap[corr];
+        if (meta.api_start_ns > maxApiStartNs) continue;
+        drained.push_back(corr);
+
+        if (isSyntheticNonKernelLaunchName(meta.name)) continue;
+
+        ActivityRecord out = meta;
         out.type = TraceType::KERNEL;
         out.stream = 0;
-        out.cpu_start_ns = out.api_start_ns;  // API_ENTER ns
-        const int64_t nextEnterNs =
-            (i + 1 < orderedCorr.size())
-                ? g_launchMetaByCorr[orderedCorr[i + 1]].api_start_ns
-                : flushNs;
-        int64_t synthDur = nextEnterNs - out.api_start_ns;
-        if (synthDur < 0) synthDur = 0;  // clock skew guard
-        out.duration_ns = synthDur;
+        out.cpu_start_ns = out.api_start_ns;
+        const int64_t nextEnterNs = (i + 1 < orderedCorr.size()) ? metaMap[orderedCorr[i+1]].api_start_ns : flushNs;
+        out.duration_ns = std::max<int64_t>(0, nextEnterNs - out.api_start_ns);
         out.corr_id = static_cast<unsigned>(corr);
         if (out.api_exit_ns <= 0) out.api_exit_ns = flushNs;
 
-        const std::string stack_trace =
-            (out.stack_id != 0) ? StackRegistry::instance().get(out.stack_id)
-                                : "";
-        GFL_LOG_DEBUG("[drainSyntheticKernels] synth corr=", corr,
-                      " name=", out.name, " scope=", out.user_scope,
-                      " dur=", out.duration_ns, "ns");
+        g_state.metadata.emittedKernelCorrIds.insert(corr);
+        const std::string stack_trace = (out.stack_id != 0) ? StackRegistry::instance().get(out.stack_id) : "";
         emitKernelRecord(out, stack_trace, rt);
     }
-    g_launchMetaByCorr.clear();
+    for (uint64_t corr : drained) metaMap.erase(corr);
 }
 
-// Emit one execution_signature record per scope at session end - runs after the
-// ring is fully drained (every KERNEL_LAUNCH_META accumulated). Called on the
-// collector thread (post-loop) and again from Shutdown's post-join drain;
-// idempotent via clear(). std::map iteration is sorted, so the hash is a stable
-// function of the multiset. See g_execSignatureByScope.
-static void emitExecutionSignatures(Runtime* rt) {
-    if (g_execSignatureByScope.empty()) return;
-    if (!(rt && rt->logger)) return;
-    const int64_t ts = detail::GetTimestampNs();
-    for (const auto& [scope, kernels] : g_execSignatureByScope) {
-        std::string buf;
-        uint64_t launch_count = 0;
-        for (const auto& [k, cnt] : kernels) {  // sorted (std::map) -> stable hash
-            buf += k;
-            buf += '=';
-            buf += std::to_string(cnt);
-            buf += ';';
-            launch_count += cnt;
-        }
-        ExecutionSignatureEvent ev;
-        ev.session_id       = rt->session_id;
-        ev.ts_ns            = ts;
-        ev.scope_name       = scope;
-        ev.signature        = Fnv1a64(buf);
-        ev.launch_count     = launch_count;
-        ev.distinct_kernels = static_cast<uint32_t>(kernels.size());
-        rt->logger->write(model::ExecutionSignatureModel(ev));
-        GFL_LOG_DEBUG("[execSignature] scope='", scope, "' launches=",
-                      launch_count, " distinct=", kernels.size(),
-                      " sig=", ev.signature);
-    }
-    g_execSignatureByScope.clear();
-}
+// --- Record Dispatcher ---
 
-// Consume + route ONE record from the ring buffer; returns false when empty.
-// File-scope (was a lambda inside CollectorLoop) so Monitor::Shutdown can
-// re-drain on the MAIN thread after joining the collector. On Windows
-// process-exit the collector thread can be torn down before it runs its own
-// post-loop drain, stranding records (e.g. the synthetic kernels pushed by
-// CuptiBackend::stop()) in the ring buffer. The post-join drain recovers them.
-static bool collectorProcessNext() {
+struct RecordProcessor {
+    static bool processNext() {
         ActivityRecord rec{};
         if (!g_monitorBuffer.Consume(rec)) return false;
 
-        // Launch-meta control records (Step 4b-2): collector-thread-only join-
-        // map maintenance, never emitted. Handled before the runtime/logger
-        // check - they carry no output, only the join state that later KERNEL /
-        // MEMCPY / MEMSET activity records read.
-        if (rec.type == TraceType::KERNEL_LAUNCH_META) {
-            // Merge into the worker-local join map. Keep-first-unless-upgrade: a
-            // single logical launch fires BOTH runtime and driver callbacks with
-            // the SAME corr; the first (runtime) wins unless it lacked grid/block
-            // details and a later record supplies them. Mirrors the merge the old
-            // KernelLaunchHandler::handle did under meta_mu_. (MemTransferHandler
-            // metas always have has_details=false, so duplicate-corr mem callbacks
-            // resolve to the first/runtime one - its user-facing scope label.)
-            auto it = g_launchMetaByCorr.find(rec.corr_id);
-            bool countForSignature = false;
-            if (it == g_launchMetaByCorr.end()) {
-                g_launchMetaByCorr.emplace(rec.corr_id, rec);
-                // First record for this launch - count it once for the exec
-                // signature IF it already carries grid/block (a kernel launch).
-                // Dim-less metas (e.g. memcpy) are not kernel launches and are
-                // never counted.
-                countForSignature = rec.has_details;
-            } else if (!it->second.has_details && rec.has_details) {
-                it->second = rec;
-                // Details arrived on the launch's 2nd callback (same corr) -
-                // count now; the emplace above skipped it for lack of dims.
-                countForSignature = true;
-            }
-            if (countForSignature) accumulateExecSignature(rec);
-            return true;
-        }
-        if (rec.type == TraceType::KERNEL_API_EXIT) {
-            if (auto it = g_launchMetaByCorr.find(rec.corr_id);
-                it != g_launchMetaByCorr.end()) {
-                it->second.api_exit_ns = rec.api_exit_ns;
-            }
-            return true;
-        }
-        if (rec.type == TraceType::SYNC_META) {
-            // Stash the sync call stack until its SYNCHRONIZATION activity
-            // record arrives (Step 4c). Last-write-wins on corr collision (sync
-            // corrs are unique per call, so collisions don't occur in practice).
-            g_syncStackByCorr[rec.corr_id] = rec.stack_id;
-            return true;
+        switch (rec.type) {
+            case TraceType::KERNEL_LAUNCH_META:
+                handleKernelLaunchMeta(rec);
+                return true;
+            case TraceType::KERNEL_API_EXIT:
+                handleKernelApiExit(rec);
+                return true;
+            case TraceType::SYNC_META:
+                g_state.metadata.syncStackByCorr[rec.corr_id] = rec.stack_id;
+                return true;
+            default:
+                break;
         }
 
-        const int64_t duration_ns = rec.duration_ns;
         Runtime* rt = runtime();
-        if (!(rt && rt->logger)) {
-            GFL_LOG_DEBUG("[CollectorLoop] DROP rec type=", (int)rec.type,
-                          " - runtime/logger null");
-            return true;
+        if (!(rt && rt->logger)) return true;
+
+        switch (rec.type) {
+            case TraceType::KERNEL:
+            case TraceType::MEMCPY:
+            case TraceType::MEMSET:
+                handleGpuActivity(rec, rt);
+                break;
+            case TraceType::RANGE:
+                handleRange(rec);
+                break;
+            case TraceType::PC_SAMPLE:
+                handlePcSample(rec, rt);
+                break;
+            case TraceType::NVTX_MARKER:
+                handleNvtxMarker(rec, rt);
+                break;
+            case TraceType::GRAPH_LAUNCH:
+                handleGraphLaunch(rec, rt);
+                break;
+            case TraceType::MEMORY_ALLOC:
+                handleMemoryAlloc(rec, rt);
+                break;
+            case TraceType::SYNCHRONIZATION:
+                handleSynchronization(rec);
+                break;
+            default:
+                break;
         }
-        if (rec.type == TraceType::KERNEL || rec.type == TraceType::MEMCPY ||
-            rec.type == TraceType::MEMSET) {
-            // Join launch-callback metadata recorded at API_ENTER (Step 4b-2).
-            // Before the cutover the producing handler did this under meta_mu_;
-            // now the raw activity record arrives with empty scope/stack and we
-            // fill it here from the worker-local map (lock-free - single
-            // consumer). No-op while the map is empty (scaffolding / cache miss).
-            joinLaunchMeta(rec);
-            const std::string stack_trace =
-                (rec.stack_id != 0) ? StackRegistry::instance().get(rec.stack_id)
-                                    : "";
-            const char* platform =
-                g_adapter ? g_adapter->platformName() : "unknown";
-
-            if (rec.type == TraceType::KERNEL) {
-                if (rec.corr_id != 0 &&
-                    !g_emittedKernelCorrIds.insert(rec.corr_id).second) {
-                    GFL_LOG_DEBUG("[CollectorLoop] skipping duplicate kernel corr=",
-                                  rec.corr_id);
-                    return true;
-                }
-                emitKernelRecord(rec, stack_trace, rt);
-
-            } else if (rec.type == TraceType::MEMCPY) {
-                MemcpyBatchRow row;
-                row.start_ns    = rec.cpu_start_ns;
-                row.stream_id   = static_cast<uint32_t>(rec.stream);
-                row.duration_ns = duration_ns;
-                row.bytes       = rec.bytes;
-                row.copy_kind   = rec.copy_kind;
-                row.corr_id     = rec.corr_id;
-                g_memcpyBatch.push(row);
-
-                if (g_memcpyBatch.needsFlush()) {
-                    flushBatches(*rt->logger, rt->session_id);
-                }
-
-            } else {
-                // MEMSET - infrequent, keep as immediate verbose write
-                MemsetEvent be;
-                be.platform    = platform;
-                be.device_id   = rec.device_id;
-                be.stream_id   = static_cast<uint32_t>(rec.stream);
-                be.session_id  = rt->session_id;
-                be.pid         = detail::GetPid();
-                be.app         = rt->app_name;
-                be.name        = rec.name;
-                be.start_ns    = rec.cpu_start_ns;
-                be.end_ns      = rec.cpu_start_ns + duration_ns;
-                be.api_start_ns = rec.api_start_ns;
-                be.api_exit_ns  = rec.api_exit_ns;
-                be.user_scope  = rec.user_scope;
-                be.scope_depth = rec.scope_depth;
-                be.corr_id     = rec.corr_id;
-                be.stack_trace = stack_trace;
-                be.bytes       = rec.bytes;
-                rt->logger->write(model::MemsetEventModel(be));
-            }
-        } else if (rec.type == TraceType::RANGE) {
-            const uint32_t name_id =
-                g_dictManager.internScopeName(rec.name);
-            const uint64_t instance_id =
-                g_nextScopeInstanceId.fetch_add(1, std::memory_order_relaxed);
-
-            ScopeBatchRow begin_row;
-            begin_row.ts_ns             = rec.cpu_start_ns;
-            begin_row.scope_instance_id = instance_id;
-            begin_row.name_id           = name_id;
-            begin_row.event_type        = 0;  // begin
-            begin_row.depth             = rec.scope_depth;
-
-            ScopeBatchRow end_row;
-            end_row.ts_ns             = rec.cpu_start_ns + duration_ns;
-            end_row.scope_instance_id = instance_id;
-            end_row.name_id           = name_id;
-            end_row.event_type        = 1;  // end
-            end_row.depth             = rec.scope_depth;
-
-            {
-                std::lock_guard lk(g_scopeBatchMu);
-                g_scopeBatch.push(begin_row);
-                g_scopeBatch.push(end_row);
-            }
-        } else if (rec.type == TraceType::PC_SAMPLE) {
-            // Determine sample kind: 0=pc_sampling, 1=sass_metric
-            uint8_t kind = 0;
-            if (rec.metric_name[0] != '\0') {
-                kind = 1;
-            } else if (rec.sample_kind[0] != '\0' &&
-                       rec.sample_kind[0] == 's') {
-                kind = 1;  // "sass_metric"
-            }
-
-            // Demangle the name part so PC sampling's function identity matches
-            // Trace's already-demangled kernel_dict for the cross-pass merge.
-            const std::string func_key =
-                std::string(rec.function_name) + "@" + rec.source_file;
-            // rec.function_name is the BARE mangled symbol (== cubin functions.name), captured
-            // here before demangling so the backend can derive funcKey = md5(symbol).
-            const uint32_t function_id =
-                g_dictManager.internFunction(DemangleFunctionKeyCached(func_key),
-                                             std::string(rec.function_name));
-            // For PC sampling rows metric_name is empty; use reason_name so the
-            // stall reason string is interned into metric_dict and reachable via
-            // metric_id on the backend.  For SASS rows metric_name is always set.
-            const std::string metric_key = (rec.metric_name[0] != '\0')
-                ? std::string(rec.metric_name)
-                : rec.reason_name;
-            const uint32_t metric_id =
-                g_dictManager.internMetric(metric_key);
-            // Use the most recently begun scope.  PC samples are pushed to the
-            // ring buffer by EndPerfScope() (inside ScopedMonitor dtor), which
-            // runs after the scope begin row is pushed via PushScopeRow().
-            // g_activeScopeNameId is therefore already set to the correct ID
-            // by the time the collector loop processes these records.
-            const uint32_t scope_name_id =
-                g_activeScopeNameId.load(std::memory_order_relaxed);
-
-            const uint32_t source_file_id =
-                g_dictManager.internSourceFile(rec.source_file);
-
-            ProfileSampleBatchRow row;
-            row.ts_ns           = rec.cpu_start_ns;
-            row.corr_id         = rec.corr_id;
-            row.device_id       = rec.device_id;
-            row.function_id     = function_id;
-            row.pc_offset       = rec.pc_offset;
-            row.metric_id       = metric_id;
-            row.metric_value    = (kind == 1) ? rec.metric_value
-                                              : rec.samples_count;
-            row.stall_reason    = rec.stall_reason;
-            row.sample_kind     = kind;
-            row.scope_name_id   = scope_name_id;
-            row.source_file_id  = source_file_id;
-            row.source_line     = rec.source_line;
-
-            bool needs_flush = false;
-            {
-                std::lock_guard lk(g_scopeBatchMu);
-                g_profileBatch.push(row);
-                needs_flush = g_profileBatch.needsFlush();
-            }
-            if (needs_flush) {
-                flushBatches(*rt->logger, rt->session_id);
-            }
-        } else if (rec.type == TraceType::NVTX_MARKER) {
-            // NVTX range captured via CUPTI_ACTIVITY_KIND_MARKER. Emitted
-            // directly as a single event (not batched) - NVTX traffic at
-            // scale is primarily from PyTorch and framework internals,
-            // which we're comfortable serializing per-event for now.
-            // Consider batching if volume becomes a problem.
-            NvtxMarkerEvent ev;
-            ev.pid         = detail::GetPid();
-            ev.app         = rt->app_name;
-            ev.session_id  = rt->session_id;
-            ev.name        = rec.name;
-            ev.domain      = rec.user_scope;   // stashed here by cupti_backend
-            ev.start_ns    = rec.cpu_start_ns;
-            ev.end_ns      = rec.cpu_start_ns + duration_ns;
-            ev.duration_ns = duration_ns;
-            ev.marker_id   = rec.corr_id;
-            rt->logger->write(model::NvtxMarkerModel(ev));
-        } else if (rec.type == TraceType::GRAPH_LAUNCH) {
-            // cudaGraphLaunch with aggregate timing. Emit per-event;
-            // volume is so low (tens to low hundreds per session) that
-            // batching would be pointless overhead.
-            GraphLaunchEvent ev;
-            ev.pid          = detail::GetPid();
-            ev.app          = rt->app_name;
-            ev.session_id   = rt->session_id;
-            ev.start_ns     = rec.cpu_start_ns;
-            ev.end_ns       = rec.cpu_start_ns + duration_ns;
-            ev.duration_ns  = duration_ns;
-            ev.graph_id     = rec.graph_id;
-            ev.device_id    = rec.device_id;
-            ev.stream_id    = static_cast<uint32_t>(rec.stream);
-            ev.corr_id      = rec.corr_id;
-            rt->logger->write(model::GraphLaunchEventModel(ev));
-        } else if (rec.type == TraceType::MEMORY_ALLOC) {
-            // cudaMalloc / cudaFree / cudaMallocAsync / etc.
-            // Batched into memory_alloc_event_batch - per-event JSON
-            // dropped because the envelope (type/pid/app/session_id)
-            // amortizes far better across a 512-row batch. Pure-
-            // numeric row → no dictionary lookup needed.
-            MemoryAllocEventBatchRow row;
-            row.start_ns    = rec.cpu_start_ns;
-            row.duration_ns = duration_ns;          // 0 in v1
-            row.memory_op   = rec.memory_op;
-            row.memory_kind = rec.memory_kind;
-            row.address     = rec.address;
-            row.bytes       = rec.bytes;
-            row.device_id   = rec.device_id;
-            row.stream_id   = static_cast<uint32_t>(rec.stream);
-            row.corr_id     = rec.corr_id;
-            g_memAllocBatch.push(row);
-        } else if (rec.type == TraceType::SYNCHRONIZATION) {
-            // cudaStreamSynchronize / cudaDeviceSynchronize / etc.
-            // Batched into synchronization_event_batch. The user call
-            // stack captured by SynchronizationHandler on API_ENTER
-            // (PR-B) gets interned via the existing function_dict so
-            // hot loops with identical stacks ship the string exactly
-            // once via dictionary_update - ~14× wire compression on
-            // the canonical "sync inside a loop" workload.
-            //
-            // Join the API_ENTER call stack here (Step 4c) - moved off the
-            // BufferCompleted thread / sync_meta_mu_ onto this single consumer.
-            // 1:1 with the API call, so erase on join. Best-effort: a missing
-            // SYNC_META (dropped to ring backpressure) leaves stack_id 0.
-            if (auto it = g_syncStackByCorr.find(rec.corr_id);
-                it != g_syncStackByCorr.end()) {
-                rec.stack_id = it->second;
-                g_syncStackByCorr.erase(it);
-            }
-            SynchronizationEventBatchRow row;
-            row.start_ns    = rec.cpu_start_ns;
-            row.duration_ns = duration_ns;
-            row.sync_type   = rec.sync_type;
-            row.stream_id   = static_cast<uint32_t>(rec.stream);
-            row.event_id    = rec.sync_event_id;
-            row.context_id  = rec.context_id;
-            row.corr_id     = rec.corr_id;
-            if (rec.stack_id != 0) {
-                row.function_id = g_dictManager.internFunction(
-                        StackRegistry::instance().get(rec.stack_id));
-            } else {
-                row.function_id = 0;
-            }
-            g_syncBatch.push(row);
-        }
-
         return true;
-}
+    }
+
+private:
+    static void handleKernelLaunchMeta(const ActivityRecord& rec) {
+        const auto it = g_state.metadata.launchMetaByCorr.find(rec.corr_id);
+        bool countForSignature = false;
+        if (it == g_state.metadata.launchMetaByCorr.end()) {
+            g_state.metadata.launchMetaByCorr.emplace(rec.corr_id, rec);
+            countForSignature = rec.has_details;
+        } else if (!it->second.has_details && rec.has_details) {
+            it->second = rec;
+            countForSignature = true;
+        }
+        if (countForSignature) g_state.metadata.accumulateSignature(rec);
+    }
+
+    static void handleKernelApiExit(const ActivityRecord& rec) {
+        if (const auto it = g_state.metadata.launchMetaByCorr.find(rec.corr_id);
+            it != g_state.metadata.launchMetaByCorr.end()) {
+            it->second.api_exit_ns = rec.api_exit_ns;
+        }
+    }
+
+    static void handleGpuActivity(ActivityRecord& rec, Runtime* rt) {
+        g_state.metadata.joinLaunchMeta(rec);
+        const std::string stack_trace = (rec.stack_id != 0) ? StackRegistry::instance().get(rec.stack_id) : "";
+
+        if (rec.type == TraceType::KERNEL) {
+            if (rec.corr_id != 0 && !g_state.metadata.emittedKernelCorrIds.insert(rec.corr_id).second) return;
+            emitKernelRecord(rec, stack_trace, rt);
+        } else if (rec.type == TraceType::MEMCPY) {
+            MemcpyBatchRow row;
+            row.start_ns = rec.cpu_start_ns;
+            row.stream_id = static_cast<uint32_t>(rec.stream);
+            row.duration_ns = rec.duration_ns;
+            row.bytes = rec.bytes;
+            row.copy_kind = rec.copy_kind;
+            row.corr_id = rec.corr_id;
+            g_state.batches.memcpyBatch.push(row);
+            if (g_state.batches.memcpyBatch.needsFlush()) {
+                g_state.batches.flushAll(*rt->logger, rt->session_id);
+            }
+        } else { // MEMSET
+            MemsetEvent be;
+            be.platform = g_state.adapter ? g_state.adapter->platformName() : "unknown";
+            be.device_id = rec.device_id;
+            be.stream_id = static_cast<uint32_t>(rec.stream);
+            be.session_id = rt->session_id;
+            be.pid = detail::GetPid();
+            be.app = rt->app_name;
+            be.name = rec.name;
+            be.start_ns = rec.cpu_start_ns;
+            be.end_ns = rec.cpu_start_ns + rec.duration_ns;
+            be.api_start_ns = rec.api_start_ns;
+            be.api_exit_ns = rec.api_exit_ns;
+            be.user_scope = rec.user_scope;
+            be.scope_depth = rec.scope_depth;
+            be.corr_id = rec.corr_id;
+            be.stack_trace = stack_trace;
+            be.bytes = rec.bytes;
+            rt->logger->write(model::MemsetEventModel(be));
+        }
+    }
+
+    static void handleRange(const ActivityRecord& rec) {
+        const uint32_t name_id = g_state.batches.dictManager.internScopeName(rec.name);
+        const uint64_t instance_id = g_state.batches.nextScopeInstanceId.fetch_add(1, std::memory_order_relaxed);
+        
+        ScopeBatchRow begin_row, end_row;
+        begin_row.ts_ns = rec.cpu_start_ns;
+        begin_row.scope_instance_id = instance_id;
+        begin_row.name_id = name_id;
+        begin_row.event_type = 0;
+        begin_row.depth = rec.scope_depth;
+
+        end_row.ts_ns = rec.cpu_start_ns + rec.duration_ns;
+        end_row.scope_instance_id = instance_id;
+        end_row.name_id = name_id;
+        end_row.event_type = 1;
+        end_row.depth = rec.scope_depth;
+
+        std::lock_guard lk(g_state.batches.scopeBatchMu);
+        g_state.batches.scopeBatch.push(begin_row);
+        g_state.batches.scopeBatch.push(end_row);
+    }
+
+    static void handlePcSample(const ActivityRecord& rec, Runtime* rt) {
+        uint8_t kind = rec.metric_name[0] != '\0' ||
+                    (rec.sample_kind[0] != '\0' && rec.sample_kind[0] == 's') ? 1 : 0;
+        const std::string func_key = std::string(rec.function_name) + "@" + rec.source_file;
+        const uint32_t function_id = g_state.batches.dictManager.internFunction(
+            g_state.metadata.demangleFunctionKey(func_key), std::string(rec.function_name));
+        const std::string metric_key = (rec.metric_name[0] != '\0') ? std::string(rec.metric_name) : rec.reason_name;
+        const uint32_t metric_id = g_state.batches.dictManager.internMetric(metric_key);
+        const uint32_t scope_name_id = g_state.batches.activeScopeNameId.load(std::memory_order_relaxed);
+        const uint32_t source_file_id = g_state.batches.dictManager.internSourceFile(rec.source_file);
+
+        ProfileSampleBatchRow row;
+        row.ts_ns = rec.cpu_start_ns;
+        row.corr_id = rec.corr_id;
+        row.device_id = rec.device_id;
+        row.function_id = function_id;
+        row.pc_offset = rec.pc_offset;
+        row.metric_id = metric_id;
+        row.metric_value = (kind == 1) ? rec.metric_value : rec.samples_count;
+        row.stall_reason = rec.stall_reason;
+        row.sample_kind = kind;
+        row.scope_name_id = scope_name_id;
+        row.source_file_id = source_file_id;
+        row.source_line = rec.source_line;
+
+        bool needs_flush = false;
+        {
+            std::lock_guard lk(g_state.batches.scopeBatchMu);
+            g_state.batches.profileBatch.push(row);
+            needs_flush = g_state.batches.profileBatch.needsFlush();
+        }
+        if (needs_flush) {
+            g_state.batches.flushAll(*rt->logger, rt->session_id);
+        }
+    }
+
+    static void handleNvtxMarker(const ActivityRecord& rec, Runtime* rt) {
+        NvtxMarkerEvent ev;
+        ev.pid = detail::GetPid();
+        ev.app = rt->app_name;
+        ev.session_id = rt->session_id;
+        ev.name = rec.name;
+        ev.domain = rec.user_scope;
+        ev.start_ns = rec.cpu_start_ns;
+        ev.end_ns = rec.cpu_start_ns + rec.duration_ns;
+        ev.duration_ns = rec.duration_ns;
+        ev.marker_id = rec.corr_id;
+        rt->logger->write(model::NvtxMarkerModel(ev));
+    }
+
+    static void handleGraphLaunch(const ActivityRecord& rec, Runtime* rt) {
+        GraphLaunchEvent ev;
+        ev.pid = detail::GetPid();
+        ev.app = rt->app_name;
+        ev.session_id = rt->session_id;
+        ev.start_ns = rec.cpu_start_ns;
+        ev.end_ns = rec.cpu_start_ns + rec.duration_ns;
+        ev.duration_ns = rec.duration_ns;
+        ev.graph_id = rec.graph_id;
+        ev.device_id = rec.device_id;
+        ev.stream_id = static_cast<uint32_t>(rec.stream);
+        ev.corr_id = rec.corr_id;
+        rt->logger->write(model::GraphLaunchEventModel(ev));
+    }
+
+    static void handleMemoryAlloc(const ActivityRecord& rec, Runtime* rt) {
+        MemoryAllocEventBatchRow row;
+        row.start_ns = rec.cpu_start_ns;
+        row.duration_ns = rec.duration_ns;
+        row.memory_op = rec.memory_op;
+        row.memory_kind = rec.memory_kind;
+        row.address = rec.address;
+        row.bytes = rec.bytes;
+        row.device_id = rec.device_id;
+        row.stream_id = static_cast<uint32_t>(rec.stream);
+        row.corr_id = rec.corr_id;
+        g_state.batches.memAllocBatch.push(row);
+        if (g_state.batches.memAllocBatch.needsFlush()) {
+            g_state.batches.flushAll(*rt->logger, rt->session_id);
+        }
+    }
+
+    static void handleSynchronization(ActivityRecord& rec) {
+        if (auto it = g_state.metadata.syncStackByCorr.find(rec.corr_id);
+            it != g_state.metadata.syncStackByCorr.end()) {
+            rec.stack_id = it->second;
+            g_state.metadata.syncStackByCorr.erase(it);
+        }
+        SynchronizationEventBatchRow row;
+        row.start_ns = rec.cpu_start_ns;
+        row.duration_ns = rec.duration_ns;
+        row.sync_type = rec.sync_type;
+        row.stream_id = static_cast<uint32_t>(rec.stream);
+        row.event_id = rec.sync_event_id;
+        row.context_id = rec.context_id;
+        row.corr_id = rec.corr_id;
+        row.function_id = (rec.stack_id != 0) 
+            ? g_state.batches.dictManager.internFunction(StackRegistry::instance().get(rec.stack_id))
+            : 0;
+        g_state.batches.syncBatch.push(row);
+    }
+};
+
+} // anonymous namespace
+
+// --- Collector Loop ---
 
 void CollectorLoop() {
     GFL_LOG_DEBUG("[CollectorLoop] START");
-    while (g_collectorRunning.load()) {
-        if (!collectorProcessNext()) {
+    // Local (not static): the flush cadence resets per CollectorLoop invocation,
+    // so an Initialize->Shutdown->Initialize cycle doesn't inherit a stale
+    // timestamp from the previous session.
+    auto lastFlush = std::chrono::steady_clock::now();
+
+    while (g_state.collectorRunning.load()) {
+        if (!RecordProcessor::processNext()) {
             std::this_thread::sleep_for(std::chrono::milliseconds(1));
         }
 
-        static auto lastFlush = std::chrono::steady_clock::now();
-        if (std::chrono::steady_clock::now() - lastFlush >
-            std::chrono::milliseconds(250)) {
-            if (const Runtime* rt = runtime(); rt && rt->logger) {
-                flushBatches(*rt->logger, rt->session_id);
+        if (std::chrono::steady_clock::now() - lastFlush > std::chrono::milliseconds(250)) {
+            if (Runtime* rt = runtime(); rt && rt->logger) {
+                if (g_state.drainSyntheticMidRun) {
+                    constexpr int64_t kMidRunSyntheticGraceNs = 100'000'000;
+                    drainSyntheticKernels(rt, detail::GetTimestampNs() - kMidRunSyntheticGraceNs);
+                }
+                g_state.batches.flushAll(*rt->logger, rt->session_id);
             }
-            // Periodically drain PC sampling hardware buffer so data from
-            // multiple kernels is collected (not just the first kernel).
-            if (g_adapter) g_adapter->drainProfilingData();
+            if (g_state.adapter) g_state.adapter->drainProfilingData();
             lastFlush = std::chrono::steady_clock::now();
         }
     }
 
-    GFL_LOG_DEBUG("[CollectorLoop] while EXIT, running=",
-                  g_collectorRunning.load());
-    // Drain remaining ring buffer entries
-    int drained = 0;
-    while (collectorProcessNext()) { ++drained; }
-    GFL_LOG_DEBUG("[CollectorLoop] drain-remaining consumed=", drained);
+    while (RecordProcessor::processNext()) {}
 
-    // Final flush of any partially-filled batches. drainSyntheticKernels runs
-    // FIRST (ring now empty → the meta map holds only orphaned launches) so the
-    // synthetic kernel rows it emits are included in this last flush.
     if (Runtime* rt = runtime(); rt && rt->logger) {
         drainSyntheticKernels(rt);
-        emitExecutionSignatures(rt);
-        flushBatches(*rt->logger, rt->session_id, FlushBatchesMode::Full);
+        g_state.metadata.emitSignatures(rt);
+        g_state.batches.flushAll(*rt->logger, rt->session_id, BatchManager::FlushMode::Full);
     }
     GFL_LOG_DEBUG("[CollectorLoop] END");
 }
 
-void Monitor::Initialize(const MonitorOptions& opts) {
-    if (g_initialized.exchange(true)) return;
+// --- Public Monitor API ---
 
-    // Reset batch state for this session
+void Monitor::Initialize(const MonitorOptions& opts) {
+    if (g_state.initialized.exchange(true)) return;
+
     g_monitorBuffer.resetDroppedCount();
-    g_dictManager.reset();
-    g_dictManager.enable_source_collection = opts.enable_source_collection;
-    g_kernelBatch.clear();
-    g_memcpyBatch.clear();
-    // Worker-local launch-meta join map (Step 4b-2): drop any entries a prior
-    // session left behind so corr ids can't collide across init/shutdown cycles.
-    g_launchMetaByCorr.clear();
-    g_emittedKernelCorrIds.clear();
-    g_syncStackByCorr.clear();  // Step 4c: same cross-session hygiene for syncs.
-    g_execSignatureByScope.clear();  // P2 exec-signature: drop prior session's multiset.
-    g_kernelBatchId  = 0;
-    g_memcpyBatchId  = 0;
-    g_scopeBatch.clear();
-    g_profileBatch.clear();
-    g_pmSampleBatch.clear();
-    g_scopeBatchId   = 0;
-    g_profileBatchId = 0;
-    g_pmSampleBatchId = 0;
-    g_nextScopeInstanceId.store(1);
-    g_activeScopeNameId.store(0);
+    g_state.batches.reset();
+    g_state.metadata.reset();
+    g_state.batches.dictManager.enable_source_collection = opts.enable_source_collection;
+    
     {
-        std::lock_guard lk(g_scopeBatchMu);
-        g_openScopeWindows.clear();
-        g_completedScopeWindows.clear();
+        std::lock_guard lk(g_state.batches.scopeBatchMu);
+        g_state.openScopeWindows.clear();
+        g_state.completedScopeWindows.clear();
     }
 
     DebugLogger::setEnabled(opts.enable_debug_output);
-    g_adapter = CreateMonitorAdapter(opts);
-    if (g_adapter) g_adapter->initialize(opts);
+    g_state.adapter = CreateMonitorAdapter(opts);
+    if (g_state.adapter) g_state.adapter->initialize(opts);
 
-    g_collectorRunning.store(true);
-    g_collectorThread = std::thread(CollectorLoop);
+    g_state.collectorRunning.store(true);
+    g_state.collectorThread = std::thread(CollectorLoop);
 }
 
 void Monitor::Shutdown() {
-    if (!g_initialized.exchange(false)) return;
+    if (!g_state.initialized.exchange(false)) return;
 
-    // Stop and tear down the backend BEFORE joining the collector thread.
-    //
-    // CuptiBackend::stop() calls cuptiActivityFlushAll(1), which fires
-    // BufferCompleted -> pushes activity records to the ring buffer. Some
-    // engines also emit final profiling rows from shutdown(); SassMetrics
-    // deliberately defers cuptiSassMetricsFlushData until shutdown to avoid
-    // mid-run PyTorch deadlocks. If we join the collector first and only then
-    // call backend shutdown, those final PC_SAMPLE rows arrive after the
-    // collector has drained and never become profile_sample_batch records.
-    //
-    // Keeping the collector alive until after backend shutdown ensures every
-    // final activity/profiling record lands in the ring buffer and is consumed.
-    GFL_LOG_DEBUG("Monitor::Shutdown: adapter->stop()");
-    if (g_adapter) g_adapter->stop();
-    GFL_LOG_DEBUG("Monitor::Shutdown: adapter->shutdown()");
-    if (g_adapter) g_adapter->shutdown();
-
-    GFL_LOG_DEBUG("Monitor::Shutdown: join collector thread");
-    g_collectorRunning.store(false);
-    if (g_collectorThread.joinable()) g_collectorThread.join();
-
-    // Belt-and-suspenders post-join drain. On Windows process-exit the collector
-    // thread can be torn down before running its own post-loop drain, stranding
-    // late records - notably the synthetic kernels CuptiBackend::stop() pushes
-    // during adapter->stop() above - in the ring buffer. Re-drain here on the
-    // MAIN thread: it's guaranteed alive, the collector is joined (so we are the
-    // sole consumer), and g_adapter + the logger are still valid (reset below).
-    // No-op on Linux, where the collector already drained everything itself.
-    GFL_LOG_DEBUG("Monitor::Shutdown: collector joined -> post-join drain");
-    {
-        int drained = 0;
-        while (collectorProcessNext()) { ++drained; }
-        if (Runtime* rt = runtime(); rt && rt->logger) {
-            // Emit any launch metas the collector's own drain didn't reach
-            // (Windows process-exit can tear the collector down early). No-op
-            // when CollectorLoop already drained them - the map is cleared.
-            drainSyntheticKernels(rt);
-            emitExecutionSignatures(rt);
-            flushBatches(*rt->logger, rt->session_id, FlushBatchesMode::Full);
-        }
-        GFL_LOG_DEBUG("Monitor::Shutdown: post-join drained=", drained);
+    if (g_state.adapter) {
+        g_state.adapter->stop();
+        g_state.adapter->shutdown();
     }
 
-    if (const size_t dropped = g_monitorBuffer.resetDroppedCount();
-        dropped > 0) {
-        GFL_LOG_ERROR("Monitor::Shutdown: dropped ", dropped,
-                      " monitor record(s) due to ring-buffer backpressure");
+    g_state.collectorRunning.store(false);
+    if (g_state.collectorThread.joinable()) g_state.collectorThread.join();
+
+    while (RecordProcessor::processNext()) {}
+    if (Runtime* rt = runtime(); rt && rt->logger) {
+        drainSyntheticKernels(rt);
+        g_state.metadata.emitSignatures(rt);
+        g_state.batches.flushAll(*rt->logger, rt->session_id, BatchManager::FlushMode::Full);
     }
 
-    GFL_LOG_DEBUG("Monitor::Shutdown: adapter.reset()");
-    g_adapter.reset();
-    GFL_LOG_DEBUG("Monitor::Shutdown: done");
+    g_monitorBuffer.resetDroppedCount();
+    g_state.adapter.reset();
 }
 
-void Monitor::Start() {
-    if (g_adapter) g_adapter->start();
-}
-
-void Monitor::Stop() {
-    if (g_adapter) g_adapter->stop();
-}
+void Monitor::Start() { if (g_state.adapter) g_state.adapter->start(); }
+void Monitor::Stop() { if (g_state.adapter) g_state.adapter->stop(); }
 
 void Monitor::PushRange(const char* name) {
     void* handle = nullptr;
@@ -967,15 +734,14 @@ void Monitor::PopRange() {
     RecordStop(handle, 0);
 }
 
-void Monitor::RecordStart(const char* name, const StreamHandle stream,
-                          const TraceType type, void** outHandle) {
+void Monitor::RecordStart(const char* name, const StreamHandle stream, const TraceType type, void** outHandle) {
     auto* rec = new ActivityRecord();
     strncpy(rec->name, name, 127);
-    rec->type       = type;
-    rec->stream     = stream;
+    rec->type = type;
+    rec->stream = stream;
     rec->cpu_start_ns = detail::GetTimestampNs();
-    rec->duration_ns  = 0;
-    rec->has_details  = false;
+    rec->duration_ns = 0;
+    rec->has_details = false;
     *outHandle = rec;
 }
 
@@ -986,158 +752,91 @@ void Monitor::RecordStop(void* handle, StreamHandle) {
     delete rec;
 }
 
-void Monitor::BeginProfilerScope(const char* name) {
-    if (auto* b = GetBackend()) b->OnScopeStart(name);
-}
+void Monitor::BeginProfilerScope(const char* name) { if (auto* b = GetBackend()) b->OnScopeStart(name); }
+void Monitor::EndProfilerScope(const char* name) { if (auto* b = GetBackend()) b->OnScopeStop(name); }
+void Monitor::BeginPerfScope(const char* name) { if (auto* b = GetBackend()) b->OnPerfScopeStart(name); }
+void Monitor::EndPerfScope(const char* name) { if (auto* b = GetBackend()) b->OnPerfScopeStop(name); }
 
-void Monitor::EndProfilerScope(const char* name) {
-    if (auto* b = GetBackend()) b->OnScopeStop(name);
-}
-
-void Monitor::BeginPerfScope(const char* name) {
-    if (auto* b = GetBackend()) b->OnPerfScopeStart(name);
-}
-
-void Monitor::EndPerfScope(const char* name) {
-    if (auto* b = GetBackend()) b->OnPerfScopeStop(name);
-}
-
-IMonitorBackend* Monitor::GetBackend() {
-    return g_adapter ? g_adapter->backend() : nullptr;
-}
-
-uint32_t Monitor::InternScopeName(const std::string& name) {
-    return g_dictManager.internScopeName(name);
-}
-
-void Monitor::EnqueueCubinForDisassembly(uint64_t crc, const uint8_t* data,
-                                         size_t size) {
-    g_dictManager.enqueueDisassembly(crc, data, size);
-}
-
+IMonitorBackend* Monitor::GetBackend() { return g_state.adapter ? g_state.adapter->backend() : nullptr; }
+uint32_t Monitor::InternScopeName(const std::string& name) { return g_state.batches.dictManager.internScopeName(name); }
+void Monitor::EnqueueCubinForDisassembly(uint64_t crc, const uint8_t* data, size_t size) { g_state.batches.dictManager.enqueueDisassembly(crc, data, size); }
 void Monitor::FlushDisassemblyNow() {
-    // Disassemble + emit any enqueued cubins immediately, off the normal
-    // shutdown flush. Used by the cubin worker under Windows-injection PC
-    // sampling so nvdisasm runs during the live run rather than during the
-    // process-exit teardown (where it intermittently hangs). flushDisassembly
-    // swaps the pending list under its lock, then runs nvdisasm outside it, so
-    // this is safe to call concurrently with the collector's own flushes.
     if (Runtime* rt = runtime(); rt && rt->logger) {
-        g_dictManager.flushDisassembly(*rt->logger, rt->session_id);
+        g_state.batches.dictManager.flushDisassembly(*rt->logger, rt->session_id);
     }
 }
-
-void Monitor::PushActivityRecord(const ActivityRecord& rec) {
-    g_monitorBuffer.Push(rec);
-}
+void Monitor::PushActivityRecord(const ActivityRecord& rec) { g_monitorBuffer.Push(rec); }
 
 void Monitor::PushScopeRow(const ScopeBatchRow& row) {
-    if (row.event_type == 0) {  // begin: update active scope for PC sample association
-        g_activeScopeNameId.store(row.name_id, std::memory_order_relaxed);
-    }
-
-    std::lock_guard lk(g_scopeBatchMu);
     if (row.event_type == 0) {
-        g_openScopeWindows[row.scope_instance_id] = OpenScopeWindow{
-            row.ts_ns, row.name_id, row.depth};
+        g_state.batches.activeScopeNameId.store(row.name_id, std::memory_order_relaxed);
+    }
+    std::lock_guard lk(g_state.batches.scopeBatchMu);
+    if (row.event_type == 0) {
+        g_state.openScopeWindows[row.scope_instance_id] = {row.ts_ns, row.name_id, row.depth};
     } else {
-        if (const auto it = g_openScopeWindows.find(row.scope_instance_id);
-            it != g_openScopeWindows.end()) {
-            g_completedScopeWindows.push_back(ScopeWindow{
-                it->second.start_ns, row.ts_ns, row.scope_instance_id,
-                row.name_id, it->second.depth});
-            g_openScopeWindows.erase(it);
+        if (const auto it = g_state.openScopeWindows.find(row.scope_instance_id); it != g_state.openScopeWindows.end()) {
+            g_state.completedScopeWindows.push_back({it->second.start_ns, row.ts_ns, row.scope_instance_id, row.name_id, it->second.depth});
+            g_state.openScopeWindows.erase(it);
         }
     }
-    g_scopeBatch.push(row);
+    g_state.batches.scopeBatch.push(row);
 }
 
-void Monitor::PushProfileSamples(
-    const std::vector<ProfileSampleInput>& samples) {
+void Monitor::PushProfileSamples(const std::vector<ProfileSampleInput>& samples) {
     if (samples.empty()) return;
-    // PC samples (and SASS samples) are scope-attributed via the most
-    // recently begun scope.  This thread (the user app thread inside
-    // onScopeStop) is the SAME thread that pushed the scope-begin row
-    // earlier in ScopedMonitor's ctor, so g_activeScopeNameId is already
-    // set to the correct ID for these samples.
-    const uint32_t scope_name_id =
-        g_activeScopeNameId.load(std::memory_order_relaxed);
-    // Single lock acquisition for the entire burst - replaces what was
-    // previously thousands of g_monitorBuffer.Push() calls per scope drain.
-    // DO NOT call flushBatches() from inside this lock: flushBatches itself
-    // takes g_scopeBatchMu (via lock_guard, not recursive), so re-entry
-    // would deadlock.  CollectorLoop's 250 ms periodic drain handles flush.
-    std::lock_guard lk(g_scopeBatchMu);
-    // Burst-local demangle cache (this runs on the USER thread). CUPTI hands
-    // SASS function names MANGLED; demangling makes SASS's function identity
-    // match Trace's already-demangled kernel_dict for the cross-pass merge.
-    // Local (not the collector-thread g_functionKeyDemangleCache) so the maps
-    // stay single-threaded and race-free; a burst shares few unique keys across
-    // its per-(pc_offset,metric) rows, so one map per drain dedups cheaply.
+    const uint32_t scope_name_id = g_state.batches.activeScopeNameId.load(std::memory_order_relaxed);
+    std::lock_guard lk(g_state.batches.scopeBatchMu);
     std::unordered_map<std::string, std::string> demangle_cache;
-    auto demangledKey =
-        [&demangle_cache](const std::string& key) -> const std::string& {
+    auto demangledKey = [&demangle_cache](const std::string& key) -> const std::string& {
         auto it = demangle_cache.find(key);
         if (it != demangle_cache.end()) return it->second;
-        return demangle_cache
-            .emplace(key, gpufl::core::DemangleFunctionKey(key))
-            .first->second;
+        return demangle_cache.emplace(key, gpufl::core::DemangleFunctionKey(key)).first->second;
     };
     for (const auto& s : samples) {
         ProfileSampleBatchRow row;
-        row.ts_ns          = s.ts_ns;
-        row.corr_id        = s.corr_id;
-        row.device_id      = s.device_id;
-        // The bare mangled symbol is function_key before '@' (== cubin functions.name).
+        row.ts_ns = s.ts_ns; row.corr_id = s.corr_id; row.device_id = s.device_id;
         const std::string funcSymbol = s.function_key.substr(0, s.function_key.find('@'));
-        row.function_id    = g_dictManager.internFunction(demangledKey(s.function_key), funcSymbol);
-        row.pc_offset      = s.pc_offset;
-        row.metric_id      = g_dictManager.internMetric(s.metric_name);
-        row.metric_value   = s.metric_value;
-        row.stall_reason   = s.stall_reason;
-        row.sample_kind    = s.sample_kind;
-        row.scope_name_id  = scope_name_id;
-        row.source_file_id = g_dictManager.internSourceFile(s.source_file);
-        row.source_line    = s.source_line;
-        g_profileBatch.push(row);
+        row.function_id = g_state.batches.dictManager.internFunction(demangledKey(s.function_key), funcSymbol);
+        row.pc_offset = s.pc_offset;
+        row.metric_id = g_state.batches.dictManager.internMetric(s.metric_name);
+        row.metric_value = s.metric_value;
+        row.stall_reason = s.stall_reason;
+        row.sample_kind = s.sample_kind;
+        row.scope_name_id = scope_name_id;
+        row.source_file_id = g_state.batches.dictManager.internSourceFile(s.source_file);
+        row.source_line = s.source_line;
+        g_state.batches.profileBatch.push(row);
     }
 }
 
 void Monitor::PushPmSamples(const std::vector<PmSampleInput>& samples) {
     if (samples.empty()) return;
-    const uint32_t fallback_scope_name_id =
-        g_activeScopeNameId.load(std::memory_order_relaxed);
-    std::lock_guard lk(g_scopeBatchMu);
+    const uint32_t fallback_id = g_state.batches.activeScopeNameId.load(std::memory_order_relaxed);
+    std::lock_guard lk(g_state.batches.scopeBatchMu);
     for (const auto& s : samples) {
         if (s.metric_name.empty()) continue;
         PmSampleBatchRow row;
-        row.sample_index = s.sample_index;
-        row.ts_ns = s.ts_ns;
-        row.device_id = s.device_id;
-        row.metric_id = g_dictManager.internMetric(s.metric_name);
+        row.sample_index = s.sample_index; row.ts_ns = s.ts_ns; row.device_id = s.device_id;
+        row.metric_id = g_state.batches.dictManager.internMetric(s.metric_name);
         row.value = s.value;
-        row.scope_name_id = ResolveScopeNameIdForTimestampLocked(s.ts_ns);
-        if (row.scope_name_id == 0) row.scope_name_id = fallback_scope_name_id;
-        g_pmSampleBatch.push(row);
+        row.scope_name_id = g_state.resolveScopeId(s.ts_ns);
+        if (row.scope_name_id == 0) row.scope_name_id = fallback_id;
+        g_state.batches.pmSampleBatch.push(row);
     }
 }
 
-void Monitor::EmitPmSamplingConfig(uint32_t device_id,
-                                   uint32_t interval_us,
-                                   uint32_t max_samples,
-                                   const std::string& preset,
-                                   const std::vector<std::string>& metrics) {
-    Runtime* rt = runtime();
+void Monitor::EmitPmSamplingConfig(uint32_t device_id, uint32_t interval_us, uint32_t max_samples, const std::string& preset, const std::vector<std::string>& metrics) {
+    const Runtime* rt = runtime();
     if (!(rt && rt->logger)) return;
     PmSamplingConfigEvent ev;
-    ev.session_id = rt->session_id;
-    ev.ts_ns = detail::GetTimestampNs();
-    ev.device_id = device_id;
-    ev.interval_us = interval_us;
-    ev.max_samples = max_samples;
-    ev.preset = preset;
-    ev.metrics = metrics;
+    ev.session_id = rt->session_id; ev.ts_ns = detail::GetTimestampNs();
+    ev.device_id = device_id; ev.interval_us = interval_us; ev.max_samples = max_samples;
+    ev.preset = preset; ev.metrics = metrics;
     rt->logger->write(model::PmSamplingConfigModel(ev));
 }
+
+void SetSuppressOrphanSyntheticKernels(const bool suppress) { g_state.suppressOrphanSyntheticKernels = suppress; }
+void SetDrainSyntheticKernelsMidRun(const bool enable) { g_state.drainSyntheticMidRun = enable; }
 
 }  // namespace gpufl

--- a/include/gpufl/core/monitor.hpp
+++ b/include/gpufl/core/monitor.hpp
@@ -293,6 +293,13 @@ class Monitor {
                                            size_t size);
 
     /**
+     * Disassemble and emit any enqueued cubins now, instead of waiting for the
+     * shutdown flush. Used by the cubin worker under Windows-injection PC
+     * sampling to keep nvdisasm off the fragile process-exit teardown.
+     */
+    static void FlushDisassemblyNow();
+
+    /**
      * @brief Push a pre-built ScopeBatchRow into the scope batch buffer.
      */
     static void PushScopeRow(const ScopeBatchRow& row);

--- a/include/gpufl/core/monitor.hpp
+++ b/include/gpufl/core/monitor.hpp
@@ -238,9 +238,26 @@ class Monitor {
     static void Initialize(const MonitorOptions& opts = {});
 
     /**
-     * @brief Shuts down the monitoring engine.
+     * @brief Shuts down the monitoring engine (clean teardown order: release
+     *        the CUPTI backend, then drain + flush). Used off the normal
+     *        (embedded) exit path.
      */
     static void Shutdown();
+
+    /**
+     * @brief Windows-injection process-exit teardown, phase 1: stop the
+     *        collector, drain the ring, flush all batches, and emit backend
+     *        capabilities WITHOUT touching CUPTI. Leaves all run data in the
+     *        logger so the caller can close it before the fragile release.
+     */
+    static void DrainAndFinalizeForExit();
+
+    /**
+     * @brief Windows-injection process-exit teardown, phase 2: the fragile
+     *        CUPTI release (cuptiPCSamplingStop/Disable). Call LAST, after the
+     *        logs are flushed + closed, so a hang/crash here can't lose data.
+     */
+    static void ReleaseBackendForExit();
 
     /**
      * @brief Starts global collection.

--- a/include/gpufl/core/monitor.hpp
+++ b/include/gpufl/core/monitor.hpp
@@ -220,6 +220,13 @@ struct PmSampleInput {
 // Default false: normal / PC modes keep best-effort synthesis.
 void SetSuppressOrphanSyntheticKernels(bool suppress);
 
+// Session-level switch (set by the active backend at start): when true the
+// collector emits orphaned launches as synthetic kernel rows PERIODICALLY during
+// the run, not only at shutdown. Used for Windows-injection PC sampling, whose
+// process-exit teardown drops the final flush - mid-run emission is the only way
+// those kernel rows survive. Default false (other modes emit at shutdown).
+void SetDrainSyntheticKernelsMidRun(bool enable);
+
 /**
  * @brief The central monitoring engine.
  */

--- a/include/gpufl/core/monitor_backend.hpp
+++ b/include/gpufl/core/monitor_backend.hpp
@@ -29,6 +29,15 @@ class IMonitorBackend {
     virtual void shutdown() = 0;
 
     /**
+     * @brief Emit the capture-capabilities report (what was actually
+     *        collected) to the logger, without releasing any backend
+     *        resources. Used by the Windows-injection process-exit path to
+     *        write capabilities BEFORE the fragile CUPTI release. Idempotent;
+     *        a no-op for backends that report no capabilities.
+     */
+    virtual void emitCapabilities() {}
+
+    /**
      * @brief start active monitoring/tracing.
      */
     virtual void start() = 0;

--- a/include/gpufl/upload/upload_logs.cpp
+++ b/include/gpufl/upload/upload_logs.cpp
@@ -917,7 +917,69 @@ StreamPostResult postStreamChunk(httplib::Client&         client,
     return out;
 }
 
+bool postSessionCompleteImpl(httplib::Client& client,
+                             const std::string& api_path,
+                             const std::string& api_key,
+                             const std::string& session_id) {
+    const std::string path = normalizeApiPath(api_path) + "/events/session-complete";
+    const std::string ua = std::string("gpufl-client/") + kClientVersion + " (signal)";
+    const httplib::Headers headers = {
+        {"Authorization",              "Bearer " + api_key},
+        {"User-Agent",                 ua},
+        {"X-GpuFlight-Client-Version", kClientVersion},
+        {"X-GpuFlight-Wire-Version",   kWireVersion},
+        {"X-GpuFlight-Session-Id",     session_id},
+    };
+    // Empty body: the backend reads the session id from the header and stamps
+    // upload_complete_at; the body is ignored.
+    auto res = client.Post(path.c_str(), headers, std::string(), "application/json");
+    if (!res) {
+        GFL_LOG_DEBUG("[sessionComplete] transport error for ", session_id,
+                      " (httplib::Error=", static_cast<int>(res.error()), ")");
+        return false;
+    }
+    if (res->status >= 200 && res->status < 300) {
+        GFL_LOG_DEBUG("[sessionComplete] accepted for ", session_id,
+                      " (HTTP ", res->status, ")");
+        return true;
+    }
+    // Non-2xx (e.g. 404 on a backend that predates the endpoint): not fatal —
+    // the backend's grace/settle path still finalizes. Log and move on.
+    GFL_LOG_DEBUG("[sessionComplete] backend returned HTTP ", res->status,
+                  " for ", session_id);
+    return false;
+}
+
 }  // namespace
+
+// ─────────────────────────────────────────────────────────────────────
+// Out-of-process completion signal (POST /api/v1/events/session-complete)
+// ─────────────────────────────────────────────────────────────────────
+
+bool postSessionComplete(const BackendConfig& config,
+                         const std::string& session_id) {
+    UrlParts url;
+    if (!parseUrl(config.backend_url, url)) {
+        GFL_LOG_DEBUG("[sessionComplete] unparseable backend url '", config.backend_url, "'");
+        return false;
+    }
+    // Best-effort signal — fail fast (the backend grace path is the backstop) so a black-holed
+    // backend can't stall trace exit on the way out.
+    UploadOptions opts;
+    opts.connect_timeout_ms = 2000;
+    opts.read_timeout_ms = 4000;
+    auto client = makeClient(url, opts);
+    if (!client) return false;
+
+    return postSessionCompleteImpl(*client, config.api_path, config.api_key, session_id);
+}
+
+bool postSessionComplete(const std::string& backend_url,
+                         const std::string& api_path_in,
+                         const std::string& api_key,
+                         const std::string& session_id) {
+    return postSessionComplete({backend_url, api_key, api_path_in}, session_id);
+}
 
 // ─────────────────────────────────────────────────────────────────────
 // Main entry point

--- a/include/gpufl/upload/upload_logs.hpp
+++ b/include/gpufl/upload/upload_logs.hpp
@@ -20,6 +20,23 @@
 namespace gpufl {
 
 /**
+ * Backend communication parameters, used by postSessionComplete and
+ * other low-level signals.
+ */
+struct BackendConfig {
+    /** Backend host, e.g. "https://api.gpuflight.com". No trailing slash. */
+    std::string backend_url;
+
+    /** Bearer token sent as `Authorization: Bearer <api_key>`. */
+    std::string api_key;
+
+    /**
+     * Reverse-proxy path mount. Empty resolves to "/api/v1".
+     */
+    std::string api_path;
+};
+
+/**
  * Configuration for a single uploadLogs() invocation.
  *
  * All fields are independent. Callers typically populate at minimum
@@ -244,5 +261,23 @@ struct UploadResult {
  * Local NDJSON files are NEVER deleted by this call.
  */
 UploadResult uploadLogs(const UploadOptions& opts);
+
+/**
+ * Best-effort "upload finished cleanly" signal for ONE session.
+ *
+ * @param config backend location and credentials.
+ * @param session_id the UUID to signal.
+ */
+bool postSessionComplete(const BackendConfig& config,
+                         const std::string& session_id);
+
+/**
+ * Legacy version of postSessionComplete with individual parameters.
+ * Prefer the BackendConfig version.
+ */
+bool postSessionComplete(const std::string& backend_url,
+                         const std::string& api_path,
+                         const std::string& api_key,
+                         const std::string& session_id);
 
 }  // namespace gpufl


### PR DESCRIPTION
## Description
0 pc sampling when profiling through `gpufl trace`. This is to fix for the issue. 
- correlate source/SASS to the merged kernel under Windows injection
- flush logs before the fragile CUPTI release on Windows-injection exit
- report kernel_events fallback when synthetic durations dominate

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

## Testing
## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas