### PR TITLE
fix(nvml): use classic nvmlDeviceGetTemperature for driver portability

### DIFF
--- a/include/gpufl/backends/nvidia/nvml_collector.cpp
+++ b/include/gpufl/backends/nvidia/nvml_collector.cpp
@@ -148,11 +148,15 @@ std::vector<gpufl::DeviceSample> NvmlCollector::sampleAll() {
         }
 #endif
 
-        nvmlTemperature_t tempInfo{};
-        tempInfo.version = nvmlTemperature_v1;
-        tempInfo.sensorType = NVML_TEMPERATURE_GPU;
-        if (nvmlDeviceGetTemperatureV(dev, &tempInfo) == NVML_SUCCESS) {
-            s.temp_c = static_cast<int>(tempInfo.temperature);
+        // Classic nvmlDeviceGetTemperature, NOT the newer nvmlDeviceGetTemperatureV:
+        // the versioned variant is a link-time symbol that older NVML drivers don't
+        // export, so a link-time reference to it makes the ENTIRE gpufl binary fail
+        // to load on such a driver (undefined symbol: nvmlDeviceGetTemperatureV,
+        // exit 127) before it runs anything. The classic call is deprecated in
+        // CUDA 13 but present in every driver and returns the same GPU temperature.
+        // (tempC is declared with the other per-device locals above.)
+        if (nvmlDeviceGetTemperature(dev, NVML_TEMPERATURE_GPU, &tempC) == NVML_SUCCESS) {
+            s.temp_c = static_cast<int>(tempC);
         }
 
         if (nvmlDeviceGetPowerUsage(dev, &powerMilliW) == NVML_SUCCESS) {


### PR DESCRIPTION
nvmlDeviceGetTemperatureV is a link-time symbol older NVML drivers don't export, so a reference to it makes the whole gpufl binary fail to load on such a driver (undefined symbol, exit 127) before it runs anything - hit on Cloud Run's managed L4 (driver ~535). The classic nvmlDeviceGetTemperature is present in every driver and returns the same GPU temperature; it's deprecated in CUDA 13 (a benign -Wdeprecated warning, no -Werror here). Reuses the tempC already declared with the per-device loop locals.

Low urgency in practice - CUDA 13.3 needs driver >=580 which has the V symbol anyway - but harmless and strictly safer across driver versions.

## Description
## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update

## Testing
## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas